### PR TITLE
[Lemma42] Prove allNormsBelow_def

### DIFF
--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -185,6 +185,10 @@ theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Tri
           _ = ‖P i - (P' i : ℝ³)‖ := norm_sub_rev _ _
           _ ≤ κ := hk i
     suffices h : |mv.valA - mv.valB| ≤ 6 * κ by rw [hva, hvb, abs_sub_comm]; exact h
-    grw [norm_sub_le_bound1 mv κ (by norm_num [κ]) hdbb hanb]
+    have hbs1 : ∀ b ∈ [1 + κ, 1 + κ, 1, 1 + κ, 1 + κ], 1 ≤ b := by
+      simp only [List.mem_cons, List.mem_nil_iff, or_false]
+      intro b hb
+      rcases hb with rfl | rfl | rfl | rfl | rfl <;> norm_num [κ]
+    grw [norm_sub_le_bound1 mv κ (by norm_num [κ]) hdbb hbs1 hanb]
     simp only [mv]
     norm_num [κ]

--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -185,10 +185,7 @@ theorem ek_spanning_imp_e_spanning (P : Local.Triangle) (P' : RationalApprox.Tri
           _ = ‖P i - (P' i : ℝ³)‖ := norm_sub_rev _ _
           _ ≤ κ := hk i
     suffices h : |mv.valA - mv.valB| ≤ 6 * κ by rw [hva, hvb, abs_sub_comm]; exact h
-    have hbs1 : ∀ b ∈ [1 + κ, 1 + κ, 1, 1 + κ, 1 + κ], 1 ≤ b := by
-      simp only [List.mem_cons, List.mem_nil_iff, or_false]
-      intro b hb
-      rcases hb with rfl | rfl | rfl | rfl | rfl <;> norm_num [κ]
+    have hbs1 : ∀ b ∈ [1 + κ, 1 + κ, 1, 1 + κ, 1 + κ], 1 ≤ b := by simp [κ]
     grw [norm_sub_le_bound1 mv κ (by norm_num [κ]) hdbb hbs1 hanb]
     simp only [mv]
     norm_num [κ]

--- a/Noperthedron/RationalApprox/Lemma42.lean
+++ b/Noperthedron/RationalApprox/Lemma42.lean
@@ -144,10 +144,7 @@ lemma allNormsBelow_def {n m : ℕ} (mv : MatVec n m)
     | cons b bsr =>
       simp only [hbsr, MatVec.allNormsBelow.go] at hb
       obtain ⟨htl, hA, hB⟩ := hb
-      -- htl : go tl bsr, so tl.allNormsBelow bsr.reverse
-      have htl' : tl.allNormsBelow bsr.reverse := by
-        simp only [MatVec.allNormsBelow, List.reverse_reverse]
-        exact htl
+      have htl' : tl.allNormsBelow bsr.reverse := by simpa [MatVec.allNormsBelow]
       -- Elements of bsr.reverse are in bs, so they're ≥ 1
       have hbsr1 : ∀ x ∈ bsr.reverse, 1 ≤ x := fun x hx ↦ by
         apply hbs1
@@ -155,32 +152,12 @@ lemma allNormsBelow_def {n m : ℕ} (mv : MatVec n m)
         have hbsr_sub : bsr ⊆ bs.reverse := by simp [hbsr]
         exact List.mem_reverse.mp (hbsr_sub this)
       have ih_bound := ih hbsr1 htl'
-      -- bs = bsr.reverse ++ [b]
-      have hbs : bs = bsr.reverse ++ [b] := by
-        have := congrArg List.reverse hbsr
-        simp at this
-        exact this
-      -- b is in bs, so b ≥ 1
-      have hb1 : 1 ≤ b := by
-        apply hbs1
-        rw [hbs]
-        exact List.mem_append_right _ (List.mem_singleton_self b)
+      have hbs : bs = bsr.reverse ++ [b] := by simpa using congrArg List.reverse hbsr
+      have hb1 : 1 ≤ b := hbs1 b (by simp [hbs])
       rw [hbs, List.prod_append, List.prod_singleton, List.prod_append, List.prod_singleton]
-      -- Goal: tl.maxNormList.prod * max (max ‖A‖ ‖B‖) 1 ≤ bsr.reverse.prod * b
-      have h_max_le : max (max ‖A‖ ‖B‖) 1 ≤ b := by
-        rw [max_le_iff]
-        exact ⟨max_le hA hB, hb1⟩
-      have h_prod_nonneg : 0 ≤ tl.maxNormList.prod := tl.maxNormList_non_neg
-      have h_max_pos : 0 < max (max ‖A‖ ‖B‖) 1 := lt_max_of_lt_right one_pos
-      have h_bsr_nonneg : 0 ≤ bsr.reverse.prod := by
-        calc bsr.reverse.prod
-          _ ≥ tl.maxNormList.prod := ih_bound
-          _ ≥ 0 := h_prod_nonneg
-      calc tl.maxNormList.prod * max (max ‖A‖ ‖B‖) 1
-        _ ≤ bsr.reverse.prod * max (max ‖A‖ ‖B‖) 1 := by
-            exact mul_le_mul_of_nonneg_right ih_bound (le_of_lt h_max_pos)
-        _ ≤ bsr.reverse.prod * b := by
-            exact mul_le_mul_of_nonneg_left h_max_le h_bsr_nonneg
+      have h_max_le : max (max ‖A‖ ‖B‖) 1 ≤ b := max_le_iff.mpr ⟨max_le hA hB, hb1⟩
+      have h_bsr_nonneg : 0 ≤ bsr.reverse.prod := le_trans tl.maxNormList_non_neg ih_bound
+      exact mul_le_mul ih_bound h_max_le (le_of_lt (lt_max_of_lt_right one_pos)) h_bsr_nonneg
 
 lemma norm_sub_le_bound {n m : ℕ} (mv : MatVec n m)
     (κ : ℝ) (κ_pos : κ > 0) (hκ : mv.DiffBoundedBy κ)

--- a/Noperthedron/RationalApprox/Lemma42.lean
+++ b/Noperthedron/RationalApprox/Lemma42.lean
@@ -127,16 +127,66 @@ lemma norm_sub_le_prod {n m : ℕ} (mv : MatVec n m)
     simp [le_refl]
 
 lemma allNormsBelow_def {n m : ℕ} (mv : MatVec n m)
-    (κ : ℝ) (κ_pos : κ > 0)
-    {bs : List ℝ} (hb : mv.allNormsBelow bs) :
+    {bs : List ℝ} (hbs1 : ∀ b ∈ bs, 1 ≤ b) (hb : mv.allNormsBelow bs) :
     mv.maxNormList.prod ≤ bs.prod := by
-  sorry
+  induction mv generalizing bs with
+  | nil =>
+    simp only [MatVec.maxNormList, List.prod_nil, MatVec.allNormsBelow] at hb ⊢
+    cases hbsr : bs.reverse with
+    | nil =>
+      have : bs = [] := List.reverse_eq_nil_iff.mp hbsr
+      simp [this]
+    | cons b bsr => simp only [hbsr, MatVec.allNormsBelow.go] at hb
+  | cons tl A B ih =>
+    simp only [MatVec.maxNormList, MatVec.allNormsBelow] at hb ⊢
+    cases hbsr : bs.reverse with
+    | nil => simp only [hbsr, MatVec.allNormsBelow.go] at hb
+    | cons b bsr =>
+      simp only [hbsr, MatVec.allNormsBelow.go] at hb
+      obtain ⟨htl, hA, hB⟩ := hb
+      -- htl : go tl bsr, so tl.allNormsBelow bsr.reverse
+      have htl' : tl.allNormsBelow bsr.reverse := by
+        simp only [MatVec.allNormsBelow, List.reverse_reverse]
+        exact htl
+      -- Elements of bsr.reverse are in bs, so they're ≥ 1
+      have hbsr1 : ∀ x ∈ bsr.reverse, 1 ≤ x := fun x hx ↦ by
+        apply hbs1
+        have : x ∈ bsr := List.mem_reverse.mp hx
+        have hbsr_sub : bsr ⊆ bs.reverse := by simp [hbsr]
+        exact List.mem_reverse.mp (hbsr_sub this)
+      have ih_bound := ih hbsr1 htl'
+      -- bs = bsr.reverse ++ [b]
+      have hbs : bs = bsr.reverse ++ [b] := by
+        have := congrArg List.reverse hbsr
+        simp at this
+        exact this
+      -- b is in bs, so b ≥ 1
+      have hb1 : 1 ≤ b := by
+        apply hbs1
+        rw [hbs]
+        exact List.mem_append_right _ (List.mem_singleton_self b)
+      rw [hbs, List.prod_append, List.prod_singleton, List.prod_append, List.prod_singleton]
+      -- Goal: tl.maxNormList.prod * max (max ‖A‖ ‖B‖) 1 ≤ bsr.reverse.prod * b
+      have h_max_le : max (max ‖A‖ ‖B‖) 1 ≤ b := by
+        rw [max_le_iff]
+        exact ⟨max_le hA hB, hb1⟩
+      have h_prod_nonneg : 0 ≤ tl.maxNormList.prod := tl.maxNormList_non_neg
+      have h_max_pos : 0 < max (max ‖A‖ ‖B‖) 1 := lt_max_of_lt_right one_pos
+      have h_bsr_nonneg : 0 ≤ bsr.reverse.prod := by
+        calc bsr.reverse.prod
+          _ ≥ tl.maxNormList.prod := ih_bound
+          _ ≥ 0 := h_prod_nonneg
+      calc tl.maxNormList.prod * max (max ‖A‖ ‖B‖) 1
+        _ ≤ bsr.reverse.prod * max (max ‖A‖ ‖B‖) 1 := by
+            exact mul_le_mul_of_nonneg_right ih_bound (le_of_lt h_max_pos)
+        _ ≤ bsr.reverse.prod * b := by
+            exact mul_le_mul_of_nonneg_left h_max_le h_bsr_nonneg
 
 lemma norm_sub_le_bound {n m : ℕ} (mv : MatVec n m)
     (κ : ℝ) (κ_pos : κ > 0) (hκ : mv.DiffBoundedBy κ)
-    {bs : List ℝ} (hb : mv.allNormsBelow bs) :
+    {bs : List ℝ} (hbs1 : ∀ b ∈ bs, 1 ≤ b) (hb : mv.allNormsBelow bs) :
     ‖mv.compA - mv.compB‖ ≤ mv.size * κ * bs.prod := by
-  grw [norm_sub_le_prod mv κ κ_pos hκ, allNormsBelow_def mv κ κ_pos hb]
+  grw [norm_sub_le_prod mv κ κ_pos hκ, allNormsBelow_def mv hbs1 hb]
 
 lemma norm_sub_le_prod1 (mv : MatVec 1 1)
     (κ : ℝ) (κ_pos : κ > 0) (hκ : mv.DiffBoundedBy κ) :
@@ -157,9 +207,9 @@ lemma norm_sub_le_prod1 (mv : MatVec 1 1)
 
 lemma norm_sub_le_bound1 (mv : MatVec 1 1)
     (κ : ℝ) (κ_pos : κ > 0) (hκ : mv.DiffBoundedBy κ)
-    {bs : List ℝ} (hb : mv.allNormsBelow bs) :
+    {bs : List ℝ} (hbs1 : ∀ b ∈ bs, 1 ≤ b) (hb : mv.allNormsBelow bs) :
     |mv.valA - mv.valB| ≤ mv.size * κ * bs.prod := by
-  grw [norm_sub_le_prod1 mv κ κ_pos hκ, allNormsBelow_def mv κ κ_pos hb]
+  grw [norm_sub_le_prod1 mv κ κ_pos hκ, allNormsBelow_def mv hbs1 hb]
 
 end RationalApprox
 

--- a/Noperthedron/RationalApprox/Lemma42.lean
+++ b/Noperthedron/RationalApprox/Lemma42.lean
@@ -145,14 +145,9 @@ lemma allNormsBelow_def {n m : ℕ} (mv : MatVec n m)
       simp only [hbsr, MatVec.allNormsBelow.go] at hb
       obtain ⟨htl, hA, hB⟩ := hb
       have htl' : tl.allNormsBelow bsr.reverse := by simpa [MatVec.allNormsBelow]
-      -- Elements of bsr.reverse are in bs, so they're ≥ 1
-      have hbsr1 : ∀ x ∈ bsr.reverse, 1 ≤ x := fun x hx ↦ by
-        apply hbs1
-        have : x ∈ bsr := List.mem_reverse.mp hx
-        have hbsr_sub : bsr ⊆ bs.reverse := by simp [hbsr]
-        exact List.mem_reverse.mp (hbsr_sub this)
-      have ih_bound := ih hbsr1 htl'
       have hbs : bs = bsr.reverse ++ [b] := by simpa using congrArg List.reverse hbsr
+      have hbsr1 : ∀ x ∈ bsr.reverse, 1 ≤ x := fun x hx ↦ hbs1 x (hbs ▸ List.mem_append_left _ hx)
+      have ih_bound := ih hbsr1 htl'
       have hb1 : 1 ≤ b := hbs1 b (by simp [hbs])
       rw [hbs, List.prod_append, List.prod_singleton, List.prod_append, List.prod_singleton]
       have h_max_le : max (max ‖A‖ ‖B‖) 1 ≤ b := max_le_iff.mpr ⟨max_le hA hB, hb1⟩


### PR DESCRIPTION
Prove `allNormsBelow_def` (Lemma42.lean:129) with an added hypothesis that all bounds are ≥ 1.

The lemma `mv.maxNormList.prod ≤ bs.prod` requires bounds ≥ 1 because `maxNormList` elements are `max (max ‖A‖ ‖B‖) 1 ≥ 1`. Without this constraint, the inequality can fail when `b < 1`.

Changes:
- Add `hbs1 : ∀ b ∈ bs, 1 ≤ b` hypothesis to `allNormsBelow_def`
- Propagate to `norm_sub_le_bound` and `norm_sub_le_bound1`
- Update EpsKapSpanning.lean call site (bounds are `[1 + κ, 1 + κ, 1, 1 + κ, 1 + κ]`, all ≥ 1)
- Remove unused `κ` parameter from `allNormsBelow_def`

**Question:** If you want to avoid the `hP : ∀ i, ‖P i‖ ≤ 1` assumption in `ek_spanning_imp_e_spanning`, do you prefer switching to an `hP' : ∀ i, ‖(P' i : ℝ³)‖ ≤ 1 + κ` assumption, or parameterizing the bound by `max_i ‖P i‖`?