### PR TITLE
Fill ConvertPose.lean sorries, weaken pose_of_matrix_pose

### DIFF
--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -96,8 +96,7 @@ lemma exists_SO3_mulVec_ez_eq_ZY (v : EuclideanSpace ℝ (Fin 3)) (hv : ‖v‖ 
       rw [Real.cos_arccos, Real.sin_arccos] <;> try nlinarith
       exact ⟨rfl, congrArg Real.sqrt <| sub_eq_iff_eq_add.mpr hv.symm⟩
     by_cases h : v 0 + v 1 * Complex.I = 0 <;> simp_all [Complex.cos_arg, Complex.sin_arg]
-    · simp_all [Complex.ext_iff]
-      ext i; fin_cases i <;> tauto
+    · ext i; simp_all [Complex.ext_iff]; fin_cases i <;> tauto
     · simp [Complex.normSq, Complex.norm_def] at *
       simp [← sq, mul_div_cancel₀ _ (show √(v 0 ^ 2 + v 1 ^ 2) ≠ 0 from ne_of_gt <| Real.sqrt_pos.mpr <|
         by nlinarith [mul_self_pos.mpr <| show v 0 ^ 2 + v 1 ^ 2 ≠ 0 from

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -131,15 +131,14 @@ lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
   have hU_det : IsUnit U.det := by
     simp only [isUnit_iff_ne_zero, ne_eq, U]
     simp_all [Matrix.mem_specialOrthogonalGroup_iff]
-  have hAe3 : A.mulVec ![0, 0, 1] = v.ofLp := by
-    ext i; fin_cases i <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three, v]
   have hB_fixes_ez : (U⁻¹ * A).mulVec ![0, 0, 1] = ![0, 0, 1] := by
-    rw [← Matrix.mulVec_mulVec, hAe3, ← hU_ez]
-    rw [Matrix.mulVec_mulVec, Matrix.nonsing_inv_mul _ hU_det, Matrix.one_mulVec]
-  -- U⁻¹ * A ∈ SO3 and fixes e₃, so it's Rz(γ)
-  have hB_SO3 : U⁻¹ * A ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
-    Submonoid.mul_mem _ (Bounding.specialOrthogonalGroup_mem_inv hU_SO3) hA
-  obtain ⟨γ, hγ⟩ := Bounding.SO3_fixing_z_is_Rz (U⁻¹ * A) hB_SO3 (by convert hB_fixes_ez; simp)
+    have hAe3 : A.mulVec ![0, 0, 1] = v.ofLp := by
+      ext i; fin_cases i <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three, v]
+    rw [← Matrix.mulVec_mulVec, hAe3, ← hU_ez,
+      Matrix.mulVec_mulVec, Matrix.nonsing_inv_mul _ hU_det, Matrix.one_mulVec]
+  obtain ⟨γ, hγ⟩ := Bounding.SO3_fixing_z_is_Rz (U⁻¹ * A)
+    (Submonoid.mul_mem _ (Bounding.specialOrthogonalGroup_mem_inv hU_SO3) hA)
+    (by convert hB_fixes_ez; simp)
   exact ⟨α, β, γ, by rw [← hγ, ← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hU_det, Matrix.one_mul]⟩
 
 /--

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -119,14 +119,11 @@ lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
   let v : EuclideanSpace ℝ (Fin 3) := WithLp.toLp 2 fun i => A i 2
   have hv_norm : ‖v‖ = 1 := by
     simp only [EuclideanSpace.norm_eq, v]
-    have hATA := hA.1.1  -- A^T * A = 1
-    have h22 := congrFun (congrFun hATA 2) 2
+    have h22 := congrFun (congrFun hA.1.1 2) 2
     simp only [Matrix.mul_apply, Matrix.one_apply_eq, Fin.sum_univ_three,
       Matrix.star_apply, star_trivial] at h22
-    rw [Real.sqrt_eq_one, Fin.sum_univ_three, Real.norm_eq_abs, Real.norm_eq_abs,
-      Real.norm_eq_abs, sq_abs, sq_abs, sq_abs]
-    convert h22 using 1
-    ring
+    simp only [Real.sqrt_eq_one, Fin.sum_univ_three, Real.norm_eq_abs, sq_abs]
+    linarith
   -- Find α, β such that U := Rz(α) * Ry(β) maps e₃ to v (third column of A)
   obtain ⟨α, β, hU_SO3, hU_ez⟩ := exists_SO3_mulVec_ez_eq_ZY v hv_norm
   let U := Rz_mat α * Ry_mat β
@@ -143,11 +140,7 @@ lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
   have hB_SO3 : U⁻¹ * A ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
     Submonoid.mul_mem _ (Bounding.specialOrthogonalGroup_mem_inv hU_SO3) hA
   obtain ⟨γ, hγ⟩ := Bounding.SO3_fixing_z_is_Rz (U⁻¹ * A) hB_SO3 (by convert hB_fixes_ez; simp)
-  -- A = U * Rz(γ) = Rz(α) * Ry(β) * Rz(γ)
-  have hA_eq : A = U * Rz_mat γ := by
-    calc A = U * (U⁻¹ * A) := by rw [← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hU_det, Matrix.one_mul]
-      _ = U * Rz_mat γ := by rw [hγ]
-  exact ⟨α, β, γ, hA_eq⟩
+  exact ⟨α, β, γ, by rw [← hγ, ← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hU_det, Matrix.one_mul]⟩
 
 /--
 Given a MatrixPose with zero offset whose outer rotation is in the image of `rotRM_mat _ _ 0`,

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -43,11 +43,54 @@ def Pose.matrixPoseOfPose (p : Pose) : MatrixPose where
 
 theorem converted_pose_inner_shadow_eq (v : Pose) (S : Set ℝ³) :
     innerShadow v S = innerShadow (v.matrixPoseOfPose) S := by
-  sorry -- TODO(easy)
+  -- Both sides are { proj_xyL (PoseLike.inner pose x) | x ∈ S }
+  -- For Pose: PoseLike.inner v = (rotRM v.θ₁ v.φ₁ v.α).toAffineMap
+  -- For MatrixPose with zero offset: PoseLike.inner = the inner rotation
+  unfold innerShadow
+  congr 1
+  ext x
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    refine ⟨y, hy, ?_⟩
+    congr 1
+    simp only [PoseLike.inner, Pose.matrixPoseOfPose]
+    simp only [AffineEquiv.coe_toAffineMap, AffineMap.coe_comp, Function.comp_apply,
+      AffineEquiv.vaddConst_apply, LinearMap.coe_toAffineMap]
+    rw [rotRM_eq_rotRM_mat]
+    simp only [Matrix.toEuclideanLin_apply, inject_xy]
+    ext i
+    fin_cases i <;> simp [vadd_eq_add]
+  · rintro ⟨y, hy, rfl⟩
+    refine ⟨y, hy, ?_⟩
+    congr 1
+    simp only [PoseLike.inner, Pose.matrixPoseOfPose]
+    simp only [AffineEquiv.coe_toAffineMap, AffineMap.coe_comp, Function.comp_apply,
+      AffineEquiv.vaddConst_apply, LinearMap.coe_toAffineMap]
+    rw [rotRM_eq_rotRM_mat]
+    simp only [Matrix.toEuclideanLin_apply, inject_xy]
+    ext i
+    fin_cases i <;> simp [vadd_eq_add]
 
 theorem converted_pose_outer_shadow_eq (v : Pose) (S : Set ℝ³) :
     outerShadow v S = outerShadow (v.matrixPoseOfPose) S := by
-  sorry -- TODO(easy)
+  unfold outerShadow
+  congr 1
+  ext x
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    refine ⟨y, hy, ?_⟩
+    congr 1
+    simp only [PoseLike.outer, Pose.matrixPoseOfPose]
+    simp only [LinearMap.coe_toAffineMap]
+    rw [rotRM_eq_rotRM_mat]
+    rfl
+  · rintro ⟨y, hy, rfl⟩
+    refine ⟨y, hy, ?_⟩
+    congr 1
+    simp only [PoseLike.outer, Pose.matrixPoseOfPose]
+    simp only [LinearMap.coe_toAffineMap]
+    rw [rotRM_eq_rotRM_mat]
+    rfl
 
 theorem converted_pose_rupert_iff (v : Pose) (S : Set ℝ³) :
     RupertPose v S ↔ RupertPose (v.matrixPoseOfPose) S := by
@@ -56,5 +99,30 @@ theorem converted_pose_rupert_iff (v : Pose) (S : Set ℝ³) :
     rw [converted_pose_inner_shadow_eq, converted_pose_outer_shadow_eq]
     exact id
 
+/--
+Any SO3 matrix can be written in ZYZ Euler form: Rz(α) * Ry(β) * Rz(γ).
+This is the classic Euler angle decomposition theorem.
+
+Strategy: Given A ∈ SO3,
+1. The third column of A is a unit vector v
+2. By exists_SO3_mulVec_ez_eq, ∃ U = Rz(ϕ) * Ry(-θ) with U * e₃ = v
+3. Then U⁻¹ * A fixes e₃, so by SO3_fixing_z_is_Rz it equals Rz(γ)
+4. Therefore A = U * Rz(γ) = Rz(ϕ) * Ry(-θ) * Rz(γ)
+-/
+lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
+    (hA : A ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ α β γ : ℝ, A = Rz_mat α * Ry_mat β * Rz_mat γ := by
+  sorry -- TODO: Complete using exists_SO3_mulVec_ez_eq and SO3_fixing_z_is_Rz
+
+/--
+Given a MatrixPose with zero offset, there exists a 5-parameter Pose that produces
+the same rotations. This follows from the ZYZ Euler angle decomposition.
+-/
 theorem pose_of_matrix_pose (p : MatrixPose) : ∃ pp : Pose, pp.matrixPoseOfPose = p.zeroOffset := by
-  sorry -- TODO(easy)
+  -- Decompose each SO3 matrix into Euler angles
+  obtain ⟨α₁, β₁, γ₁, h_inner⟩ := SO3_euler_ZYZ p.innerRot.val p.innerRot.property
+  obtain ⟨α₂, β₂, γ₂, h_outer⟩ := SO3_euler_ZYZ p.outerRot.val p.outerRot.property
+  -- rotRM_mat θ φ α = Rz(-(π/2)) * Rz(α) * Ry(φ) * Rz(-θ) = Rz(α - π/2) * Ry(φ) * Rz(-θ)
+  -- Match: Rz(α₁) * Ry(β₁) * Rz(γ₁) = Rz(α' - π/2) * Ry(φ') * Rz(-θ')
+  -- Solution: α' = α₁ + π/2, φ' = β₁, θ' = -γ₁
+  sorry -- TODO: Construct pose and prove equality using h_inner, h_outer

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -136,10 +136,7 @@ lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
     simp only [isUnit_iff_ne_zero, ne_eq, U]
     simp_all [Matrix.mem_specialOrthogonalGroup_iff]
   have hAe3 : A.mulVec ![0, 0, 1] = v.ofLp := by
-    ext i
-    simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, v,
-      Matrix.cons_val_zero, Matrix.cons_val_one, Fin.isValue]
-    fin_cases i <;> simp
+    ext i; fin_cases i <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three, v]
   have hB_fixes_ez : (U⁻¹ * A).mulVec ![0, 0, 1] = ![0, 0, 1] := by
     rw [← Matrix.mulVec_mulVec, hAe3, ← hU_ez]
     rw [Matrix.mulVec_mulVec, Matrix.nonsing_inv_mul _ hU_det, Matrix.one_mulVec]

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -109,10 +109,56 @@ Strategy: Given A ∈ SO3,
 3. Then U⁻¹ * A fixes e₃, so by SO3_fixing_z_is_Rz it equals Rz(γ)
 4. Therefore A = U * Rz(γ) = Rz(ϕ) * Ry(-θ) * Rz(γ)
 -/
+-- Any SO3 matrix that maps e₃ to v can be written as Rz(α) * Ry(β) for some α, β.
+-- This follows from the spherical coordinate representation.
+lemma SO3_maps_ez_to_v_is_ZY (U : Matrix (Fin 3) (Fin 3) ℝ)
+    (hU : U ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ)
+    (v : EuclideanSpace ℝ (Fin 3)) (hv : ‖v‖ = 1)
+    (hUv : U.mulVec ![0, 0, 1] = v.ofLp) :
+    ∃ α β : ℝ, U = Rz_mat α * Ry_mat β := by
+  sorry -- TODO: Derive from spherical coordinates
+
 lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
     (hA : A ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
     ∃ α β γ : ℝ, A = Rz_mat α * Ry_mat β * Rz_mat γ := by
-  sorry -- TODO: Complete using exists_SO3_mulVec_ez_eq and SO3_fixing_z_is_Rz
+  -- The third column of A is a unit vector
+  let v : EuclideanSpace ℝ (Fin 3) := WithLp.toLp 2 fun i => A i 2
+  have hv_norm : ‖v‖ = 1 := by
+    simp only [EuclideanSpace.norm_eq, v]
+    have hATA := hA.1.1  -- A^T * A = 1
+    have h22 := congrFun (congrFun hATA 2) 2
+    simp only [Matrix.mul_apply, Matrix.one_apply_eq, Fin.sum_univ_three,
+      Matrix.star_apply, star_trivial] at h22
+    rw [Real.sqrt_eq_one, Fin.sum_univ_three, Real.norm_eq_abs, Real.norm_eq_abs,
+      Real.norm_eq_abs, sq_abs, sq_abs, sq_abs]
+    convert h22 using 1
+    ring
+  -- Find U with U * e₃ = v (third column of A)
+  obtain ⟨U, hU_SO3, hU_ez⟩ := Bounding.exists_SO3_mulVec_ez_eq v hv_norm
+  -- U⁻¹ * A fixes e₃
+  have hU_det : IsUnit U.det := by
+    simp only [isUnit_iff_ne_zero, ne_eq]
+    simp_all [Matrix.mem_specialOrthogonalGroup_iff]
+  have hAe3 : A.mulVec ![0, 0, 1] = v.ofLp := by
+    ext i
+    simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, v,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Fin.isValue]
+    fin_cases i <;> simp
+  have hB_fixes_ez : (U⁻¹ * A).mulVec ![0, 0, 1] = ![0, 0, 1] := by
+    rw [← Matrix.mulVec_mulVec, hAe3, ← hU_ez]
+    rw [Matrix.mulVec_mulVec, Matrix.nonsing_inv_mul _ hU_det, Matrix.one_mulVec]
+  -- U⁻¹ * A ∈ SO3 and fixes e₃, so it's Rz(γ)
+  have hB_SO3 : U⁻¹ * A ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
+    Submonoid.mul_mem _ (Bounding.specialOrthogonalGroup_mem_inv hU_SO3) hA
+  obtain ⟨γ, hγ⟩ := Bounding.SO3_fixing_z_is_Rz (U⁻¹ * A) hB_SO3 (by convert hB_fixes_ez; simp)
+  -- A = U * Rz(γ)
+  have hA_eq : A = U * Rz_mat γ := by
+    calc A = U * (U⁻¹ * A) := by rw [← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hU_det, Matrix.one_mul]
+      _ = U * Rz_mat γ := by rw [hγ]
+  -- U = Rz(α) * Ry(β) by SO3_maps_ez_to_v_is_ZY
+  obtain ⟨α, β, hU_eq⟩ := SO3_maps_ez_to_v_is_ZY U hU_SO3 v hv_norm hU_ez
+  -- Therefore A = Rz(α) * Ry(β) * Rz(γ)
+  exact ⟨α, β, γ, by rw [hA_eq, hU_eq]⟩
 
 /--
 Given a MatrixPose with zero offset, there exists a 5-parameter Pose that produces

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -42,8 +42,7 @@ lemma Rz_mat_mul (a b : ℝ) : Rz_mat a * Rz_mat b = Rz_mat (a + b) := by
 /-- Collapse leading Rz terms: `rotRM_mat θ φ α = Rz(α - π/2) * Ry(φ) * Rz(-θ)`. -/
 lemma rotRM_mat_eq (θ φ α : ℝ) :
     rotRM_mat θ φ α = Rz_mat (α - π / 2) * Ry_mat φ * Rz_mat (-θ) := by
-  simp only [rotRM_mat, Rz_mat_mul, sub_eq_add_neg]
-  ring_nf
+  simp only [rotRM_mat, Rz_mat_mul, sub_eq_add_neg, add_comm]
 
 noncomputable
 def Pose.matrixPoseOfPose (p : Pose) : MatrixPose where

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -104,10 +104,7 @@ theorem converted_pose_outer_shadow_eq (v : Pose) (S : Set ℝ³) :
 
 theorem converted_pose_rupert_iff (v : Pose) (S : Set ℝ³) :
     RupertPose v S ↔ RupertPose (v.matrixPoseOfPose) S := by
-  constructor; all_goals
-  · unfold RupertPose
-    rw [converted_pose_inner_shadow_eq, converted_pose_outer_shadow_eq]
-    exact id
+  simp [RupertPose, converted_pose_inner_shadow_eq, converted_pose_outer_shadow_eq]
 
 /-- For any unit vector v, there exist angles α, β such that Rz(α) * Ry(β) is in SO3
 and maps e₃ to v. Uses spherical coordinates: θ = arccos(v₂), ϕ = arg(v₀ + v₁·i).

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -59,20 +59,8 @@ theorem converted_pose_inner_shadow_eq (v : Pose) (S : Set ℝ³) :
   unfold innerShadow
   congr 1
   ext x
-  constructor
-  · rintro ⟨y, hy, rfl⟩
-    refine ⟨y, hy, ?_⟩
-    congr 1
-    simp only [PoseLike.inner, Pose.matrixPoseOfPose]
-    simp only [AffineEquiv.coe_toAffineMap, AffineMap.coe_comp, Function.comp_apply,
-      AffineEquiv.vaddConst_apply, LinearMap.coe_toAffineMap]
-    rw [rotRM_eq_rotRM_mat]
-    simp only [Matrix.toEuclideanLin_apply, inject_xy]
-    ext i
-    fin_cases i <;> simp [vadd_eq_add]
-  · rintro ⟨y, hy, rfl⟩
-    refine ⟨y, hy, ?_⟩
-    congr 1
+  constructor <;> (rintro ⟨y, hy, rfl⟩; refine ⟨y, hy, ?_⟩; congr 1)
+  all_goals
     simp only [PoseLike.inner, Pose.matrixPoseOfPose]
     simp only [AffineEquiv.coe_toAffineMap, AffineMap.coe_comp, Function.comp_apply,
       AffineEquiv.vaddConst_apply, LinearMap.coe_toAffineMap]
@@ -86,21 +74,10 @@ theorem converted_pose_outer_shadow_eq (v : Pose) (S : Set ℝ³) :
   unfold outerShadow
   congr 1
   ext x
-  constructor
-  · rintro ⟨y, hy, rfl⟩
-    refine ⟨y, hy, ?_⟩
-    congr 1
-    simp only [PoseLike.outer, Pose.matrixPoseOfPose]
-    simp only [LinearMap.coe_toAffineMap]
-    rw [rotRM_eq_rotRM_mat]
-    rfl
-  · rintro ⟨y, hy, rfl⟩
-    refine ⟨y, hy, ?_⟩
-    congr 1
-    simp only [PoseLike.outer, Pose.matrixPoseOfPose]
-    simp only [LinearMap.coe_toAffineMap]
-    rw [rotRM_eq_rotRM_mat]
-    rfl
+  constructor <;> (rintro ⟨y, hy, rfl⟩; refine ⟨y, hy, ?_⟩; congr 1)
+  all_goals
+    simp only [PoseLike.outer, Pose.matrixPoseOfPose, LinearMap.coe_toAffineMap]
+    rw [rotRM_eq_rotRM_mat]; rfl
 
 theorem converted_pose_rupert_iff (v : Pose) (S : Set ℝ³) :
     RupertPose v S ↔ RupertPose (v.matrixPoseOfPose) S := by

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -104,11 +104,11 @@ and maps e₃ to v. This is a repackaging of exists_SO3_mulVec_ez_eq. -/
 lemma exists_SO3_mulVec_ez_eq_ZY (v : EuclideanSpace ℝ (Fin 3)) (hv : ‖v‖ = 1) :
     ∃ α β : ℝ, let U := Rz_mat α * Ry_mat β
       U ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ ∧ U.mulVec ![0, 0, 1] = v := by
-  -- The proof of exists_SO3_mulVec_ez_eq constructs U = rot3_mat 2 ϕ * rot3_mat 1 (-θ)
-  -- where rot3_mat 2 = Rz_mat and rot3_mat 1 = Ry_mat
+  -- Use exists_SO3_mulVec_ez_eq and observe that its construction gives Rz * Ry form
+  -- The construction is: U = rot3_mat 2 ϕ * rot3_mat 1 (-θ) = Rz_mat ϕ * Ry_mat (-θ)
   obtain ⟨U, hU_SO3, hU_ez⟩ := Bounding.exists_SO3_mulVec_ez_eq v hv
-  -- The construction gives U = Rz_mat ϕ * Ry_mat (-θ) for specific ϕ, θ
-  -- We need to extract these angles. Since this is for existence, we use sorry for now.
+  -- For now, we use sorry since extracting the exact angles from the existential
+  -- requires repeating the construction or modifying exists_SO3_mulVec_ez_eq
   sorry
 
 /-- Any SO3 matrix can be written in ZYZ Euler form: Rz(α) * Ry(β) * Rz(γ).
@@ -157,12 +157,24 @@ lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
 /--
 Given a MatrixPose with zero offset, there exists a 5-parameter Pose that produces
 the same rotations. This follows from the ZYZ Euler angle decomposition.
+
+Note: This requires showing that any SO3 matrix can be written in the form
+`Rz(α - π/2) * Ry(φ) * Rz(-θ)` which is what `rotRM_mat θ φ α` expands to.
+For the outer rotation (where α = 0), this means `Rz(-π/2) * Ry(φ) * Rz(-θ)`,
+which is a 2-parameter family. The full SO3 has 3 parameters, so additional
+argument is needed to show every SO3 matrix can be represented this way
+(e.g., via the freedom in ZYZ angle selection).
 -/
 theorem pose_of_matrix_pose (p : MatrixPose) : ∃ pp : Pose, pp.matrixPoseOfPose = p.zeroOffset := by
-  -- Decompose each SO3 matrix into Euler angles
-  obtain ⟨α₁, β₁, γ₁, h_inner⟩ := SO3_euler_ZYZ p.innerRot.val p.innerRot.property
-  obtain ⟨α₂, β₂, γ₂, h_outer⟩ := SO3_euler_ZYZ p.outerRot.val p.outerRot.property
-  -- rotRM_mat θ φ α = Rz(-(π/2)) * Rz(α) * Ry(φ) * Rz(-θ) = Rz(α - π/2) * Ry(φ) * Rz(-θ)
-  -- Match: Rz(α₁) * Ry(β₁) * Rz(γ₁) = Rz(α' - π/2) * Ry(φ') * Rz(-θ')
-  -- Solution: α' = α₁ + π/2, φ' = β₁, θ' = -γ₁
-  sorry -- TODO: Construct pose and prove equality using h_inner, h_outer
+  -- The ZYZ decomposition gives p.innerRot = Rz(α₁) * Ry(β₁) * Rz(γ₁)
+  -- We need rotRM_mat θ₁ φ₁ α = Rz(α - π/2) * Ry(φ) * Rz(-θ) to equal this
+  -- Solution for inner: α = α₁ + π/2, φ₁ = β₁, θ₁ = -γ₁
+  --
+  -- For outer: rotRM_mat θ₂ φ₂ 0 = Rz(-π/2) * Ry(φ₂) * Rz(-θ₂)
+  -- This is the form Rz(-π/2) * Ry(β₂) * Rz(γ₂) where we identify φ₂ = β₂, θ₂ = -γ₂
+  -- But we need to show p.outerRot can be written as Rz(-π/2) * Ry(β) * Rz(γ)
+  -- This requires α₂ = -π/2 (mod 2π) in the ZYZ decomposition.
+  --
+  -- TODO: This may require a different approach - perhaps showing that any SO3
+  -- matrix can be decomposed with a specific first angle via alternative decompositions.
+  sorry

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -1,9 +1,44 @@
 import Noperthedron.MatrixPose
 import Noperthedron.Pose
+import Noperthedron.Bounding.OrthEquivRotz
 
+open scoped Matrix
+open Real
+
+/--
+The matrix form of `rotRM θ φ α`, which is `Rz(-(π/2)) * Rz(α) * Ry(φ) * Rz(-θ)`.
+-/
+noncomputable
+def rotRM_mat (θ φ α : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  Rz_mat (-(π / 2)) * Rz_mat α * Ry_mat φ * Rz_mat (-θ)
+
+/--
+The matrix `rotRM_mat θ φ α` is in SO3 because it's a product of SO3 matrices.
+-/
+lemma rotRM_mat_mem_SO3 (θ φ α : ℝ) :
+    rotRM_mat θ φ α ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ := by
+  unfold rotRM_mat
+  refine Submonoid.mul_mem _ (Submonoid.mul_mem _ (Submonoid.mul_mem _ ?_ ?_) ?_) ?_
+  · exact Bounding.rot3_mat_mem_SO3 2 (-(π / 2))
+  · exact Bounding.rot3_mat_mem_SO3 2 α
+  · exact Bounding.rot3_mat_mem_SO3 1 φ
+  · exact Bounding.rot3_mat_mem_SO3 2 (-θ)
+
+/--
+`rotRM θ φ α` equals the continuous linear map induced by `rotRM_mat θ φ α`.
+-/
+lemma rotRM_eq_rotRM_mat (θ φ α : ℝ) :
+    rotRM θ φ α = (rotRM_mat θ φ α).toEuclideanLin.toContinuousLinearMap := by
+  unfold rotRM rotRM_mat RzL RyL
+  ext v i
+  simp only [ContinuousLinearMap.coe_comp', Function.comp_apply,
+    LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+  rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
+
+noncomputable
 def Pose.matrixPoseOfPose (p : Pose) : MatrixPose where
-  innerRot := sorry -- TODO(easy)
-  outerRot := sorry -- TODO(easy)
+  innerRot := ⟨rotRM_mat p.θ₁ p.φ₁ p.α, rotRM_mat_mem_SO3 p.θ₁ p.φ₁ p.α⟩
+  outerRot := ⟨rotRM_mat p.θ₂ p.φ₂ 0, rotRM_mat_mem_SO3 p.θ₂ p.φ₂ 0⟩
   innerOffset := 0
 
 theorem converted_pose_inner_shadow_eq (v : Pose) (S : Set ℝ³) :

--- a/Noperthedron/Final.lean
+++ b/Noperthedron/Final.lean
@@ -32,7 +32,13 @@ There is no purely rotational pose that makes the Noperthedron have the Rupert p
 theorem no_nopert_rot_pose : ¬ ∃ p : MatrixPose, RupertPose p.zeroOffset nopert.hull := by
   intro r
   obtain ⟨p, r⟩ := r
-  let ⟨v, e⟩ := pose_of_matrix_pose p
+  -- TODO: Need to prove that p.outerRot is in the image of rotRM_mat _ _ 0.
+  -- This requires either:
+  -- (1) Showing RupertPose implies the outer rotation has this form, or
+  -- (2) Proving RupertPose is invariant under left-multiplying rotations by Rz(δ),
+  --     then picking δ so the first Euler angle becomes -π/2.
+  have h_outer : ∃ θ φ, p.outerRot.val = rotRM_mat θ φ 0 := by sorry
+  let ⟨v, e⟩ := pose_of_matrix_pose p h_outer
   refine no_nopert_pose ⟨v, ?_⟩
   apply (converted_pose_rupert_iff v nopert.hull).mpr
   rw [e]


### PR DESCRIPTION
## Summary

Fills sorries in `ConvertPose.lean`, with one exception: the original `pose_of_matrix_pose` statement was false, so we weakened it, pushing a new sorry to `Final.lean`. See #7 for details and proposed fix.

### What's Proved (no sorries)

- `matrixPoseOfPose` definition - converts 5-parameter `Pose` to `MatrixPose`
- `Rz_mat_mul`: `Rz_mat a * Rz_mat b = Rz_mat (a + b)`
- `rotRM_mat_eq`: `rotRM_mat θ φ α = Rz(α - π/2) * Ry(φ) * Rz(-θ)`
- `exists_SO3_mulVec_ez_eq_ZY` - any unit vector reachable by `Rz(α) * Ry(β)` on e₃
- `SO3_euler_ZYZ` - ZYZ Euler decomposition for SO3
- `converted_pose_inner_shadow_eq`, `converted_pose_outer_shadow_eq`
- `converted_pose_rupert_iff`
- `pose_of_matrix_pose` (with weakened statement)

### What Remains Sorry

**`Final.lean:40`** - `h_outer : ∃ θ φ, p.outerRot.val = rotRM_mat θ φ 0`

### The `pose_of_matrix_pose` Issue

The **original Lean statement was false**:

```lean
-- ORIGINAL (false):
theorem pose_of_matrix_pose (p : MatrixPose) : ∃ pp : Pose, pp.matrixPoseOfPose = p.zeroOffset
```

**Why it's false**: `Pose` has 5 parameters (θ₁, φ₁, α, θ₂, φ₂). The outer rotation `rotRM_mat θ φ 0 = Rz(-π/2) * Ry(φ) * Rz(-θ)` has only 2 DOF - the first Euler angle is fixed at -π/2. A general SO3 outer rotation has 3 DOF, so not every `MatrixPose` can be represented.

**Blueprint ambiguity**: The blueprint says "equivalent" which could mean MatrixPose-equal (false) or Rupert-equivalent (probably true). The Lean formalization chose the stronger interpretation.

**Our fix**: Weakened statement to require `h_outer : ∃ θ φ, p.outerRot.val = rotRM_mat θ φ 0`.

**Better fix (future work)**: Prove `RupertPose` is invariant under left-multiplying both rotations by `Rz(δ)`, then pick δ to make outer rotation's first Euler angle equal -π/2. This would eliminate the sorry in Final.lean. See #7.