### PR TITLE
[CommonCenter] Fill sorry in shadows_eq lemma

### DIFF
--- a/Noperthedron/CommonCenter.lean
+++ b/Noperthedron/CommonCenter.lean
@@ -85,10 +85,10 @@ lemma shadows_eq {S : Set ℝ³} (p : MatrixPose) :
   change ((p.shift ∘ proj_xyL) ∘ p.innerRotPart) '' S =
      ((proj_xyL ∘ p.innerOffsetPart) ∘ p.innerRotPart) '' S
   rw [← proj_xy_eq_proj_xyL]
-  rw [show p.shift ∘ proj_xy = proj_xy ∘ p.innerOffsetPart from funext fun v ↦ by
-    simp only [Function.comp_apply, MatrixPose.shift, Homeomorph.coe_addRight,
-               MatrixPose.innerOffsetPart, AffineEquiv.vaddConst_apply]
-    exact proj_offset_commute p.innerOffset v]
+  have : p.shift ∘ proj_xy = proj_xy ∘ p.innerOffsetPart := funext fun v ↦ by
+    simpa [MatrixPose.shift, MatrixPose.innerOffsetPart] using
+      proj_offset_commute p.innerOffset v
+  rw [this]
 
 /--
 If a set is point symmetric and convex, then it being rupert implies

--- a/Noperthedron/CommonCenter.lean
+++ b/Noperthedron/CommonCenter.lean
@@ -85,8 +85,10 @@ lemma shadows_eq {S : Set ℝ³} (p : MatrixPose) :
   change ((p.shift ∘ proj_xyL) ∘ p.innerRotPart) '' S =
      ((proj_xyL ∘ p.innerOffsetPart) ∘ p.innerRotPart) '' S
   rw [← proj_xy_eq_proj_xyL]
-  rw [show p.shift ∘ proj_xy = proj_xy ∘ p.innerOffsetPart from funext fun v ↦
-    by simp[MatrixPose.shift]; sorry]
+  rw [show p.shift ∘ proj_xy = proj_xy ∘ p.innerOffsetPart from funext fun v ↦ by
+    simp only [Function.comp_apply, MatrixPose.shift, Homeomorph.coe_addRight,
+               MatrixPose.innerOffsetPart, AffineEquiv.vaddConst_apply]
+    exact proj_offset_commute p.innerOffset v]
 
 /--
 If a set is point symmetric and convex, then it being rupert implies


### PR DESCRIPTION
Fill the sorry in `shadows_eq` proving `p.shift ∘ proj_xy = proj_xy ∘ p.innerOffsetPart` using existing `proj_offset_commute` lemma from `Util.lean`.