### PR TITLE
[Blueprint] Add \leanok to Lemma 46 proof

### DIFF
--- a/blueprint/src/chapters/rational.tex
+++ b/blueprint/src/chapters/rational.tex
@@ -189,8 +189,9 @@ See \cite{polyhedron.without.rupert}, Lemma 44.
     Let $P_1, P_2, P_3 \in \R^3$ with $\|P_i\| \leq 1$ and $\widetilde{P}_1, \widetilde{P}_2, \widetilde{P}_3 \in \Q^3$ be their $\kappa$-rational approximations. Assume that $\widetilde{P}_1, \widetilde{P}_2, \widetilde{P}_3$ are $\epsilon$-$\kappa$-spanning for some $\theta, \phi \in \Q \cap [-4,4]$, then $P_1, P_2, P_3$ are $\epsilon$-spanning for $\theta, \phi$.
 \end{lemma}
 \begin{proof}
-See \cite{polyhedron.without.rupert}, Lemma 46.
+\leanok
 \uses{lem:A1AnB1Bn,lem:eps-spanning,corr:kappa1kappa}
+See \cite{polyhedron.without.rupert}, Lemma 46.
 \end{proof}
 
 


### PR DESCRIPTION
Add `\leanok` to the proof of `lem:ekspanningespanning` (Lemma 46), which was completed in PR #10. Also reorder `\uses` to follow standard pattern (`\leanok` → `\uses` → text).