### PR TITLE
Implement inner_ge_implies_LMD (Lemma 32 from [SY25])

### DIFF
--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -43,13 +43,9 @@ private lemma angle_condition_implies_not_interior {P : Finset Euc(2)} {Q : Euc(
   -- convexHull P ⊆ {x : ⟪Q, x⟫ ≤ ‖Q‖²}
   have h_hull_in_halfspace : convexHull ℝ (P : Set Euc(2)) ⊆ {x : Euc(2) | ⟪Q, x⟫ ≤ ‖Q‖^2} :=
     convexHull_min h_halfspace (convex_halfSpace_le (innerSL ℝ Q).toLinearMap.isLinear _)
-  -- Q ∈ interior(convexHull P) means there's an open set U with Q ∈ U ⊆ convexHull P
-  rw [mem_interior] at hQ_int
-  obtain ⟨U, hU_sub, hU_open, hQ_in_U⟩ := hQ_int
-  -- Since U is open and Q ∈ U, there exists ε > 0 such that B(Q, ε) ⊆ U
-  rw [Metric.isOpen_iff] at hU_open
-  obtain ⟨ε, hε_pos, hball_sub_U⟩ := hU_open Q hQ_in_U
-  -- Consider Q + (ε/2) * (Q / ‖Q‖) - this is in B(Q, ε) ⊆ U ⊆ convexHull P
+  -- Q ∈ interior(convexHull P) gives a ball around Q contained in convexHull P
+  rw [mem_interior_iff_mem_nhds, Metric.mem_nhds_iff] at hQ_int
+  obtain ⟨ε, hε_pos, hball_sub_hull⟩ := hQ_int
   have hQ_pos : 0 < ‖Q‖ := norm_pos_iff.mpr hQ_ne_zero
   let v := (ε / (2 * ‖Q‖)) • Q  -- direction scaled to have norm ε/2
   have hv_norm : ‖v‖ = ε / 2 := by
@@ -58,8 +54,7 @@ private lemma angle_condition_implies_not_interior {P : Finset Euc(2)} {Q : Euc(
   have hQv_in_ball : Q + v ∈ Metric.ball Q ε := by
     simp only [Metric.mem_ball, dist_eq_norm, add_sub_cancel_left, hv_norm]
     linarith
-  have hQv_in_hull : Q + v ∈ convexHull ℝ (P : Set Euc(2)) :=
-    hU_sub (hball_sub_U hQv_in_ball)
+  have hQv_in_hull : Q + v ∈ convexHull ℝ (P : Set Euc(2)) := hball_sub_hull hQv_in_ball
   -- But ⟪Q, Q + v⟫ > ‖Q‖², contradicting Q + v ∈ convexHull P ⊆ {x : ⟪Q, x⟫ ≤ ‖Q‖²}
   have hQv_inner : ⟪Q, Q + v⟫ = ‖Q‖^2 + (ε / 2) * ‖Q‖ := by
     simp only [v, inner_add_right, inner_smul_right]

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -36,10 +36,9 @@ private lemma angle_condition_implies_not_interior {P : Finset Euc(2)} {Q : Euc(
   have h_halfspace : ∀ Pᵢ ∈ P, ⟪Q, Pᵢ⟫ ≤ ‖Q‖^2 := by
     intro Pᵢ hPᵢ
     by_cases heq : Pᵢ = Q
-    · simp [heq, inner_self_eq_norm_sq_to_K]
+    · simp [heq]
     · have h1 := h_angle Pᵢ hPᵢ heq
-      simp only [inner_sub_right] at h1
-      have h2 : ⟪Q, Q⟫ = ‖Q‖^2 := inner_self_eq_norm_sq_to_K Q
+      simp only [inner_sub_right, real_inner_self_eq_norm_sq] at h1
       linarith
   -- convexHull P ⊆ {x : ⟪Q, x⟫ ≤ ‖Q‖²}
   have h_hull_in_halfspace : convexHull ℝ (P : Set Euc(2)) ⊆ {x : Euc(2) | ⟪Q, x⟫ ≤ ‖Q‖^2} := by

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -187,10 +187,7 @@ theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
   -- Combine: ⟪Q, A - Q⟫ ≤ -(δ/r) * ‖Q‖ * ‖A - Q‖
   -- First we need δ > 0 (since ‖Q - Q_‖ < δ and norms are ≥ 0)
   have hδ_pos : 0 < δ := lt_of_le_of_lt (norm_nonneg _) hQ_
-  have h_coeff_neg : -(δ / r) * ‖Q‖ ≤ 0 := by
-    apply mul_nonpos_of_nonpos_of_nonneg
-    · linarith [div_pos hδ_pos hr]
-    · exact le_of_lt hQ_pos
+  have h_coeff_neg : -(δ / r) * ‖Q‖ ≤ 0 := by nlinarith [div_pos hδ_pos hr]
   have h_inner_final : ⟪Q, A - Q⟫ ≤ -(δ / r) * ‖Q‖ * ‖A - Q‖ := by
     calc ⟪Q, A - Q⟫ ≤ -(δ / r) * ‖Q‖ * ∑ y ∈ P, w y * ‖y - Q‖ := h_inner_bound
       _ ≤ -(δ / r) * ‖Q‖ * ‖A - Q‖ := mul_le_mul_of_nonpos_left h_norm_bound h_coeff_neg

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -241,6 +241,5 @@ theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
         _ = ‖A - Q‖ * (‖A - Q‖ - 2 * δ * ‖Q‖ / r) := h_rhs
         _ < 0 := mul_neg_of_pos_of_neg h_AQ_pos h_factor
   -- From ‖A‖² < ‖Q‖², conclude ‖A‖ < ‖Q‖
-  have h_nonneg_A : 0 ≤ ‖A‖ := norm_nonneg A
-  have h_nonneg_Q : 0 ≤ ‖Q‖ := norm_nonneg Q
-  nlinarith [sq_nonneg ‖A‖, sq_nonneg ‖Q‖, sq_nonneg (‖A‖ - ‖Q‖), sq_nonneg (‖A‖ + ‖Q‖)]
+  have h_sq_lt : ‖A‖^2 < ‖Q‖^2 := by linarith
+  rwa [sq_lt_sq, abs_of_nonneg (norm_nonneg A), abs_of_nonneg (norm_nonneg Q)] at h_sq_lt

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -21,10 +21,83 @@ def LocallyMaximallyDistant (δ : ℝ) (Q Q_ : Euc(2)) (P : Finset Euc(2)) : Pro
   ∀ A ∈ sect δ Q_ P, ‖A‖ < ‖Q‖
 
 /--
+Key algebraic identity: ‖A‖² - ‖Q‖² = 2⟪Q, A - Q⟫ + ‖A - Q‖²
+-/
+private lemma norm_sq_diff_eq {A Q : Euc(2)} :
+    ‖A‖^2 - ‖Q‖^2 = 2 * ⟪Q, A - Q⟫ + ‖A - Q‖^2 := by
+  have h := norm_add_sq_real Q (A - Q)
+  simp only [add_sub_cancel] at h
+  linarith
+
+/--
+If the angle condition holds and Q ≠ 0, then ⟪Q, Pᵢ - Q⟫ is bounded above by a negative quantity.
+-/
+private lemma inner_toward_vertex_neg {P : Finset Euc(2)} {Q : Euc(2)} {δ r : ℝ}
+    (hr : 0 < r) (hrQ : r < ‖Q‖) (Pᵢ : Euc(2)) (hPᵢ : Pᵢ ∈ P) (hne : Pᵢ ≠ Q)
+    (hle : δ / r ≤ ⟪Q, Q - Pᵢ⟫ / (‖Q‖ * ‖Q - Pᵢ‖)) :
+    ⟪Q, Pᵢ - Q⟫ ≤ -(δ / r) * ‖Q‖ * ‖Q - Pᵢ‖ := by
+  have hQ_pos : 0 < ‖Q‖ := lt_trans hr hrQ
+  have hQPᵢ_pos : 0 < ‖Q - Pᵢ‖ := norm_sub_pos_iff.mpr hne.symm
+  have hdenom_pos : 0 < ‖Q‖ * ‖Q - Pᵢ‖ := mul_pos hQ_pos hQPᵢ_pos
+  have h1 : δ / r * (‖Q‖ * ‖Q - Pᵢ‖) ≤ ⟪Q, Q - Pᵢ⟫ := by
+    have h := (le_div_iff₀ hdenom_pos).mp hle
+    linarith
+  have h2 : ⟪Q, Pᵢ - Q⟫ = -⟪Q, Q - Pᵢ⟫ := by simp [inner_sub_right]
+  linarith
+
+/--
 [SY25] Lemma 32
 -/
 theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
     (hQ : Q ∈ P) (hQ_ : ‖Q - Q_‖ < δ) (hr : 0 < r) (hrQ : r < ‖Q‖)
     (hle : ∀ Pᵢ ∈ P, Pᵢ ≠ Q → δ / r ≤ ⟪Q, Q - Pᵢ⟫ / (‖Q‖ * ‖Q - Pᵢ‖)) :
     LocallyMaximallyDistant δ Q Q_ P := by
-  sorry
+  -- We need to show: for all A in sect δ Q_ P, ‖A‖ < ‖Q‖
+  intro A hA
+  simp only [sect, Set.mem_inter_iff, Metric.mem_ball] at hA
+  obtain ⟨hA_ball, hA_interior⟩ := hA
+  -- A is within δ of Q_, and Q is within δ of Q_, so A is within 2δ of Q
+  have hAQ : ‖A - Q‖ < 2 * δ := by
+    calc ‖A - Q‖ ≤ ‖A - Q_‖ + ‖Q_ - Q‖ := norm_sub_le_norm_sub_add_norm_sub A Q_ Q
+    _ = ‖A - Q_‖ + ‖Q - Q_‖ := by rw [norm_sub_rev Q_ Q]
+    _ < δ + δ := by
+      apply add_lt_add
+      · rwa [dist_eq_norm] at hA_ball
+      · exact hQ_
+    _ = 2 * δ := by ring
+  -- The key is to show ‖A‖² < ‖Q‖² using the angle condition
+  -- We have: ‖A‖² - ‖Q‖² = 2⟪Q, A - Q⟫ + ‖A - Q‖²
+  -- If A is in the interior and close to Q, then ⟪Q, A - Q⟫ should be negative enough
+  have hQ_pos : 0 < ‖Q‖ := lt_trans hr hrQ
+  -- Show ‖A‖² < ‖Q‖² by showing the difference is negative
+  have h_sq_diff : ‖A‖^2 - ‖Q‖^2 < 0 := by
+    rw [norm_sq_diff_eq]
+    -- Need: 2 * ⟪Q, A - Q⟫ + ‖A - Q‖² < 0
+    --
+    -- [SY25] Lemma 32 proof outline:
+    -- The key geometric insight is that since A is in the interior of the
+    -- convex hull and Q is a vertex, A - Q points "into" the polygon.
+    -- The angle condition ensures Q "sticks out" enough.
+    --
+    -- Specifically:
+    -- 1. Since Q is a vertex of convexHull P, Q is an extreme point
+    -- 2. Since A ∈ interior (convexHull P), A is not on the boundary
+    -- 3. The direction A - Q must have ⟪Q, A - Q⟫ < 0 (pointing "inward")
+    -- 4. The angle condition quantifies: for each edge direction (Q - Pᵢ),
+    --    the cosine ⟪Q, Q - Pᵢ⟫/(‖Q‖ * ‖Q - Pᵢ‖) ≥ δ/r
+    -- 5. This implies ⟪Q, Pᵢ - Q⟫ ≤ -(δ/r) * ‖Q‖ * ‖Q - Pᵢ‖ (inward is negative)
+    -- 6. Since A - Q is a positive combination of inward directions when A ∈ interior,
+    --    we get ⟪Q, A - Q⟫ ≤ -(δ/r) * ‖Q‖ * ‖A - Q‖
+    -- 7. Combined with ‖A - Q‖ < 2δ and ‖Q‖ > r:
+    --    2⟪Q, A - Q⟫ + ‖A - Q‖² ≤ 2 * (-(δ/r) * ‖Q‖ * ‖A - Q‖) + ‖A - Q‖²
+    --                            = ‖A - Q‖ * (‖A - Q‖ - 2δ‖Q‖/r)
+    --                            < ‖A - Q‖ * (2δ - 2δ‖Q‖/r)  [since ‖A - Q‖ < 2δ]
+    --                            = 2δ * ‖A - Q‖ * (1 - ‖Q‖/r)
+    --                            < 0  [since ‖Q‖ > r]
+    --
+    -- The remaining challenge is formalizing step 6: that A - Q being in the
+    -- interior direction means it can be bounded by the angle condition on edges.
+    sorry
+  have h_nonneg_A : 0 ≤ ‖A‖ := norm_nonneg A
+  have h_nonneg_Q : 0 ≤ ‖Q‖ := norm_nonneg Q
+  nlinarith [sq_nonneg ‖A‖, sq_nonneg ‖Q‖]

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -41,19 +41,8 @@ private lemma angle_condition_implies_not_interior {P : Finset Euc(2)} {Q : Euc(
       simp only [inner_sub_right, real_inner_self_eq_norm_sq] at h1
       linarith
   -- convexHull P ⊆ {x : ⟪Q, x⟫ ≤ ‖Q‖²}
-  have h_hull_in_halfspace : convexHull ℝ (P : Set Euc(2)) ⊆ {x : Euc(2) | ⟪Q, x⟫ ≤ ‖Q‖^2} := by
-    apply convexHull_min
-    · intro x hx
-      simp only [Set.mem_setOf_eq]
-      exact h_halfspace x hx
-    · -- The half-space {x : ⟪Q, x⟫ ≤ c} is convex
-      intro x hx y hy a b ha hb hab
-      simp only [Set.mem_setOf_eq] at hx hy ⊢
-      calc ⟪Q, a • x + b • y⟫ = a * ⟪Q, x⟫ + b * ⟪Q, y⟫ := by
-              simp [inner_add_right, inner_smul_right]
-        _ ≤ a * ‖Q‖^2 + b * ‖Q‖^2 := by nlinarith
-        _ = (a + b) * ‖Q‖^2 := by ring
-        _ = ‖Q‖^2 := by rw [hab, one_mul]
+  have h_hull_in_halfspace : convexHull ℝ (P : Set Euc(2)) ⊆ {x : Euc(2) | ⟪Q, x⟫ ≤ ‖Q‖^2} :=
+    convexHull_min h_halfspace (convex_halfSpace_le (innerSL ℝ Q).toLinearMap.isLinear _)
   -- Q ∈ interior(convexHull P) means there's an open set U with Q ∈ U ⊆ convexHull P
   rw [mem_interior] at hQ_int
   obtain ⟨U, hU_sub, hU_open, hQ_in_U⟩ := hQ_int

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -57,9 +57,7 @@ private lemma angle_condition_implies_not_interior {P : Finset Euc(2)} {Q : Euc(
   have hQv_in_hull : Q + v ∈ convexHull ℝ (P : Set Euc(2)) := hball_sub_hull hQv_in_ball
   -- But ⟪Q, Q + v⟫ > ‖Q‖², contradicting Q + v ∈ convexHull P ⊆ {x : ⟪Q, x⟫ ≤ ‖Q‖²}
   have hQv_inner : ⟪Q, Q + v⟫ = ‖Q‖^2 + (ε / 2) * ‖Q‖ := by
-    simp only [v, inner_add_right, inner_smul_right]
-    have h_inner_Q : ⟪Q, Q⟫ = ‖Q‖^2 := inner_self_eq_norm_sq_to_K Q
-    rw [h_inner_Q]
+    simp only [v, inner_add_right, inner_smul_right, real_inner_self_eq_norm_sq]
     field_simp
   have hQv_gt : ⟪Q, Q + v⟫ > ‖Q‖^2 := by
     rw [hQv_inner]

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -162,7 +162,7 @@ theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
     -- Extend back to sum over P (Q term is 0)
     have h_sum_extend : ∑ y ∈ P.erase Q, w y * ‖y - Q‖ = ∑ y ∈ P, w y * ‖y - Q‖ := by
       rw [← Finset.add_sum_erase P (fun y ↦ w y * ‖y - Q‖) hQ]
-      simp only [sub_self, norm_zero, mul_zero, zero_add]
+      simp [sub_self, norm_zero, mul_zero, zero_add]
     calc ∑ y ∈ P.erase Q, w y * ⟪Q, y - Q⟫
         ≤ ∑ y ∈ P.erase Q, w y * (-(δ / r) * ‖Q‖ * ‖y - Q‖) := Finset.sum_le_sum h_term_bound
       _ = -(δ / r) * ‖Q‖ * ∑ y ∈ P.erase Q, w y * ‖y - Q‖ := h_sum_factor

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -83,15 +83,18 @@ private lemma inner_convex_combination {P : Finset Euc(2)} {Q A : Euc(2)}
     (hA : A ∈ convexHull ℝ (P : Set Euc(2))) :
     ∃ w : Euc(2) → ℝ, (∀ y ∈ P, 0 ≤ w y) ∧ (∑ y ∈ P, w y = 1) ∧
       (∑ y ∈ P, w y • y = A) ∧
+      (A - Q = ∑ y ∈ P, w y • (y - Q)) ∧
       ⟪Q, A - Q⟫ = ∑ y ∈ P, w y * ⟪Q, y - Q⟫ := by
   rw [Finset.mem_convexHull'] at hA
   obtain ⟨w, hw_nonneg, hw_sum, hw_eq⟩ := hA
-  refine ⟨w, hw_nonneg, hw_sum, hw_eq, ?_⟩
-  calc ⟪Q, A - Q⟫ = ⟪Q, ∑ y ∈ P, w y • y - Q⟫ := by rw [hw_eq]
-    _ = ⟪Q, ∑ y ∈ P, w y • y - (∑ y ∈ P, w y) • Q⟫ := by rw [hw_sum, one_smul]
-    _ = ⟪Q, ∑ y ∈ P, w y • y - ∑ y ∈ P, w y • Q⟫ := by rw [Finset.sum_smul]
-    _ = ⟪Q, ∑ y ∈ P, (w y • y - w y • Q)⟫ := by rw [← Finset.sum_sub_distrib]
-    _ = ⟪Q, ∑ y ∈ P, w y • (y - Q)⟫ := by simp_rw [← smul_sub]
+  have hAQ_eq : A - Q = ∑ y ∈ P, w y • (y - Q) := by
+    calc A - Q = ∑ y ∈ P, w y • y - Q := by rw [hw_eq]
+      _ = ∑ y ∈ P, w y • y - (∑ y ∈ P, w y) • Q := by rw [hw_sum, one_smul]
+      _ = ∑ y ∈ P, w y • y - ∑ y ∈ P, w y • Q := by rw [Finset.sum_smul]
+      _ = ∑ y ∈ P, (w y • y - w y • Q) := by rw [← Finset.sum_sub_distrib]
+      _ = ∑ y ∈ P, w y • (y - Q) := by simp_rw [← smul_sub]
+  refine ⟨w, hw_nonneg, hw_sum, hw_eq, hAQ_eq, ?_⟩
+  calc ⟪Q, A - Q⟫ = ⟪Q, ∑ y ∈ P, w y • (y - Q)⟫ := by rw [hAQ_eq]
     _ = ∑ y ∈ P, ⟪Q, w y • (y - Q)⟫ := inner_sum P (fun y ↦ w y • (y - Q)) Q
     _ = ∑ y ∈ P, w y * ⟪Q, y - Q⟫ := by simp_rw [real_inner_smul_right]
 
@@ -135,7 +138,7 @@ theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
   -- A is in the interior, so it's in the convex hull
   have hA_hull : A ∈ convexHull ℝ (P : Set Euc(2)) := interior_subset hA_interior
   -- Get convex combination representation and the inner product identity
-  obtain ⟨w, hw_nonneg, hw_sum, hw_eq, hw_inner⟩ := inner_convex_combination hA_hull
+  obtain ⟨w, hw_nonneg, hw_sum, hw_eq, hAQ_eq, hw_inner⟩ := inner_convex_combination hA_hull
   -- Key bound: ⟪Q, A - Q⟫ ≤ -(δ/r) * ‖Q‖ * ‖A - Q‖
   -- First bound the inner product using angle conditions on each vertex
   have h_inner_bound : ⟪Q, A - Q⟫ ≤ -(δ / r) * ‖Q‖ * ∑ y ∈ P, w y * ‖y - Q‖ := by
@@ -169,13 +172,6 @@ theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
       _ = -(δ / r) * ‖Q‖ * ∑ y ∈ P, w y * ‖y - Q‖ := by rw [h_sum_extend]
   -- Triangle inequality for convex combination: ‖A - Q‖ ≤ ∑ wᵢ ‖yᵢ - Q‖
   have h_norm_bound : ‖A - Q‖ ≤ ∑ y ∈ P, w y * ‖y - Q‖ := by
-    -- A - Q = ∑ wᵢ (yᵢ - Q) because A = ∑ wᵢ yᵢ and ∑ wᵢ = 1
-    have hAQ_eq : A - Q = ∑ y ∈ P, w y • (y - Q) := by
-      calc A - Q = ∑ y ∈ P, w y • y - Q := by rw [hw_eq]
-        _ = ∑ y ∈ P, w y • y - (∑ y ∈ P, w y) • Q := by rw [hw_sum, one_smul]
-        _ = ∑ y ∈ P, w y • y - ∑ y ∈ P, w y • Q := by rw [Finset.sum_smul]
-        _ = ∑ y ∈ P, (w y • y - w y • Q) := by rw [← Finset.sum_sub_distrib]
-        _ = ∑ y ∈ P, w y • (y - Q) := by simp_rw [← smul_sub]
     rw [hAQ_eq]
     calc ‖∑ y ∈ P, w y • (y - Q)‖
         ≤ ∑ y ∈ P, ‖w y • (y - Q)‖ := norm_sum_le P (fun y ↦ w y • (y - Q))

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -105,11 +105,8 @@ private lemma inner_toward_vertex_neg {Q : Euc(2)} {δ r : ℝ}
   have hQ_pos : 0 < ‖Q‖ := lt_trans hr hrQ
   have hQPᵢ_pos : 0 < ‖Q - Pᵢ‖ := norm_sub_pos_iff.mpr hne.symm
   have hdenom_pos : 0 < ‖Q‖ * ‖Q - Pᵢ‖ := mul_pos hQ_pos hQPᵢ_pos
-  have h1 : δ / r * (‖Q‖ * ‖Q - Pᵢ‖) ≤ ⟪Q, Q - Pᵢ⟫ := by
-    have h := (le_div_iff₀ hdenom_pos).mp hle
-    linarith
-  have h2 : ⟪Q, Pᵢ - Q⟫ = -⟪Q, Q - Pᵢ⟫ := by simp [inner_sub_right]
-  linarith
+  simp only [inner_sub_right, real_inner_self_eq_norm_sq] at hle ⊢
+  nlinarith [(le_div_iff₀ hdenom_pos).mp hle]
 
 /--
 [SY25] Lemma 32

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -228,12 +228,9 @@ theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
       exact absurd hA_interior (angle_condition_implies_not_interior hQ hQ_ne_zero h_angle)
     · -- If ‖A - Q‖ > 0
       have h_AQ_pos : 0 < ‖A - Q‖ := lt_of_le_of_ne h_AQ_nonneg (Ne.symm hAQ_zero)
-      -- Use the bound
-      have h_bound : 2 * ⟪Q, A - Q⟫ ≤ 2 * (-(δ / r) * ‖Q‖ * ‖A - Q‖) := by linarith [h_inner_final]
-      have h_rhs : 2 * (-(δ / r) * ‖Q‖ * ‖A - Q‖) + ‖A - Q‖^2 =
-          ‖A - Q‖ * (‖A - Q‖ - 2 * δ * ‖Q‖ / r) := by ring
-      calc 2 * ⟪Q, A - Q⟫ + ‖A - Q‖^2 ≤ 2 * (-(δ / r) * ‖Q‖ * ‖A - Q‖) + ‖A - Q‖^2 := by linarith
-        _ = ‖A - Q‖ * (‖A - Q‖ - 2 * δ * ‖Q‖ / r) := h_rhs
+      calc 2 * ⟪Q, A - Q⟫ + ‖A - Q‖^2
+          ≤ 2 * (-(δ / r) * ‖Q‖ * ‖A - Q‖) + ‖A - Q‖^2 := by linarith [h_inner_final]
+        _ = ‖A - Q‖ * (‖A - Q‖ - 2 * δ * ‖Q‖ / r) := by ring
         _ < 0 := mul_neg_of_pos_of_neg h_AQ_pos h_factor
   -- From ‖A‖² < ‖Q‖², conclude ‖A‖ < ‖Q‖
   have h_sq_lt : ‖A‖^2 < ‖Q‖^2 := by linarith

--- a/Noperthedron/Local/LocallyMaximallyDistant.lean
+++ b/Noperthedron/Local/LocallyMaximallyDistant.lean
@@ -212,9 +212,7 @@ theorem inner_ge_implies_LMD {P : Finset Euc(2)} {Q Q_ : Euc(2)} {δ r : ℝ}
     · -- If A = Q, then A is a vertex in the interior of the convex hull.
       -- This is impossible: vertices of a finite set are extreme points of the hull,
       -- and extreme points cannot be interior points.
-      have hAQ_eq : A = Q := by
-        rw [← sub_eq_zero]
-        exact (norm_eq_zero (E := Euc(2))).mp hAQ_zero
+      have hAQ_eq : A = Q := by rwa [norm_eq_zero, sub_eq_zero] at hAQ_zero
       rw [hAQ_eq] at hA_interior
       -- The angle condition implies ⟪Q, Q - Pᵢ⟫ > 0 for all Pᵢ ≠ Q
       have h_angle : ∀ Pᵢ ∈ P, Pᵢ ≠ Q → ⟪Q, Q - Pᵢ⟫ > 0 := by


### PR DESCRIPTION
## Summary

Proves Lemma 32 from the Steininger-Yurkevich paper: if vertex Q satisfies an angle condition relative to all other vertices, then Q is δ-locally maximally distant (δ-LMD) with respect to Q̄.

## Changes

- **`Noperthedron/Local/LocallyMaximallyDistant.lean`**
  - Added `sect` definition (intersection of δ-ball with interior of convex hull)
  - Added `LocallyMaximallyDistant` definition (Definition 31)
  - Proved `inner_ge_implies_LMD` theorem (Lemma 32)
  - Helper lemmas: `angle_condition_implies_not_interior`, `norm_sq_diff_eq`, `inner_convex_combination`, `inner_toward_vertex_neg`

## Proof approach

The main theorem shows that under the angle condition, any point A in the sector (δ-ball ∩ interior of convex hull) has ‖A‖ < ‖Q‖.

Key steps:
1. Triangle inequality bounds ‖A - Q‖ < 2δ
2. Convex combination representation gives ⟪Q, A - Q⟫ = Σ wᵢ ⟪Q, Pᵢ - Q⟫
3. Angle condition bounds each term negatively
4. Algebraic identity ‖A‖² - ‖Q‖² = 2⟪Q, A - Q⟫ + ‖A - Q‖² shows ‖A‖² < ‖Q‖²

The edge case A = Q required a separate lemma (`angle_condition_implies_not_interior`) showing Q cannot be in the interior when the angle condition holds, using a half-space argument with `convex_halfSpace_le`.

## Mathlib lemmas used

- `convex_halfSpace_le` with `innerSL` for half-space convexity
- `mem_interior_iff_mem_nhds` + `Metric.mem_nhds_iff` for interior characterization
- `sq_lt_sq` for concluding ‖A‖ < ‖Q‖ from ‖A‖² < ‖Q‖²
- `Finset.mem_convexHull'` for convex combination representation