### PR TITLE
Complete MatrixPose → Pose conversion

### DIFF
--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -2,52 +2,50 @@ import Noperthedron.MatrixPose
 import Noperthedron.Pose
 import Noperthedron.Bounding.OrthEquivRotz
 
+open Bounding Real
 open scoped Matrix
-open Real
 
-/--
-The matrix form of `rotRM θ φ α`, which is `Rz(-(π/2)) * Rz(α) * Ry(φ) * Rz(-θ)`.
--/
+/-- Matrix version of rotRM. -/
 noncomputable
 def rotRM_mat (θ φ α : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
   Rz_mat (-(π / 2)) * Rz_mat α * Ry_mat φ * Rz_mat (-θ)
 
-/--
-The matrix `rotRM_mat θ φ α` is in SO3 because it's a product of SO3 matrices.
--/
-lemma rotRM_mat_mem_SO3 (θ φ α : ℝ) :
-    rotRM_mat θ φ α ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ := by
-  unfold rotRM_mat
-  refine Submonoid.mul_mem _ (Submonoid.mul_mem _ (Submonoid.mul_mem _ ?_ ?_) ?_) ?_
-  · exact Bounding.rot3_mat_mem_SO3 2 (-(π / 2))
-  · exact Bounding.rot3_mat_mem_SO3 2 α
-  · exact Bounding.rot3_mat_mem_SO3 1 φ
-  · exact Bounding.rot3_mat_mem_SO3 2 (-θ)
+/-- rotRM_mat is in SO3. -/
+lemma rotRM_mat_mem_SO3 (θ φ α : ℝ) : rotRM_mat θ φ α ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
+  Submonoid.mul_mem _ (Submonoid.mul_mem _ (Submonoid.mul_mem _
+    (rot3_mat_mem_SO3 2 _) (rot3_mat_mem_SO3 2 _)) (rot3_mat_mem_SO3 1 _)) (rot3_mat_mem_SO3 2 _)
 
-/--
-`rotRM θ φ α` equals the continuous linear map induced by `rotRM_mat θ φ α`.
--/
+/-- rotRM equals the EuclideanLin of rotRM_mat. -/
 lemma rotRM_eq_rotRM_mat (θ φ α : ℝ) :
     rotRM θ φ α = (rotRM_mat θ φ α).toEuclideanLin.toContinuousLinearMap := by
-  unfold rotRM rotRM_mat RzL RyL
-  ext v i
+  simp only [rotRM, rotRM_mat, RzL, RyL]
+  ext v
   simp only [ContinuousLinearMap.coe_comp', Function.comp_apply,
-    LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
-  rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
+    LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, Matrix.mulVec_mulVec]
+  congr 1
+  simp only [Matrix.mul_assoc]
 
-/-- Rz matrices multiply by adding angles. -/
-lemma Rz_mat_mul (a b : ℝ) : Rz_mat a * Rz_mat b = Rz_mat (a + b) := by
-  ext i j; fin_cases i <;> fin_cases j <;> simp [Rz_mat, cos_add, sin_add] <;> ring
+/-- rotRM_mat θ φ 0 simplifies to Rz(-π/2) * Ry(φ) * Rz(-θ). -/
+lemma rotRM_mat_zero_alpha (θ φ : ℝ) : rotRM_mat θ φ 0 = Rz_mat (-(π / 2)) * Ry_mat φ * Rz_mat (-θ) := by
+  simp only [rotRM_mat]
+  rw [Rz_mat_zero, Matrix.mul_one]
 
-/-- Collapse leading Rz terms: `rotRM_mat θ φ α = Rz(α - π/2) * Ry(φ) * Rz(-θ)`. -/
-lemma rotRM_mat_eq (θ φ α : ℝ) :
-    rotRM_mat θ φ α = Rz_mat (α - π / 2) * Ry_mat φ * Rz_mat (-θ) := by
-  simp only [rotRM_mat, Rz_mat_mul, sub_eq_add_neg, add_comm]
+/-- For any SO3 matrix, there exists δ such that Rz(δ) * M has the form rotRM_mat θ φ 0. -/
+lemma exists_Rz_to_rotRM_form (M : SO3) :
+    ∃ δ θ φ, Rz_mat δ * M.val = rotRM_mat θ φ 0 := by
+  obtain ⟨α, β, γ, h_decomp⟩ := SO3_ZYZ_decomposition M.val M.property
+  use -(π / 2) - α, -γ, β
+  rw [rotRM_mat_zero_alpha, h_decomp]
+  rw [← Matrix.mul_assoc, ← Matrix.mul_assoc]
+  congr 1
+  · rw [Rz_mat_mul_Rz_mat]
+    ring_nf
+  · rw [neg_neg]
 
-noncomputable
-def Pose.matrixPoseOfPose (p : Pose) : MatrixPose where
-  innerRot := ⟨rotRM_mat p.θ₁ p.φ₁ p.α, rotRM_mat_mem_SO3 p.θ₁ p.φ₁ p.α⟩
-  outerRot := ⟨rotRM_mat p.θ₂ p.φ₂ 0, rotRM_mat_mem_SO3 p.θ₂ p.φ₂ 0⟩
+/-- Convert a Pose to a MatrixPose. -/
+noncomputable def Pose.matrixPoseOfPose (p : Pose) : MatrixPose where
+  innerRot := ⟨rotRM_mat p.θ₁ p.φ₁ p.α, rotRM_mat_mem_SO3 _ _ _⟩
+  outerRot := ⟨rotRM_mat p.θ₂ p.φ₂ 0, rotRM_mat_mem_SO3 _ _ _⟩
   innerOffset := 0
 
 theorem converted_pose_inner_shadow_eq (v : Pose) (S : Set ℝ³) :
@@ -141,29 +139,34 @@ lemma SO3_euler_ZYZ (A : Matrix (Fin 3) (Fin 3) ℝ)
     (by convert hB_fixes_ez; simp)
   exact ⟨α, β, γ, by rw [← hγ, ← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hU_det, Matrix.one_mul]⟩
 
-/--
-Given a MatrixPose with zero offset whose outer rotation is in the image of `rotRM_mat _ _ 0`,
-there exists a 5-parameter Pose that produces the same MatrixPose.
+/-- Any SO3 matrix can be written as rotRM_mat θ φ α for some θ, φ, α.
+Uses ZYZ Euler decomposition: M = Rz(a) * Ry(b) * Rz(c) = rotRM_mat (-c) b (a + π/2). -/
+lemma SO3_to_rotRM_params (M : Matrix (Fin 3) (Fin 3) ℝ)
+    (hM : M ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ θ φ α, M = rotRM_mat θ φ α := by
+  obtain ⟨a, b, c, h_decomp⟩ := SO3_ZYZ_decomposition M hM
+  use -c, b, a + π / 2
+  simp only [rotRM_mat, h_decomp, neg_neg, Rz_mat_mul_Rz_mat]
+  ring_nf
 
-Note: The assumption `h_outer` is necessary because `rotRM_mat θ φ 0 = Rz(-π/2) * Ry(φ) * Rz(-θ)`
-has only 2 DOF (the first Euler angle is fixed at -π/2), while a general SO3 matrix has 3 DOF.
--/
-theorem pose_of_matrix_pose (p : MatrixPose)
-    (h_outer : ∃ θ φ, p.outerRot.val = rotRM_mat θ φ 0) :
+/-- For a zeroOffset MatrixPose whose outer rotation is in rotRM form, we can construct
+an equivalent Pose. -/
+lemma pose_of_matrix_pose_with_outer_form (p : MatrixPose)
+    (h_outer : ∃ θ₂ φ₂, p.outerRot.val = rotRM_mat θ₂ φ₂ 0) :
     ∃ pp : Pose, pp.matrixPoseOfPose = p.zeroOffset := by
-  obtain ⟨α₁, β₁, γ₁, h_inner⟩ := SO3_euler_ZYZ p.innerRot.val p.innerRot.property
-  obtain ⟨θ₂, φ₂, h_outer⟩ := h_outer
-  let pp : Pose := { θ₁ := -γ₁, φ₁ := β₁, α := α₁ + π / 2, θ₂ := θ₂, φ₂ := φ₂ }
-  refine ⟨pp, ?_⟩
-  simp only [Pose.matrixPoseOfPose, MatrixPose.zeroOffset, pp]
-  congr 1
-  · -- innerRot: use rotRM_mat_eq to simplify
-    apply Subtype.ext
-    calc rotRM_mat (-γ₁) β₁ (α₁ + π / 2)
-        = Rz_mat α₁ * Ry_mat β₁ * Rz_mat γ₁ := by
-          simp only [rotRM_mat_eq, neg_neg]
-          ring_nf
-      _ = p.innerRot.val := h_inner.symm
-  · -- outerRot: direct from h_outer
-    apply Subtype.ext
-    exact h_outer.symm
+  obtain ⟨θ₂, φ₂, h_out⟩ := h_outer
+  obtain ⟨θ₁, φ₁, α, h_in⟩ := SO3_to_rotRM_params p.innerRot.val p.innerRot.property
+  use { θ₁ := θ₁, θ₂ := θ₂, φ₁ := φ₁, φ₂ := φ₂, α := α }
+  simp only [Pose.matrixPoseOfPose, MatrixPose.zeroOffset]
+  congr 1 <;> apply Subtype.ext <;> simp [h_in.symm, h_out.symm]
+
+/-- For any MatrixPose p, after rotating by the right δ, there exists a Pose
+that equals the rotated zeroOffset. -/
+theorem pose_of_matrix_pose (p : MatrixPose) :
+    ∃ δ : ℝ, ∃ pp : Pose, pp.matrixPoseOfPose = (p.zeroOffset.rotateBy δ) := by
+  obtain ⟨δ, θ, φ, h_form⟩ := exists_Rz_to_rotRM_form p.outerRot
+  use δ
+  have h_outer : ∃ θ₂ φ₂, (p.zeroOffset.rotateBy δ).outerRot.val = rotRM_mat θ₂ φ₂ 0 :=
+    ⟨θ, φ, by simp only [MatrixPose.rotateBy, MatrixPose.zeroOffset]; exact h_form⟩
+  simpa [MatrixPose.zeroOffset, MatrixPose.rotateBy] using
+    pose_of_matrix_pose_with_outer_form (p.zeroOffset.rotateBy δ) h_outer

--- a/Noperthedron/ConvertPose.lean
+++ b/Noperthedron/ConvertPose.lean
@@ -10,20 +10,28 @@ noncomputable
 def rotRM_mat (θ φ α : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
   Rz_mat (-(π / 2)) * Rz_mat α * Ry_mat φ * Rz_mat (-θ)
 
-/-- rotRM_mat is in SO3. -/
-lemma rotRM_mat_mem_SO3 (θ φ α : ℝ) : rotRM_mat θ φ α ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
-  Submonoid.mul_mem _ (Submonoid.mul_mem _ (Submonoid.mul_mem _
-    (rot3_mat_mem_SO3 2 _) (rot3_mat_mem_SO3 2 _)) (rot3_mat_mem_SO3 1 _)) (rot3_mat_mem_SO3 2 _)
+/--
+The matrix `rotRM_mat θ φ α` is in SO3 because it's a product of SO3 matrices.
+-/
+lemma rotRM_mat_mem_SO3 (θ φ α : ℝ) :
+    rotRM_mat θ φ α ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ := by
+  unfold rotRM_mat
+  refine Submonoid.mul_mem _ (Submonoid.mul_mem _ (Submonoid.mul_mem _ ?_ ?_) ?_) ?_
+  · exact rot3_mat_mem_SO3 2 (-(π / 2))
+  · exact rot3_mat_mem_SO3 2 α
+  · exact rot3_mat_mem_SO3 1 φ
+  · exact rot3_mat_mem_SO3 2 (-θ)
 
-/-- rotRM equals the EuclideanLin of rotRM_mat. -/
+/--
+`rotRM θ φ α` equals the continuous linear map induced by `rotRM_mat θ φ α`.
+-/
 lemma rotRM_eq_rotRM_mat (θ φ α : ℝ) :
     rotRM θ φ α = (rotRM_mat θ φ α).toEuclideanLin.toContinuousLinearMap := by
-  simp only [rotRM, rotRM_mat, RzL, RyL]
-  ext v
+  unfold rotRM rotRM_mat RzL RyL
+  ext v i
   simp only [ContinuousLinearMap.coe_comp', Function.comp_apply,
-    LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, Matrix.mulVec_mulVec]
-  congr 1
-  simp only [Matrix.mul_assoc]
+    LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+  rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
 
 /-- rotRM_mat θ φ 0 simplifies to Rz(-π/2) * Ry(φ) * Rz(-θ). -/
 lemma rotRM_mat_zero_alpha (θ φ : ℝ) : rotRM_mat θ φ 0 = Rz_mat (-(π / 2)) * Ry_mat φ * Rz_mat (-θ) := by

--- a/Noperthedron/Final.lean
+++ b/Noperthedron/Final.lean
@@ -32,17 +32,12 @@ There is no purely rotational pose that makes the Noperthedron have the Rupert p
 theorem no_nopert_rot_pose : ¬ ∃ p : MatrixPose, RupertPose p.zeroOffset nopert.hull := by
   intro r
   obtain ⟨p, r⟩ := r
-  -- TODO: Need to prove that p.outerRot is in the image of rotRM_mat _ _ 0.
-  -- This requires either:
-  -- (1) Showing RupertPose implies the outer rotation has this form, or
-  -- (2) Proving RupertPose is invariant under left-multiplying rotations by Rz(δ),
-  --     then picking δ so the first Euler angle becomes -π/2.
-  have h_outer : ∃ θ φ, p.outerRot.val = rotRM_mat θ φ 0 := by sorry
-  let ⟨v, e⟩ := pose_of_matrix_pose p h_outer
-  refine no_nopert_pose ⟨v, ?_⟩
-  apply (converted_pose_rupert_iff v nopert.hull).mpr
-  rw [e]
-  exact r
+  -- pose_of_matrix_pose gives us δ and a Pose v such that v.matrixPoseOfPose = p.zeroOffset.rotateBy δ
+  obtain ⟨δ, v, e⟩ := pose_of_matrix_pose p
+  -- TODO: Need RupertPose_rotateBy_iff to show RupertPose (p.zeroOffset.rotateBy δ) ↔ RupertPose p.zeroOffset
+  -- This is proved in the Rz-invariance PR.
+  have h_rotateBy : RupertPose (p.zeroOffset.rotateBy δ) nopert.hull := by sorry
+  exact no_nopert_pose ⟨v, (converted_pose_rupert_iff v nopert.hull).mpr (e ▸ h_rotateBy)⟩
 
 /--
 There is no pose that makes the Noperthedron have the Rupert property

--- a/Noperthedron/MatrixPose.lean
+++ b/Noperthedron/MatrixPose.lean
@@ -2,6 +2,7 @@ import Noperthedron.Basic
 import Noperthedron.Rupert.Basic
 import Noperthedron.PoseClasses
 import Noperthedron.Util
+import Noperthedron.Bounding.OrthEquivRotz
 
 open scoped Matrix
 
@@ -17,6 +18,16 @@ def IsRot (p : MatrixPose) : Prop :=
 
 def zeroOffset (p : MatrixPose) : MatrixPose :=
   { p with innerOffset := 0 }
+
+/-- Helper: Rz_mat is in SO3 -/
+lemma Rz_mat_mem_SO3 (δ : ℝ) : Rz_mat δ ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
+  Bounding.rot3_mat_mem_SO3 2 δ
+
+/-- Rotate a MatrixPose by applying Rz(δ) to both rotations and the offset. -/
+noncomputable def rotateBy (p : MatrixPose) (δ : ℝ) : MatrixPose where
+  innerRot := ⟨Rz_mat δ * p.innerRot.val, Submonoid.mul_mem _ (Rz_mat_mem_SO3 δ) p.innerRot.property⟩
+  outerRot := ⟨Rz_mat δ * p.outerRot.val, Submonoid.mul_mem _ (Rz_mat_mem_SO3 δ) p.outerRot.property⟩
+  innerOffset := rotR δ p.innerOffset
 
 noncomputable def innerOffsetPart (p : MatrixPose) : ℝ³ → ℝ³ :=
   AffineEquiv.vaddConst ℝ (inject_xy p.innerOffset)


### PR DESCRIPTION
Closes #7

## Summary

Adds infrastructure to convert any `MatrixPose` (6 DOF) to a 5-parameter `Pose` by finding the rotation angle δ that puts the outer rotation into `rotRM_mat θ φ 0` form.

## Merge Order

**This PR should merge before #11 (Rz-invariance).** Both PRs add similar infrastructure to OrthEquivRotz.lean; merging this first establishes the shared foundation. PR #11 will need to rebase after this merges.

PR #15 (golfing) can merge independently - it handles all proof golfing for ConvertPose.lean.

## Key Changes

### OrthEquivRotz.lean
- `SO3_ZYZ_decomposition`: Any SO3 matrix = Rz(α) * Ry(β) * Rz(γ)
- Various rotation helper lemmas (Rz_mat_mul_Rz_mat, transposes, etc.)

### ConvertPose.lean
- `rotRM_mat` definition and `rotRM_eq_rotRM_mat`
- `rotRM_mat_zero_alpha`, `exists_Rz_to_rotRM_form`
- `SO3_to_rotRM_params`: Any SO3 matrix is rotRM_mat form
- `pose_of_matrix_pose`: Returns (δ, Pose) where Pose equals rotated MatrixPose
  - No longer requires `h_outer` constraint
- **Note:** Proof golfing is handled by PR #15

### MatrixPose.lean
- `rotateBy`: Rotate a MatrixPose by Rz(δ) on both rotations and offset

### Final.lean
- Updates `no_nopert_rot_pose` to use new `pose_of_matrix_pose`
- **Has sorry** for `RupertPose_rotateBy_iff` (filled when #11 merges)

## How pose_of_matrix_pose changed

Old signature (required sorry for h_outer):
```lean
theorem pose_of_matrix_pose (p : MatrixPose)
    (h_outer : ∃ θ φ, p.outerRot.val = rotRM_mat θ φ 0) :
    ∃ pp : Pose, pp.matrixPoseOfPose = p.zeroOffset
```

New signature (no constraint, returns rotation angle):
```lean
theorem pose_of_matrix_pose (p : MatrixPose) :
    ∃ δ : ℝ, ∃ pp : Pose, pp.matrixPoseOfPose = (p.zeroOffset.rotateBy δ)
```

The sorry moved from `h_outer` to `RupertPose_rotateBy_iff` in `no_nopert_rot_pose`.
