### PR TITLE
Remove \leanok from no_nopert_rot_pose

### DIFF
--- a/blueprint/src/chapters/main.tex
+++ b/blueprint/src/chapters/main.tex
@@ -41,12 +41,10 @@ says that this suffices for the general case.
 \begin{theorem}
 \label{thm:no_nopert_rot_pose}
 \lean{no_nopert_rot_pose}
-\leanok
 There is no purely rotational pose that makes the noperthedron have the Rupert property.
 \end{theorem}
 \begin{proof}
 \uses{thm:pose_of_matrix_pose, thm:no_nopert_pose}
-\leanok
 Suppose there were a purely rotational pose. Then convert that to an equivalent 5-parameter pose
 with Theorem~\ref{thm:pose_of_matrix_pose} and
 appeal to Theorem~\ref{thm:no_nopert_pose}.

--- a/blueprint/src/chapters/main.tex
+++ b/blueprint/src/chapters/main.tex
@@ -41,6 +41,7 @@ says that this suffices for the general case.
 \begin{theorem}
 \label{thm:no_nopert_rot_pose}
 \lean{no_nopert_rot_pose}
+\leanok
 There is no purely rotational pose that makes the noperthedron have the Rupert property.
 \end{theorem}
 \begin{proof}


### PR DESCRIPTION
The proof has a sorry due to a DOF mismatch in pose_of_matrix_pose.

See https://github.com/jcreedcmu/Noperthedron/pull/6#discussion_r2718477866