### PR TITLE
[EpsKapSpanning] Complete Lemma 46 (ek_spanning_imp_e_spanning)

### DIFF
--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -46,36 +46,20 @@ def mapOfCovec {n : ℕ} (v : Euc(n)) : Euc(1) →L[ℝ] Euc(n) := matOfCovec v 
 private lemma matOfCovec_transpose {n : ℕ} (v : Euc(n)) : (matOfCovec v)ᵀ = matOfVec v := by
   ext i j; simp [matOfVec, matOfCovec]
 
-private lemma mapOfCovec_apply' {n : ℕ} (v : Euc(n)) (c : Euc(1)) : mapOfCovec v c = c 0 • v := by
-  unfold mapOfCovec
-  ext i : 1
-  simp only [LinearMap.coe_toContinuousLinearMap']
-  rw [Matrix.toEuclideanLin_apply]
-  simp only [PiLp.smul_apply, smul_eq_mul]
-  rw [WithLp.ofLp_toLp]
-  simp only [Matrix.mulVec, dotProduct, matOfCovec, Finset.univ_unique, Fin.default_eq_zero,
-    Finset.sum_singleton]
-  ring
+private lemma mapOfCovec_apply {n : ℕ} (v : Euc(n)) (c : Euc(1)) : mapOfCovec v c = c 0 • v := by
+  ext i
+  simp only [mapOfCovec, matOfCovec, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply,
+    WithLp.ofLp_toLp, Matrix.mulVec, dotProduct, Finset.univ_unique, Fin.default_eq_zero,
+    Finset.sum_singleton, PiLp.smul_apply, smul_eq_mul, mul_comm]
 
-private lemma Euc1_norm_eq {c : Euc(1)} : ‖c‖ = |c 0| := by
-  rw [EuclideanSpace.norm_eq]
-  simp only [Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Real.norm_eq_abs]
-  rw [Real.sqrt_sq_eq_abs, abs_abs]
+private lemma Euc1_norm_eq (c : Euc(1)) : ‖c‖ = |c 0| := by
+  simp [EuclideanSpace.norm_eq, Real.sqrt_sq_eq_abs]
 
 @[simp]
 lemma norm_map_covec_eq_norm_vec {n : ℕ} (v : Euc(n)) : ‖mapOfCovec v‖ = ‖v‖ := by
-  apply ContinuousLinearMap.opNorm_eq_of_bounds (norm_nonneg v)
-  · intro c
-    rw [mapOfCovec_apply', norm_smul, mul_comm]
-    apply mul_le_mul_of_nonneg_left
-    · rw [Euc1_norm_eq, Real.norm_eq_abs]
-    · exact norm_nonneg v
-  · intro N _ hbound
-    have h := hbound (EuclideanSpace.single 0 1)
-    rw [mapOfCovec_apply'] at h
-    simp only [EuclideanSpace.single_apply, if_true] at h
-    rw [one_smul, EuclideanSpace.norm_single, norm_one, mul_one] at h
-    exact h
+  refine ContinuousLinearMap.opNorm_eq_of_bounds (norm_nonneg v) (fun c ↦ ?_) (fun N _ hN ↦ ?_)
+  · rw [mapOfCovec_apply, norm_smul, Euc1_norm_eq, Real.norm_eq_abs, mul_comm]
+  · simpa [mapOfCovec_apply, EuclideanSpace.norm_single] using hN (EuclideanSpace.single 0 1)
 
 @[simp]
 lemma norm_map_vec_eq_norm_vec {n : ℕ} (v : Euc(n)) : ‖mapOfVec v‖ = ‖v‖ := by

--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -71,9 +71,39 @@ lemma bound_rotM (θ φ : ℝ) : ‖rotM θ φ‖ ≤ 1 + κ := by
 
 lemma bound_rotR (α : ℝ) : ‖rotR α‖ ≤ 1 := by exact le_of_eq (Bounding.rotR_norm_one α)
 
+private lemma matOfVec_sub {n : ℕ} (v w : Euc(n)) : matOfVec v - matOfVec w = matOfVec (v - w) := by
+  ext i j; simp [matOfVec]
+
+private lemma matOfCovec_sub {n : ℕ} (v w : Euc(n)) : matOfCovec v - matOfCovec w = matOfCovec (v - w) := by
+  ext i j; simp [matOfCovec]
+
+private lemma norm_mapOfVec_sub_le {n : ℕ} (v w : Euc(n)) :
+    ‖mapOfVec v - mapOfVec w‖ ≤ ‖v - w‖ := by
+  have h : mapOfVec v - mapOfVec w = mapOfVec (v - w) := by
+    unfold mapOfVec
+    simp only [← map_sub, matOfVec_sub]
+  rw [h, norm_map_vec_eq_norm_vec]
+
+private lemma norm_mapOfCovec_sub_le {n : ℕ} (v w : Euc(n)) :
+    ‖mapOfCovec v - mapOfCovec w‖ ≤ ‖v - w‖ := by
+  have h : mapOfCovec v - mapOfCovec w = mapOfCovec (v - w) := by
+    unfold mapOfCovec
+    simp only [← map_sub, matOfCovec_sub]
+  rw [h, norm_map_covec_eq_norm_vec]
+
+private lemma mapOfVec_apply {n : ℕ} (v x : Euc(n)) : (mapOfVec v x) 0 = ⟪v, x⟫ := by
+  unfold mapOfVec
+  rw [EuclideanSpace.inner_eq_star_dotProduct, star_trivial]
+  change (Matrix.toEuclideanLin (matOfVec v) x).ofLp 0 = _
+  rw [Matrix.toEuclideanLin_apply, WithLp.ofLp_toLp]
+  simp only [matOfVec, Matrix.mulVec, dotProduct]
+  congr 1
+  funext j
+  ring
+
 /- [SY25 Lemma 46] -/
 theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Triangle)
-    (hk : κApproxTri P P') {θ φ ε : ℝ}
+    (hk : κApproxTri P P') (hP : ∀ i, ‖P i‖ ≤ 1) {θ φ ε : ℝ}
     (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4)
     (hspan : P'.Spanning θ φ ε) : P.Spanning θ φ ε := by
   constructor
@@ -90,8 +120,8 @@ theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Tri
     -- (A) P (i + 1)ᵀ ∘ (rotM θ φ)ᵀ ∘ rotR (π / 2) ∘ rotM θ φ ∘ P i
     -- (B) P' (i + 1)ᵀ ∘ (rotMℚ θ φ)ᵀ ∘ rotR (π / 2) ∘ rotMℚ θ φ ∘ P' i
     let mv := ⟦
-      mapOfVec (P i),
-      mapOfVec (P' i),
+      mapOfVec (P (i + 1)),
+      mapOfVec (P' (i + 1)),
       (rotM_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap,
       (rotMℚ_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap,
       rotR (π / 2), rotR (π / 2),
@@ -101,35 +131,58 @@ theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Tri
       mapOfCovec (P' i)
     ⟧
 
-    have bound_P (i : Fin 3) : ‖P i‖ ≤ 1 + κ := by
-      sorry
-    have bound_P' (i : Fin 3) : ‖WithLp.toLp 2 fun x ↦ ↑((P' i).ofLp x)‖ ≤ 1 + κ := by
-      sorry
+    have bound_P (i : Fin 3) : ‖P i‖ ≤ 1 + κ := calc
+      ‖P i‖ ≤ 1 := hP i
+      _ ≤ 1 + κ := by norm_num [κ]
+    have bound_P' (i : Fin 3) : ‖(P' i : ℝ³)‖ ≤ 1 + κ :=
+      calc ‖(P' i : ℝ³)‖ ≤ ‖P i‖ + ‖P i - (P' i : ℝ³)‖ := norm_le_insert (P i) (P' i : ℝ³)
+        _ ≤ 1 + κ := add_le_add (hP i) (hk i)
     have hmvs : mv.size = 5 := by simp [mv]
     have hanb : MatVec.allNormsBelow mv [1 + κ, 1 + κ, 1, 1 + κ, 1 + κ] := by
       simp only [MatVec.allNormsBelow, List.reverse_cons, List.reverse_nil, List.nil_append,
         List.cons_append, MatVec.allNormsBelow.go, true_and, and_self, mv, norm_transpose_euc_lin,
         norm_map_vec_eq_norm_vec, norm_map_covec_eq_norm_vec]
       exact ⟨⟨⟨⟨
-        ⟨bound_P' i, bound_P i⟩,
+        ⟨bound_P' (i + 1), bound_P (i + 1)⟩,
         ⟨Mℚ_norm_bounded hθ hφ, bound_rotM θ φ⟩⟩, bound_rotR (π / 2)⟩,
         ⟨Mℚ_norm_bounded hθ hφ, bound_rotM θ φ⟩⟩, ⟨bound_P' i, bound_P i⟩⟩
-    have hva : ⟪(rotR (π / 2)) ((rotM θ φ) (P i)), (rotM θ φ) (P (i + 1))⟫ = mv.valA := by
-      simp [MatVec.valA, mv, MatVec.compA]
+    have hva : ⟪(rotR (π / 2)) ((rotM θ φ) (P i)), (rotM θ φ) (P (i + 1))⟫ = mv.valB := by
+      simp only [MatVec.valB, mv, MatVec.compB]
       sorry
-    have hvb : ⟪(rotR (π / 2)) (rotMℚ θ φ (P' i)), rotMℚ θ φ (P' (i + 1))⟫ = mv.valB := by
-      simp [MatVec.valB, mv, MatVec.compB]
+    have hvb : ⟪(rotR (π / 2)) (rotMℚ θ φ (P' i)), rotMℚ θ φ (P' (i + 1))⟫ = mv.valA := by
+      simp [MatVec.valA, mv, MatVec.compA]
       sorry
     have hdbb : mv.DiffBoundedBy κ := by
       simp [MatVec.DiffBoundedBy, mv]
       clear hvb hva hanb hmvs mv
       split_ands
-      · sorry
-      · sorry
-      · sorry
-      · sorry
-      · sorry
-    suffices h : |mv.valA - mv.valB| ≤ 6 * κ by simpa [hva, hvb] using h
+      · -- ‖mapOfVec (P' (i+1)) - mapOfVec (P (i+1))‖ ≤ κ
+        calc ‖mapOfVec (P' (i + 1) : ℝ³) - mapOfVec (P (i + 1))‖
+          _ ≤ ‖(P' (i + 1) : ℝ³) - P (i + 1)‖ := norm_mapOfVec_sub_le _ _
+          _ = ‖P (i + 1) - (P' (i + 1) : ℝ³)‖ := norm_sub_rev _ _
+          _ ≤ κ := hk (i + 1)
+      · -- ‖(rotMℚ_mat θ φ)ᵀ.toCLM - (rotM_mat θ φ)ᵀ.toCLM‖ ≤ κ
+        have h : (rotMℚ_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap -
+                 (rotM_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap =
+                 (rotMℚ_mat θ φ - rotM_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap := by
+          simp only [← map_sub, Matrix.transpose_sub]
+        rw [h, norm_transpose_euc_lin]
+        calc ‖(rotMℚ_mat θ φ - rotM_mat θ φ).toEuclideanLin.toContinuousLinearMap‖
+          _ = ‖rotMℚ θ φ - rotM θ φ‖ := by simp only [rotMℚ, rotM, ← map_sub]
+          _ = ‖rotM θ φ - rotMℚ θ φ‖ := norm_sub_rev _ _
+          _ ≤ κ := M_difference_norm_bounded θ φ hθ hφ
+      · -- ‖rotR (π/2) - rotR (π/2)‖ ≤ κ  i.e., 0 ≤ κ
+        norm_num [κ]
+      · -- ‖rotMℚ θ φ - rotM θ φ‖ ≤ κ
+        rw [norm_sub_rev]
+        exact M_difference_norm_bounded θ φ hθ hφ
+      · -- ‖mapOfCovec (P' i) - mapOfCovec (P i)‖ ≤ κ
+        calc ‖mapOfCovec (P' i : ℝ³) - mapOfCovec (P i)‖
+          _ ≤ ‖(P' i : ℝ³) - P i‖ := norm_mapOfCovec_sub_le _ _
+          _ = ‖P i - (P' i : ℝ³)‖ := norm_sub_rev _ _
+          _ ≤ κ := hk i
+    suffices h : |mv.valA - mv.valB| ≤ 6 * κ by
+      rw [hva, hvb]; rw [abs_sub_comm]; exact h
     grw [norm_sub_le_bound1 mv κ (by norm_num [κ]) hdbb hanb]
     rw [hmvs]
     norm_num [κ]

--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -45,7 +45,7 @@ def mapOfCovec {n : ℕ} (v : Euc(n)) : Euc(1) →L[ℝ] Euc(n) := matOfCovec v 
 
 private lemma matOfCovec_transpose {n : ℕ} (v : Euc(n)) : (matOfCovec v)ᵀ = matOfVec v := by
   ext i j
-  simp [matOfVec, matOfCovec]
+  rfl
 
 private lemma mapOfCovec_apply {n : ℕ} (v : Euc(n)) (c : Euc(1)) : mapOfCovec v c = c 0 • v := by
   ext i
@@ -62,42 +62,33 @@ lemma norm_map_covec_eq_norm_vec {n : ℕ} (v : Euc(n)) : ‖mapOfCovec v‖ = �
 
 @[simp]
 lemma norm_map_vec_eq_norm_vec {n : ℕ} (v : Euc(n)) : ‖mapOfVec v‖ = ‖v‖ := by
-  change ‖(matOfCovec v)ᵀ.toEuclideanLin.toContinuousLinearMap‖ = ‖v‖
-  rw [norm_transpose_euc_lin]
-  exact norm_map_covec_eq_norm_vec v
+  have : ‖mapOfVec v‖ = ‖mapOfCovec v‖ := by simp [mapOfVec, mapOfCovec, ← matOfCovec_transpose]
+  simp [this]
 
 lemma bound_rotM (θ φ : ℝ) : ‖rotM θ φ‖ ≤ 1 + κ := by
   norm_num [Bounding.rotM_norm_one, κ]
 
-lemma bound_rotR (α : ℝ) : ‖rotR α‖ ≤ 1 := by exact le_of_eq (Bounding.rotR_norm_one α)
+lemma bound_rotR (α : ℝ) : ‖rotR α‖ ≤ 1 := (Bounding.rotR_norm_one α).le
 
 private lemma matOfVec_sub {n : ℕ} (v w : Euc(n)) : matOfVec v - matOfVec w = matOfVec (v - w) := by
-  ext i j; simp [matOfVec]
+  ext; simp [matOfVec]
 
 private lemma matOfCovec_sub {n : ℕ} (v w : Euc(n)) : matOfCovec v - matOfCovec w = matOfCovec (v - w) := by
-  ext i j; simp [matOfCovec]
+  ext; simp [matOfCovec]
 
 private lemma norm_mapOfVec_sub_le {n : ℕ} (v w : Euc(n)) :
     ‖mapOfVec v - mapOfVec w‖ ≤ ‖v - w‖ := by
-  have h : mapOfVec v - mapOfVec w = mapOfVec (v - w) := by
-    unfold mapOfVec
-    simp only [← map_sub, matOfVec_sub]
-  rw [h, norm_map_vec_eq_norm_vec]
+  simpa [mapOfVec, ← map_sub, matOfVec_sub] using (norm_map_vec_eq_norm_vec (v - w)).le
 
 private lemma norm_mapOfCovec_sub_le {n : ℕ} (v w : Euc(n)) :
     ‖mapOfCovec v - mapOfCovec w‖ ≤ ‖v - w‖ := by
-  have h : mapOfCovec v - mapOfCovec w = mapOfCovec (v - w) := by
-    unfold mapOfCovec
-    simp only [← map_sub, matOfCovec_sub]
-  rw [h, norm_map_covec_eq_norm_vec]
+  simpa [mapOfCovec, ← map_sub, matOfCovec_sub] using (norm_map_covec_eq_norm_vec (v - w)).le
 
 private lemma mapOfVec_apply {n : ℕ} (v x : Euc(n)) : (mapOfVec v x) 0 = ⟪v, x⟫ := by
-  unfold mapOfVec
-  rw [EuclideanSpace.inner_eq_star_dotProduct, star_trivial]
-  change (Matrix.toEuclideanLin (matOfVec v) x).ofLp 0 = _
-  simp only [Matrix.toEuclideanLin_apply, matOfVec, Matrix.mulVec, dotProduct, WithLp.ofLp_toLp]
-  exact Finset.sum_congr rfl fun j _ => mul_comm _ _
+  simp [mapOfVec, matOfVec, Matrix.toEuclideanLin_apply, Matrix.mulVec, dotProduct, mul_comm,
+    EuclideanSpace.inner_eq_star_dotProduct]
 
+@[simp]
 private lemma mapOfCovec_single {n : ℕ} (v : Euc(n)) :
     mapOfCovec v (EuclideanSpace.single 0 1) = v := by
   simp [mapOfCovec_apply, EuclideanSpace.single_apply]
@@ -150,7 +141,6 @@ theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Tri
     have bound_P' (i : Fin 3) : ‖(P' i : ℝ³)‖ ≤ 1 + κ :=
       calc ‖(P' i : ℝ³)‖ ≤ ‖P i‖ + ‖P i - (P' i : ℝ³)‖ := norm_le_insert (P i) (P' i : ℝ³)
         _ ≤ 1 + κ := add_le_add (hP i) (hk i)
-    have hmvs : mv.size = 5 := by simp [mv]
     have hanb : MatVec.allNormsBelow mv [1 + κ, 1 + κ, 1, 1 + κ, 1 + κ] := by
       simp only [MatVec.allNormsBelow, List.reverse_cons, List.reverse_nil, List.nil_append,
         List.cons_append, MatVec.allNormsBelow.go, true_and, and_self, mv, norm_transpose_euc_lin,
@@ -160,18 +150,14 @@ theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Tri
         ⟨Mℚ_norm_bounded hθ hφ, bound_rotM θ φ⟩⟩, bound_rotR (π / 2)⟩,
         ⟨Mℚ_norm_bounded hθ hφ, bound_rotM θ φ⟩⟩, ⟨bound_P' i, bound_P i⟩⟩
     have hva : ⟪(rotR (π / 2)) ((rotM θ φ) (P i)), (rotM θ φ) (P (i + 1))⟫ = mv.valB := by
-      simp only [MatVec.valB, mv, MatVec.compB, ContinuousLinearMap.coe_comp',
-        ContinuousLinearMap.coe_id', Function.comp_apply, id_eq,
-        mapOfCovec_single, rotM_transpose_adjoint, mapOfVec_apply]
-      rw [ContinuousLinearMap.adjoint_inner_right, real_inner_comm]
+      simp [MatVec.valB, mv, mapOfCovec_single, rotM_transpose_adjoint, mapOfVec_apply,
+        ContinuousLinearMap.adjoint_inner_right, real_inner_comm]
     have hvb : ⟪(rotR (π / 2)) (rotMℚ θ φ (P' i)), rotMℚ θ φ (P' (i + 1))⟫ = mv.valA := by
-      simp only [MatVec.valA, mv, MatVec.compA, ContinuousLinearMap.coe_comp',
-        ContinuousLinearMap.coe_id', Function.comp_apply, id_eq,
-        mapOfCovec_single, rotMℚ_transpose_adjoint, mapOfVec_apply]
-      rw [ContinuousLinearMap.adjoint_inner_right, real_inner_comm]
+      simp [MatVec.valA, mv, mapOfCovec_single, rotMℚ_transpose_adjoint, mapOfVec_apply,
+        ContinuousLinearMap.adjoint_inner_right, real_inner_comm]
     have hdbb : mv.DiffBoundedBy κ := by
       simp [MatVec.DiffBoundedBy, mv]
-      clear hvb hva hanb hmvs mv
+      clear hvb hva hanb mv
       split_ands
       · -- ‖mapOfVec (P' (i+1)) - mapOfVec (P (i+1))‖ ≤ κ
         calc ‖mapOfVec (P' (i + 1) : ℝ³) - mapOfVec (P (i + 1))‖
@@ -198,8 +184,7 @@ theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Tri
           _ ≤ ‖(P' i : ℝ³) - P i‖ := norm_mapOfCovec_sub_le _ _
           _ = ‖P i - (P' i : ℝ³)‖ := norm_sub_rev _ _
           _ ≤ κ := hk i
-    suffices h : |mv.valA - mv.valB| ≤ 6 * κ by
-      rw [hva, hvb]; rw [abs_sub_comm]; exact h
+    suffices h : |mv.valA - mv.valB| ≤ 6 * κ by rw [hva, hvb, abs_sub_comm]; exact h
     grw [norm_sub_le_bound1 mv κ (by norm_num [κ]) hdbb hanb]
-    rw [hmvs]
+    simp only [mv]
     norm_num [κ]

--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -44,31 +44,27 @@ noncomputable
 def mapOfCovec {n : ℕ} (v : Euc(n)) : Euc(1) →L[ℝ] Euc(n) := matOfCovec v |>.toEuclideanLin.toContinuousLinearMap
 
 private lemma matOfCovec_transpose {n : ℕ} (v : Euc(n)) : (matOfCovec v)ᵀ = matOfVec v := by
-  ext i j; simp [matOfVec, matOfCovec]
+  ext i j
+  simp [matOfVec, matOfCovec]
 
 private lemma mapOfCovec_apply {n : ℕ} (v : Euc(n)) (c : Euc(1)) : mapOfCovec v c = c 0 • v := by
   ext i
-  simp only [mapOfCovec, matOfCovec, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply,
-    WithLp.ofLp_toLp, Matrix.mulVec, dotProduct, Finset.univ_unique, Fin.default_eq_zero,
-    Finset.sum_singleton, PiLp.smul_apply, smul_eq_mul, mul_comm]
+  simp [mapOfCovec, matOfCovec, Matrix.toEuclideanLin_apply, Matrix.mulVec, dotProduct, mul_comm]
 
 private lemma Euc1_norm_eq (c : Euc(1)) : ‖c‖ = |c 0| := by
-  simp [EuclideanSpace.norm_eq, Real.sqrt_sq_eq_abs]
+  simpa [EuclideanSpace.norm_eq] using Real.sqrt_sq_eq_abs _
 
 @[simp]
 lemma norm_map_covec_eq_norm_vec {n : ℕ} (v : Euc(n)) : ‖mapOfCovec v‖ = ‖v‖ := by
   refine ContinuousLinearMap.opNorm_eq_of_bounds (norm_nonneg v) (fun c ↦ ?_) (fun N _ hN ↦ ?_)
-  · rw [mapOfCovec_apply, norm_smul, Euc1_norm_eq, Real.norm_eq_abs, mul_comm]
+  · simp [mapOfCovec_apply, norm_smul, Euc1_norm_eq, mul_comm]
   · simpa [mapOfCovec_apply, EuclideanSpace.norm_single] using hN (EuclideanSpace.single 0 1)
 
 @[simp]
 lemma norm_map_vec_eq_norm_vec {n : ℕ} (v : Euc(n)) : ‖mapOfVec v‖ = ‖v‖ := by
-  calc ‖mapOfVec v‖
-  _ = ‖(matOfVec v).toEuclideanLin.toContinuousLinearMap‖ := rfl
-  _ = ‖(matOfCovec v)ᵀ.toEuclideanLin.toContinuousLinearMap‖ := by rw [matOfCovec_transpose]
-  _ = ‖(matOfCovec v).toEuclideanLin.toContinuousLinearMap‖ := norm_transpose_euc_lin _
-  _ = ‖mapOfCovec v‖ := rfl
-  _ = ‖v‖ := norm_map_covec_eq_norm_vec v
+  change ‖(matOfCovec v)ᵀ.toEuclideanLin.toContinuousLinearMap‖ = ‖v‖
+  rw [norm_transpose_euc_lin]
+  exact norm_map_covec_eq_norm_vec v
 
 lemma bound_rotM (θ φ : ℝ) : ‖rotM θ φ‖ ≤ 1 + κ := by
   norm_num [Bounding.rotM_norm_one, κ]


### PR DESCRIPTION
## Summary

Complete proof of `ek_spanning_imp_e_spanning` (Lemma 46 from [SY25]).

### ⚠️ Theorem Signature Change

Added hypothesis `hP : ∀ i, ‖P i‖ ≤ 1` to the theorem signature:

```lean
theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Triangle)
    (hk : κApproxTri P P') (hP : ∀ i, ‖P i‖ ≤ 1) {θ φ ε : ℝ}  -- hP is NEW
    (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4)
    (hspan : P'.Spanning θ φ ε) : P.Spanning θ φ ε
```

**Rationale:** The blueprint (Lemma 46) requires `‖Pᵢ‖ ≤ 1` as an explicit assumption. This cannot be derived from:
- `κApproxTri` (only bounds the difference `‖P i - P' i‖ ≤ κ`)
- `Spanning` (only provides inner product lower bounds)

The definition docstring (line 14-17) explicitly notes that users must add these constraints separately.

### Changes

**Helper lemmas added:**
- `matOfVec_sub`, `matOfCovec_sub`, `norm_mapOfVec_sub_le`, `norm_mapOfCovec_sub_le`, `mapOfVec_apply` - for linearity/norm bounds on vec/covec maps
- `mapOfCovec_single` - kills `EuclideanSpace.single 0 1` argument
- `rotM_transpose_adjoint`, `rotMℚ_transpose_adjoint` - transpose equals CLM adjoint

**Proof structure:**
- Fill all 5 `hdbb` cases proving `mv.DiffBoundedBy κ`
- Fill `hva`/`hvb` using `adjoint_inner_right` + `real_inner_comm`
- Fix `mv` construction ordering to match `valA`/`valB` semantics