### PR TITLE
Add rotation partial derivative infrastructure

### DIFF
--- a/Noperthedron/Basic.lean
+++ b/Noperthedron/Basic.lean
@@ -259,6 +259,28 @@ def rotMφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
     !![0, 0, 0; cos θ * sin φ, sin θ * sin φ, cos φ]
   A.toEuclideanLin.toContinuousLinearMap
 
+-- Second partial derivatives of rotM
+-- ∂²rotM/∂θ² (derivative of rotMθ w.r.t. θ)
+noncomputable
+def rotMθθ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+  let A : Matrix (Fin 2) (Fin 3) ℝ :=
+    !![sin θ, -cos θ, 0; cos θ * cos φ, sin θ * cos φ, 0]
+  A.toEuclideanLin.toContinuousLinearMap
+
+-- ∂²rotM/∂θ∂φ (derivative of rotMθ w.r.t. φ, or rotMφ w.r.t. θ)
+noncomputable
+def rotMθφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+  let A : Matrix (Fin 2) (Fin 3) ℝ :=
+    !![0, 0, 0; -sin θ * sin φ, cos θ * sin φ, 0]
+  A.toEuclideanLin.toContinuousLinearMap
+
+-- ∂²rotM/∂φ² (derivative of rotMφ w.r.t. φ)
+noncomputable
+def rotMφφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+  let A : Matrix (Fin 2) (Fin 3) ℝ :=
+    !![0, 0, 0; cos θ * cos φ, sin θ * cos φ, -sin φ]
+  A.toEuclideanLin.toContinuousLinearMap
+
 theorem sin_neg_pi_div_two : Real.sin (-(π / 2)) = -1 := by
   simp only [Real.sin_neg, Real.sin_pi_div_two]
 

--- a/Noperthedron/Basic.lean
+++ b/Noperthedron/Basic.lean
@@ -247,39 +247,49 @@ def rotM (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
 
 -- Partial derivative of rotM with respect to θ
 noncomputable
+def rotMθ_mat (θ : ℝ) (φ : ℝ) : Matrix (Fin 2) (Fin 3) ℝ :=
+  !![-cos θ, -sin θ, 0; sin θ * cos φ, -cos θ * cos φ, 0]
+
+noncomputable
 def rotMθ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![-cos θ, -sin θ, 0; sin θ * cos φ, -cos θ * cos φ, 0]
-  A.toEuclideanLin.toContinuousLinearMap
+  (rotMθ_mat θ φ).toEuclideanLin.toContinuousLinearMap
 
 -- Partial derivative of rotM with respect to φ
 noncomputable
+def rotMφ_mat (θ : ℝ) (φ : ℝ) : Matrix (Fin 2) (Fin 3) ℝ :=
+  !![0, 0, 0; cos θ * sin φ, sin θ * sin φ, cos φ]
+
+noncomputable
 def rotMφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![0, 0, 0; cos θ * sin φ, sin θ * sin φ, cos φ]
-  A.toEuclideanLin.toContinuousLinearMap
+  (rotMφ_mat θ φ).toEuclideanLin.toContinuousLinearMap
 
 -- Second partial derivatives of rotM
 -- ∂²rotM/∂θ² (derivative of rotMθ w.r.t. θ)
 noncomputable
+def rotMθθ_mat (θ : ℝ) (φ : ℝ) : Matrix (Fin 2) (Fin 3) ℝ :=
+  !![sin θ, -cos θ, 0; cos θ * cos φ, sin θ * cos φ, 0]
+
+noncomputable
 def rotMθθ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![sin θ, -cos θ, 0; cos θ * cos φ, sin θ * cos φ, 0]
-  A.toEuclideanLin.toContinuousLinearMap
+  (rotMθθ_mat θ φ).toEuclideanLin.toContinuousLinearMap
 
 -- ∂²rotM/∂θ∂φ (derivative of rotMθ w.r.t. φ, or rotMφ w.r.t. θ)
 noncomputable
+def rotMθφ_mat (θ : ℝ) (φ : ℝ) : Matrix (Fin 2) (Fin 3) ℝ :=
+  !![0, 0, 0; -sin θ * sin φ, cos θ * sin φ, 0]
+
+noncomputable
 def rotMθφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![0, 0, 0; -sin θ * sin φ, cos θ * sin φ, 0]
-  A.toEuclideanLin.toContinuousLinearMap
+  (rotMθφ_mat θ φ).toEuclideanLin.toContinuousLinearMap
 
 -- ∂²rotM/∂φ² (derivative of rotMφ w.r.t. φ)
 noncomputable
+def rotMφφ_mat (θ : ℝ) (φ : ℝ) : Matrix (Fin 2) (Fin 3) ℝ :=
+  !![0, 0, 0; cos θ * cos φ, sin θ * cos φ, -sin φ]
+
+noncomputable
 def rotMφφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![0, 0, 0; cos θ * cos φ, sin θ * cos φ, -sin φ]
-  A.toEuclideanLin.toContinuousLinearMap
+  (rotMφφ_mat θ φ).toEuclideanLin.toContinuousLinearMap
 
 theorem sin_neg_pi_div_two : Real.sin (-(π / 2)) = -1 := by
   simp only [Real.sin_neg, Real.sin_pi_div_two]

--- a/Noperthedron/Bounding/OpNorm.lean
+++ b/Noperthedron/Bounding/OpNorm.lean
@@ -57,11 +57,8 @@ theorem rotMθ_norm_le_one (θ φ : ℝ) : ‖rotMθ θ φ‖ ≤ 1 := by
        (Real.sin θ * Real.cos φ * v 0 - Real.cos θ * Real.cos φ * v 1) ^ 2 ≤
       v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
     -- Row 0 has norm 1 (cos² + sin² = 1), row 1 has norm |cos φ| ≤ 1
-    have h₁ := sq_nonneg (Real.sin θ * v 0 - Real.cos θ * v 1)
-    have h₂ := sq_nonneg (v 2)
-    have h₃ := Real.sin_sq_add_cos_sq θ
-    have h₄ := Real.cos_sq_le_one φ
-    nlinarith
+    nlinarith [sq_nonneg (Real.sin θ * v 0 - Real.cos θ * v 1), sq_nonneg (v 2),
+      Real.sin_sq_add_cos_sq θ, Real.cos_sq_le_one φ]
   simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
     Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, one_mul]
@@ -125,11 +122,8 @@ theorem rotMθθ_norm_le_one (θ φ : ℝ) : ‖rotMθθ θ φ‖ ≤ 1 := by
       v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
     -- Row 0: [sin θ, -cos θ, 0], norm = 1
     -- Row 1: [cos θ * cos φ, sin θ * cos φ, 0], norm = |cos φ| ≤ 1
-    have h₁ := sq_nonneg (Real.cos θ * v 0 + Real.sin θ * v 1)
-    have h₂ := sq_nonneg (v 2)
-    have h₃ := Real.sin_sq_add_cos_sq θ
-    have h₄ := Real.cos_sq_le_one φ
-    nlinarith
+    nlinarith [sq_nonneg (Real.cos θ * v 0 + Real.sin θ * v 1), sq_nonneg (v 2),
+      Real.sin_sq_add_cos_sq θ, Real.cos_sq_le_one φ]
   simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
     Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, one_mul]
@@ -364,12 +358,9 @@ theorem rotM_norm_one (θ φ : ℝ) : ‖rotM θ φ‖ = 1 := by
         (-Real.sin θ * v 0 + Real.cos θ * v 1) ^ 2 +
          (-Real.cos θ * Real.cos φ * v 0 - Real.sin θ * Real.cos φ * v 1 + Real.sin φ * v 2) ^ 2 ≤
         v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
-      have h₁ := sq_nonneg (Real.sin θ * v 1 + Real.cos θ * v 0)
-      have h₂ := sq_nonneg (Real.sin θ * v 1 + Real.cos θ * v 0)
-      have h₃ := sq_nonneg (Real.sin φ * (Real.cos θ * v 0 + Real.sin θ * v 1) + Real.cos φ * v 2)
-      have h₄ := Real.sin_sq_add_cos_sq θ
-      have h₅ := Real.sin_sq_add_cos_sq φ
-      nlinarith
+      nlinarith [sq_nonneg (Real.sin θ * v 1 + Real.cos θ * v 0),
+        sq_nonneg (Real.sin φ * (Real.cos θ * v 0 + Real.sin θ * v 1) + Real.cos φ * v 2),
+        Real.sin_sq_add_cos_sq θ, Real.sin_sq_add_cos_sq φ]
     simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
       Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
       Fin.succ_one_eq_two, one_mul]

--- a/Noperthedron/Bounding/OpNorm.lean
+++ b/Noperthedron/Bounding/OpNorm.lean
@@ -392,8 +392,6 @@ theorem lemma9 {d : Fin 3} (α : ℝ) : ‖rot3 d α‖ = 1 := by
   · exact Rz_norm_one α
 
 theorem reduceL_norm : ‖reduceL‖ = 1 := by
-  have h₁ : reduceL = rotM 0 0 := by simp [rotM, reduceL, rotM_mat]
-  rw [h₁]
-  exact Bounding.rotM_norm_one 0 0
+  simpa [rotM, reduceL, rotM_mat] using Bounding.rotM_norm_one 0 0
 
 end Bounding

--- a/Noperthedron/Bounding/OpNorm.lean
+++ b/Noperthedron/Bounding/OpNorm.lean
@@ -35,6 +35,200 @@ theorem rotR_preserves_norm (α : ℝ) :
 theorem rotR_norm_one (α : ℝ) : ‖rotR α‖ = 1 :=
   norm_one_of_preserves_norm (rotR_preserves_norm α)
 
+theorem rotR'_preserves_norm (α : ℝ) :
+    ∀ (v : E 2), ‖rotR' α v‖ = ‖v‖ := by
+  intro v
+  have heq : rotR' α v = rotR (α + Real.pi/2) v := by
+    simp only [rotR', rotR'_mat, rotR, rotR_mat]
+    simp only [LinearMap.coe_toContinuousLinearMap']
+    ext i
+    fin_cases i <;> simp [Matrix.vecHead, Matrix.vecTail, Real.sin_add_pi_div_two, Real.cos_add_pi_div_two]
+  rw [heq]
+  exact rotR_preserves_norm (α + Real.pi/2) v
+
+theorem rotR'_norm_one (α : ℝ) : ‖rotR' α‖ = 1 :=
+  norm_one_of_preserves_norm (rotR'_preserves_norm α)
+
+theorem rotMθ_norm_le_one (θ φ : ℝ) : ‖rotMθ θ φ‖ ≤ 1 := by
+  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one ?_
+  intro v
+  have h_expand :
+      (-Real.cos θ * v 0 - Real.sin θ * v 1) ^ 2 +
+       (Real.sin θ * Real.cos φ * v 0 - Real.cos θ * Real.cos φ * v 1) ^ 2 ≤
+      v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
+    -- Row 0 has norm 1 (cos² + sin² = 1), row 1 has norm |cos φ| ≤ 1
+    have h₁ := sq_nonneg (Real.sin θ * v 0 - Real.cos θ * v 1)
+    have h₂ := sq_nonneg (v 2)
+    have h₃ := Real.sin_sq_add_cos_sq θ
+    have h₄ := Real.cos_sq_le_one φ
+    nlinarith
+  simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
+    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
+    Fin.succ_one_eq_two, one_mul]
+  convert Real.sqrt_le_sqrt h_expand using 1
+  · simp only [rotMθ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+      LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
+      WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+      WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
+      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
+      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
+      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.cons_val_fin_one, neg_mul]
+    ring_nf!
+  · ring_nf
+
+theorem rotMφ_norm_le_one (θ φ : ℝ) : ‖rotMφ θ φ‖ ≤ 1 := by
+  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one ?_
+  intro v
+  have h_expand :
+      0 ^ 2 +
+       (Real.cos θ * Real.sin φ * v 0 + Real.sin θ * Real.sin φ * v 1 + Real.cos φ * v 2) ^ 2 ≤
+      v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
+    -- Row 1 of rotMφ is [cos θ sin φ, sin θ sin φ, cos φ], a unit vector
+    -- Cauchy-Schwarz via orthogonal decomposition
+    set c := Real.cos θ; set s := Real.sin θ
+    set cφ := Real.cos φ; set sφ := Real.sin φ
+    set u := c * v 0 + s * v 1
+    set w := s * v 0 - c * v 1
+    have h₁ : c^2 + s^2 = 1 := by simp only [c, s]; linarith [Real.sin_sq_add_cos_sq θ]
+    have h₂ : sφ^2 + cφ^2 = 1 := Real.sin_sq_add_cos_sq φ
+    have huw : v 0 ^ 2 + v 1 ^ 2 = u^2 + w^2 :=
+      by nlinarith [sq_nonneg c, sq_nonneg s, sq_nonneg (v 0), sq_nonneg (v 1)]
+    have heq : c * sφ * v 0 + s * sφ * v 1 + cφ * v 2 = sφ * u + cφ * v 2 := by ring
+    have hrot : u^2 + v 2 ^2 = (sφ * u + cφ * v 2)^2 + (cφ * u - sφ * v 2)^2 :=
+      by nlinarith [sq_nonneg cφ, sq_nonneg sφ, sq_nonneg u, sq_nonneg (v 2)]
+    have hw : 0 ≤ w^2 := sq_nonneg w
+    have hcomp : 0 ≤ (cφ * u - sφ * v 2)^2 := sq_nonneg _
+    simp only [heq, pow_two] at *
+    linarith
+  simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
+    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
+    Fin.succ_one_eq_two, one_mul]
+  convert Real.sqrt_le_sqrt h_expand using 1
+  · simp only [rotMφ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+      LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
+      WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+      WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
+      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
+      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
+      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.cons_val_fin_one]
+    ring_nf!
+  · ring_nf
+
+-- Operator norm bounds for second derivative matrices
+theorem rotMθθ_norm_le_one (θ φ : ℝ) : ‖rotMθθ θ φ‖ ≤ 1 := by
+  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one ?_
+  intro v
+  have h_expand :
+      (Real.sin θ * v 0 - Real.cos θ * v 1) ^ 2 +
+       (Real.cos θ * Real.cos φ * v 0 + Real.sin θ * Real.cos φ * v 1) ^ 2 ≤
+      v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
+    -- Row 0: [sin θ, -cos θ, 0], norm = 1
+    -- Row 1: [cos θ * cos φ, sin θ * cos φ, 0], norm = |cos φ| ≤ 1
+    have h₁ := sq_nonneg (Real.cos θ * v 0 + Real.sin θ * v 1)
+    have h₂ := sq_nonneg (v 2)
+    have h₃ := Real.sin_sq_add_cos_sq θ
+    have h₄ := Real.cos_sq_le_one φ
+    nlinarith
+  simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
+    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
+    Fin.succ_one_eq_two, one_mul]
+  convert Real.sqrt_le_sqrt h_expand using 1
+  · simp only [rotMθθ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+      LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
+      WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+      WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
+      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
+      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
+      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.cons_val_fin_one]
+    ring_nf!
+  · ring_nf
+
+theorem rotMθφ_norm_le_one (θ φ : ℝ) : ‖rotMθφ θ φ‖ ≤ 1 := by
+  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one ?_
+  intro v
+  have h_expand :
+      0 ^ 2 +
+       (-Real.sin θ * Real.sin φ * v 0 + Real.cos θ * Real.sin φ * v 1) ^ 2 ≤
+      v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
+    -- Row 0: [0, 0, 0], norm = 0
+    -- Row 1: [-sin θ * sin φ, cos θ * sin φ, 0], norm = |sin φ| ≤ 1
+    -- The key is: (-sin θ * v 0 + cos θ * v 1)² ≤ v 0² + v 1² (sin² + cos² = 1)
+    -- Then multiply by sin² φ ≤ 1
+    set c := Real.cos θ; set s := Real.sin θ
+    set sφ := Real.sin φ
+    set u := -s * v 0 + c * v 1  -- the term being multiplied by sin φ
+    have hsc : s^2 + c^2 = 1 := Real.sin_sq_add_cos_sq θ
+    have hu_bound : u^2 ≤ v 0^2 + v 1^2 := by
+      have h := sq_nonneg (c * v 0 + s * v 1)
+      nlinarith
+    have hsφ : sφ^2 ≤ 1 := Real.sin_sq_le_one φ
+    have h_main : (sφ * u)^2 ≤ v 0^2 + v 1^2 := by
+      have hsφ_nn : 0 ≤ sφ^2 := sq_nonneg _
+      calc (sφ * u)^2 = sφ^2 * u^2 := by ring
+        _ ≤ 1 * u^2 := by apply mul_le_mul_of_nonneg_right hsφ (sq_nonneg _)
+        _ = u^2 := by ring
+        _ ≤ v 0^2 + v 1^2 := hu_bound
+    have hv2 : 0 ≤ v 2^2 := sq_nonneg _
+    have heq : -s * sφ * v 0 + c * sφ * v 1 = sφ * u := by ring
+    simp only [heq, pow_two] at *
+    linarith
+  simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
+    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
+    Fin.succ_one_eq_two, one_mul]
+  convert Real.sqrt_le_sqrt h_expand using 1
+  · simp only [rotMθφ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+      LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
+      WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+      WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
+      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
+      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
+      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.cons_val_fin_one, neg_mul]
+    ring_nf!
+  · ring_nf
+
+theorem rotMφφ_norm_le_one (θ φ : ℝ) : ‖rotMφφ θ φ‖ ≤ 1 := by
+  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one ?_
+  intro v
+  have h_expand :
+      0 ^ 2 +
+       (Real.cos θ * Real.cos φ * v 0 + Real.sin θ * Real.cos φ * v 1 - Real.sin φ * v 2) ^ 2 ≤
+      v 0 ^ 2 + v 1 ^ 2 + v 2 ^ 2 := by
+    -- Row 0: [0, 0, 0], norm = 0
+    -- Row 1: [cos θ * cos φ, sin θ * cos φ, -sin φ], this is a unit vector
+    set c := Real.cos θ; set s := Real.sin θ
+    set cφ := Real.cos φ; set sφ := Real.sin φ
+    set u := c * v 0 + s * v 1
+    set w := s * v 0 - c * v 1
+    have h₁ : c^2 + s^2 = 1 := by simp only [c, s]; linarith [Real.sin_sq_add_cos_sq θ]
+    have h₂ : cφ^2 + sφ^2 = 1 := Real.cos_sq_add_sin_sq φ
+    have huw : v 0 ^ 2 + v 1 ^ 2 = u^2 + w^2 :=
+      by nlinarith [sq_nonneg c, sq_nonneg s, sq_nonneg (v 0), sq_nonneg (v 1)]
+    have heq : c * cφ * v 0 + s * cφ * v 1 - sφ * v 2 = cφ * u - sφ * v 2 := by ring
+    have hrot : u^2 + v 2 ^2 = (cφ * u - sφ * v 2)^2 + (sφ * u + cφ * v 2)^2 :=
+      by nlinarith [sq_nonneg cφ, sq_nonneg sφ, sq_nonneg u, sq_nonneg (v 2)]
+    have hw : 0 ≤ w^2 := sq_nonneg w
+    have hcomp : 0 ≤ (sφ * u + cφ * v 2)^2 := sq_nonneg _
+    simp only [heq, pow_two] at *
+    linarith
+  simp only [EuclideanSpace.norm_eq, Real.norm_eq_abs, sq_abs, Fin.sum_univ_succ, Fin.isValue,
+    Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
+    Fin.succ_one_eq_two, one_mul]
+  convert Real.sqrt_le_sqrt h_expand using 1
+  · simp only [rotMφφ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+      LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
+      WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+      WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
+      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
+      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
+      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.cons_val_fin_one]
+    ring_nf!
+  · ring_nf
+
 theorem Rx_preserves_norm (α : ℝ) :
     ∀ (v : E 3), ‖(RxL α) v‖ = ‖v‖ := by
   intro v

--- a/Noperthedron/Bounding/OpNorm.lean
+++ b/Noperthedron/Bounding/OpNorm.lean
@@ -66,14 +66,14 @@ theorem rotMθ_norm_le_one (θ φ : ℝ) : ‖rotMθ θ φ‖ ≤ 1 := by
     Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, one_mul]
   convert Real.sqrt_le_sqrt h_expand using 1
-  · simp only [rotMθ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+  · simp only [rotMθ, rotMθ_mat, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
       LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
       WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
       WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
-      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
-      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
-      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.cons_val_fin_one, neg_mul]
+      Matrix.dotProduct_of_isEmpty, Matrix.empty_mulVec, WithLp.linearEquiv_symm_apply,
+      Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm, WithLp.addEquiv_symm_apply, Fin.isValue,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one, neg_mul, add_zero,
+      zero_mul]
     ring_nf!
   · ring_nf
 
@@ -105,14 +105,13 @@ theorem rotMφ_norm_le_one (θ φ : ℝ) : ‖rotMφ θ φ‖ ≤ 1 := by
     Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, one_mul]
   convert Real.sqrt_le_sqrt h_expand using 1
-  · simp only [rotMφ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+  · simp only [rotMφ, rotMφ_mat, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
       LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
       WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
       WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
-      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
-      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
-      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.cons_val_fin_one]
+      Matrix.dotProduct_of_isEmpty, Matrix.empty_mulVec, WithLp.linearEquiv_symm_apply,
+      Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm, WithLp.addEquiv_symm_apply, Fin.isValue,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one, add_zero, zero_mul]
     ring_nf!
   · ring_nf
 
@@ -135,14 +134,13 @@ theorem rotMθθ_norm_le_one (θ φ : ℝ) : ‖rotMθθ θ φ‖ ≤ 1 := by
     Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, one_mul]
   convert Real.sqrt_le_sqrt h_expand using 1
-  · simp only [rotMθθ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+  · simp only [rotMθθ, rotMθθ_mat, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
       LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
       WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
       WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
-      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
-      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
-      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.cons_val_fin_one]
+      Matrix.dotProduct_of_isEmpty, Matrix.empty_mulVec, WithLp.linearEquiv_symm_apply,
+      Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm, WithLp.addEquiv_symm_apply, Fin.isValue,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one, add_zero, zero_mul]
     ring_nf!
   · ring_nf
 
@@ -179,14 +177,14 @@ theorem rotMθφ_norm_le_one (θ φ : ℝ) : ‖rotMθφ θ φ‖ ≤ 1 := by
     Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, one_mul]
   convert Real.sqrt_le_sqrt h_expand using 1
-  · simp only [rotMθφ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+  · simp only [rotMθφ, rotMθφ_mat, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
       LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
       WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
       WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
-      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
-      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
-      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.cons_val_fin_one, neg_mul]
+      Matrix.dotProduct_of_isEmpty, Matrix.empty_mulVec, WithLp.linearEquiv_symm_apply,
+      Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm, WithLp.addEquiv_symm_apply, Fin.isValue,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one, neg_mul, add_zero,
+      zero_mul]
     ring_nf!
   · ring_nf
 
@@ -218,14 +216,13 @@ theorem rotMφφ_norm_le_one (θ φ : ℝ) : ‖rotMφφ θ φ‖ ≤ 1 := by
     Finset.univ_unique, Fin.default_eq_zero, Finset.sum_singleton, Fin.succ_zero_eq_one,
     Fin.succ_one_eq_two, one_mul]
   convert Real.sqrt_le_sqrt h_expand using 1
-  · simp only [rotMφφ, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
+  · simp only [rotMφφ, rotMφφ_mat, Matrix.toEuclideanLin, LinearEquiv.trans_apply,
       LinearMap.coe_toContinuousLinearMap', LinearEquiv.arrowCongr_apply, LinearEquiv.symm_symm,
       WithLp.linearEquiv_apply, AddEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
       WithLp.addEquiv_apply, Matrix.toLin'_apply, Matrix.cons_mulVec, Matrix.cons_dotProduct,
-      zero_mul, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
-      WithLp.linearEquiv_symm_apply, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
-      WithLp.addEquiv_symm_apply, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
-      Matrix.cons_val_fin_one]
+      Matrix.dotProduct_of_isEmpty, Matrix.empty_mulVec, WithLp.linearEquiv_symm_apply,
+      Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm, WithLp.addEquiv_symm_apply, Fin.isValue,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one, add_zero, zero_mul]
     ring_nf!
   · ring_nf
 

--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -430,7 +430,7 @@ lemma global_theorem_inequality_iv (pbar p : Pose) (ε : ℝ) (hε : ε > 0)
   -- Now we're just considering a single polyhedron vertex P
   intro P hP
   have P_norm_pos : 0 < ‖P‖ := poly.nontriv P hP
-  have P_norm_nonzero : ‖P‖ ≠ 0 := by exact Ne.symm (ne_of_lt P_norm_pos)
+  have P_norm_nonzero : ‖P‖ ≠ 0 := Ne.symm (ne_of_lt P_norm_pos)
   have P_norm_le_one : ‖P‖ ≤ 1 := poly.vertex_radius_le_one P hP
 
   have hz := bounded_partials_control_difference

--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -5,6 +5,7 @@ import Noperthedron.Nopert
 import Noperthedron.PoseInterval
 import Noperthedron.Global.Basic
 import Noperthedron.Global.BoundedPartialsControlDifference
+import Noperthedron.Global.RotationPartials.Rotproj
 
 open scoped RealInnerProductSpace
 
@@ -57,29 +58,9 @@ theorem hull_scalar_prod {n : ℕ} (V : Finset (E n)) (Vne : V.Nonempty)
     ⟪w, S⟫ ≤ Finset.max' (V.image (⟪w, ·⟫)) (by simp [Finset.image_nonempty]; exact Vne) := by
   exact finset_hull_linear_max Vne S hs (InnerProductSpace.toDual ℝ (E n) w |>.toLinearMap)
 
-noncomputable
-def rotproj_inner (S : ℝ³) (w : ℝ²) (x : ℝ³) : ℝ :=
-  ⟪rotprojRM (x 1) (x 2) (x 0) S, w⟫
-
-noncomputable
-def rotproj_inner_unit (S : ℝ³) (w : ℝ²) (x : ℝ³) : ℝ :=
-  ⟪rotprojRM (x 1) (x 2) (x 0) S, w⟫ / ‖S‖
-
-noncomputable
-def rotproj_outer_unit (S : ℝ³) (w : ℝ²) (x : ℝ²) : ℝ :=
-  ⟪rotM (x 0) (x 1) S, w⟫ / ‖S‖
-
-lemma rotation_partials_exist {S : ℝ³} (S_nonzero : ‖S‖ > 0) {w : ℝ²} :
-    ContDiff ℝ 2 (rotproj_inner_unit S w) := by
-  refine ContDiff.div ?_ contDiff_const (fun x ↦ (ne_of_lt S_nonzero).symm)
-  simp [inner, rotprojRM, rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail]
-  fun_prop
-
-lemma rotation_partials_exist_outer {S : ℝ³} (S_nonzero : ‖S‖ > 0) {w : ℝ²} :
-    ContDiff ℝ 2 (rotproj_outer_unit S w) := by
-  refine ContDiff.div ?_ contDiff_const (fun x ↦ (ne_of_lt S_nonzero).symm)
-  simp [inner, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail]
-  fun_prop
+-- rotproj_inner, rotproj_inner_unit, rotproj_outer_unit, rotation_partials_exist,
+-- rotation_partials_exist_outer are now imported from Noperthedron.Global.Definitions
+-- (via Noperthedron.Global.RotationPartials.Rotproj)
 
 /- [SY25] Lemma 19 -/
 theorem rotation_partials_bounded (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
@@ -232,7 +213,7 @@ def GlobalTheoremPrecondition.f {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
 theorem f_pose_eq_sval {p pbar : Pose} {ε : ℝ} {poly : GoodPoly}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     pc.f p.innerParams = pc.Sval p := by
-  simp [GlobalTheoremPrecondition.f, GlobalTheoremPrecondition.Sval]
+  simp only [GlobalTheoremPrecondition.f, GlobalTheoremPrecondition.Sval]
   rw [rotproj_inner_pose_eq]
   apply real_inner_comm
 
@@ -250,45 +231,8 @@ theorem GlobalTheoremPrecondition.fu_pose_eq_outer {p pbar : Pose} {ε : ℝ} {p
            Function.comp_apply]
   rw [div_mul_cancel₀ _ hP, Pose.proj_rm_eq_m, real_inner_comm]
 
-lemma Differentiable.rotprojRM (S : ℝ³) :
-    Differentiable ℝ fun (x : ℝ³)  ↦ (_root_.rotprojRM (x 1) (x 2) (x 0)) S := by
-  unfold _root_.rotprojRM
-  rw [differentiable_piLp]
-  intro i
-  fin_cases i <;> simp [rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
-
-@[fun_prop]
-lemma Differentiable.rotproj_inner (S : ℝ³) (w : ℝ²) : Differentiable ℝ (rotproj_inner S w) :=
-  Differentiable.inner ℝ (Differentiable.rotprojRM S) (by fun_prop)
-
-/--
-An explicit formula for the full derivative of rotproj_inner as a function ℝ³ → ℝ
--/
-noncomputable
-def rotproj_inner' (pbar : Pose) (S : ℝ³) (w : ℝ²) : ℝ³ →L[ℝ] ℝ :=
-  let grad : Fin 3 → ℝ := ![
-    ⟪pbar.rotR' (pbar.rotM₁ S), w⟫,
-    ⟪pbar.rotR (pbar.rotM₁θ S), w⟫,
-    ⟪pbar.rotR (pbar.rotM₁φ S), w⟫
-  ]
-  EuclideanSpace.basisFun (Fin 3) ℝ |>.toBasis.constr ℝ grad |>.toContinuousLinearMap
-
-def rotprojRM' (S : ℝ³) : ℝ³ →L[ℝ] ℝ² := sorry
-
-lemma HasFDerivAt.rotproj_inner (pbar : Pose) (S : ℝ³) (w : ℝ²) :
-    (HasFDerivAt (rotproj_inner S w) (rotproj_inner' pbar S w) pbar.innerParams) := by
-
-  have z1 : HasFDerivAt (fun x => (rotprojRM (x.ofLp 1) (x.ofLp 2) (x.ofLp 0)) S) (rotprojRM' S) pbar.innerParams := by
-    sorry
-
-  have step :
-    (rotproj_inner' pbar S w) = ((fderivInnerCLM ℝ
-            ((rotprojRM (pbar.innerParams.ofLp 1) (pbar.innerParams.ofLp 2) (pbar.innerParams.ofLp 0)) S, w)).comp
-        ((rotprojRM' S).prod 0)) := by
-    sorry
-
-  rw [step]
-  exact HasFDerivAt.inner ℝ z1 (hasFDerivAt_const w pbar.innerParams)
+-- Differentiable.rotprojRM, Differentiable.rotproj_inner, rotproj_inner', rotprojRM',
+-- HasFDerivAt.rotproj_inner are now imported from Noperthedron.Global.RotationPartials.Rotproj
 
 lemma fderiv_rotproj_inner_unit (pbar : Pose) (S : ℝ³) (w : ℝ²) :
     fderiv ℝ (rotproj_inner_unit S w) pbar.innerParams = ‖S‖⁻¹ • (rotproj_inner' pbar S w) := by

--- a/Noperthedron/Global/Basic.lean
+++ b/Noperthedron/Global/Basic.lean
@@ -12,6 +12,20 @@ noncomputable
 def nth_partial {n : ℕ} (i : Fin n) (f : E n → ℝ) (x : E n) : ℝ :=
   fderiv ℝ f x (EuclideanSpace.single i 1)
 
+/-- Partial derivative of a scalar multiple equals scalar times partial derivative -/
+lemma nth_partial_const_smul {n : ℕ} (i : Fin n) (c : ℝ) (f : E n → ℝ) (x : E n)
+    (hf : DifferentiableAt ℝ f x) :
+    nth_partial i (c • f) x = c * nth_partial i f x := by
+  simp only [nth_partial]
+  rw [fderiv_const_smul hf, ContinuousLinearMap.smul_apply, smul_eq_mul]
+
+/-- Partial derivative of f/c equals (partial of f)/c -/
+lemma nth_partial_div_const {n : ℕ} (i : Fin n) (f : E n → ℝ) (c : ℝ) (x : E n)
+    (hf : DifferentiableAt ℝ f x) :
+    nth_partial i (fun y => f y / c) x = nth_partial i f x / c := by
+  simp only [div_eq_mul_inv, nth_partial, fderiv_mul_const hf, ContinuousLinearMap.smul_apply,
+    smul_eq_mul, mul_comm]
+
 def mixed_partials_bounded {n : ℕ} (f : E n → ℝ) : Prop :=
   ∀ (x : E n) (i j : Fin n), abs ((nth_partial i <| nth_partial j <| f) x) ≤ 1
 

--- a/Noperthedron/Global/Definitions.lean
+++ b/Noperthedron/Global/Definitions.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Mathlib.Analysis.InnerProductSpace.Calculus
+import Noperthedron.Nopert
+import Noperthedron.PoseInterval
+
+/-!
+# Global Theorem Definitions
+
+Shared definitions for the global theorem.
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+noncomputable
+def rotproj_inner (S : ℝ³) (w : ℝ²) (x : ℝ³) : ℝ :=
+  ⟪rotprojRM (x 1) (x 2) (x 0) S, w⟫
+
+noncomputable
+def rotproj_inner_unit (S : ℝ³) (w : ℝ²) (x : ℝ³) : ℝ :=
+  ⟪rotprojRM (x 1) (x 2) (x 0) S, w⟫ / ‖S‖
+
+noncomputable
+def rotproj_outer_unit (S : ℝ³) (w : ℝ²) (x : ℝ²) : ℝ :=
+  ⟪rotM (x 0) (x 1) S, w⟫ / ‖S‖
+
+noncomputable
+def rotproj_outer (S : ℝ³) (w : ℝ²) (x : ℝ²) : ℝ :=
+  ⟪rotM (x 0) (x 1) S, w⟫
+
+/--
+An explicit formula for the full derivative of rotproj_outer as a function ℝ² → ℝ
+-/
+noncomputable
+def rotproj_outer' (pbar : Pose) (P : ℝ³) (w : ℝ²) : ℝ² →L[ℝ] ℝ :=
+  let grad : Fin 2 → ℝ := ![
+    ⟪pbar.rotM₂θ P, w⟫,
+    ⟪pbar.rotM₂φ P, w⟫
+  ]
+  EuclideanSpace.basisFun (Fin 2) ℝ |>.toBasis.constr ℝ grad |>.toContinuousLinearMap
+
+lemma rotation_partials_exist {S : ℝ³} (S_nonzero : ‖S‖ > 0) {w : ℝ²} :
+    ContDiff ℝ 2 (rotproj_inner_unit S w) := by
+  refine ContDiff.div ?_ contDiff_const (fun x ↦ (ne_of_lt S_nonzero).symm)
+  simp [inner, rotprojRM, rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail]
+  fun_prop
+
+lemma rotation_partials_exist_outer {S : ℝ³} (S_nonzero : ‖S‖ > 0) {w : ℝ²} :
+    ContDiff ℝ 2 (rotproj_outer_unit S w) := by
+  refine ContDiff.div ?_ contDiff_const (fun x ↦ (ne_of_lt S_nonzero).symm)
+  simp [inner, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail]
+  fun_prop
+
+end GlobalTheorem

--- a/Noperthedron/Global/Definitions.lean
+++ b/Noperthedron/Global/Definitions.lean
@@ -33,6 +33,28 @@ noncomputable
 def rotproj_outer (S : ℝ³) (w : ℝ²) (x : ℝ²) : ℝ :=
   ⟪rotM (x 0) (x 1) S, w⟫
 
+/-- Expand rotproj_inner in terms of rotR and rotM -/
+@[simp]
+lemma rotproj_inner_eq (S : ℝ³) (w : ℝ²) (x : ℝ³) :
+    rotproj_inner S w x = ⟪rotR (x 0) (rotM (x 1) (x 2) S), w⟫ := by
+  simp [rotproj_inner, rotprojRM]
+
+/-- rotproj_inner_unit equals rotproj_inner divided by norm -/
+@[simp]
+lemma rotproj_inner_unit_eq (S : ℝ³) (w : ℝ²) (x : ℝ³) :
+    rotproj_inner_unit S w x = rotproj_inner S w x / ‖S‖ := by
+  simp [rotproj_inner_unit, rotproj_inner]
+
+/-- Expand rotproj_outer in terms of rotM -/
+@[simp]
+lemma rotproj_outer_eq (S : ℝ³) (w : ℝ²) (x : ℝ²) :
+    rotproj_outer S w x = ⟪rotM (x 0) (x 1) S, w⟫ := rfl
+
+/-- rotproj_outer_unit equals rotproj_outer divided by norm -/
+@[simp]
+lemma rotproj_outer_unit_eq (S : ℝ³) (w : ℝ²) (x : ℝ²) :
+    rotproj_outer_unit S w x = rotproj_outer S w x / ‖S‖ := rfl
+
 /--
 An explicit formula for the full derivative of rotproj_outer as a function ℝ² → ℝ
 -/

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -1,0 +1,304 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Mathlib.Analysis.Calculus.FDeriv.WithLp
+import Mathlib.Analysis.Calculus.LineDeriv.Basic
+import Noperthedron.RotationDerivs
+import Noperthedron.Global.SecondPartialHelpers
+
+/-!
+# FDeriv Helper Lemmas for Global Theorem
+
+This file contains helper lemmas for computing fderiv in coordinate directions.
+These show that fderiv f y (e_i) equals the partial derivative in direction i.
+
+## Main Results
+
+* `fderiv_rotR_rotM_in_e0` - fderiv of rotR ∘ rotM in direction e₀ gives rotR'
+* `fderiv_rotR_rotM_in_e1` - fderiv of rotR ∘ rotM in direction e₁ gives rotR ∘ rotMθ
+* `fderiv_rotR_rotM_in_e2` - fderiv of rotR ∘ rotM in direction e₂ gives rotR ∘ rotMφ
+* `fderiv_rotR'_rotM_in_e0` - fderiv of rotR' ∘ rotM in direction e₀ gives -rotR
+* `fderiv_rotR'_rotM_in_e1` - fderiv of rotR' ∘ rotM in direction e₁ gives rotR' ∘ rotMθ
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
+
+-- Derivative of rotR' with respect to α: d/dα(rotR' α v) = -rotR α v
+-- This is needed for the second derivative ∂²/∂α² of rotproj_inner
+-- Note: Linter reports false positives about seq focus and unused/unreachable tactics
+set_option linter.unnecessarySeqFocus false in
+set_option linter.unusedTactic false in
+set_option linter.unreachableTactic false in
+lemma HasDerivAt_rotR' (α : ℝ) (v : ℝ²) :
+    HasDerivAt (rotR' · v) (-(rotR α v)) α := by
+  -- rotR' α v = !₂[-sin α * v 0 - cos α * v 1, cos α * v 0 - sin α * v 1]
+  -- d/dα = !₂[-cos α * v 0 + sin α * v 1, -sin α * v 0 - cos α * v 1]
+  --      = -!₂[cos α * v 0 - sin α * v 1, sin α * v 0 + cos α * v 1] = -rotR α v
+  have h_f : (rotR' · v) = (fun α' => !₂[-Real.sin α' * v 0 - Real.cos α' * v 1,
+      Real.cos α' * v 0 - Real.sin α' * v 1]) := by
+    ext α' i
+    fin_cases i <;> simp [rotR', rotR'_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail] <;> ring
+  have h_f' : -(rotR α v) = !₂[-Real.cos α * v 0 + Real.sin α * v 1,
+      -Real.sin α * v 0 - Real.cos α * v 1] := by
+    ext i
+    fin_cases i <;> simp [rotR, rotR_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail] <;> ring
+  rw [h_f, h_f']
+  refine hasDerivAt_lp2 ?_ ?_
+  · -- Component 0: d/dα(-sin α * v 0 - cos α * v 1) = -cos α * v 0 + sin α * v 1
+    have h1 : HasDerivAt (fun x => -Real.sin x * v.ofLp 0) (-Real.cos α * v.ofLp 0) α := by
+      have := (Real.hasDerivAt_sin α).neg.mul_const (v.ofLp 0)
+      convert this using 2 <;> ring
+    have h2 : HasDerivAt (fun x => -Real.cos x * v.ofLp 1) (Real.sin α * v.ofLp 1) α := by
+      have := (Real.hasDerivAt_cos α).neg.mul_const (v.ofLp 1)
+      convert this using 2 <;> ring
+    convert h1.add h2 using 1 <;> first | (funext x; simp only [Pi.add_apply]; ring) | ring
+  · -- Component 1: d/dα(cos α * v 0 - sin α * v 1) = -sin α * v 0 - cos α * v 1
+    have h1 : HasDerivAt (fun x => Real.cos x * v.ofLp 0) (-Real.sin α * v.ofLp 0) α := by
+      have := (Real.hasDerivAt_cos α).mul_const (v.ofLp 0)
+      convert this using 2 <;> ring
+    have h2 : HasDerivAt (fun x => -Real.sin x * v.ofLp 1) (-Real.cos α * v.ofLp 1) α := by
+      have := (Real.hasDerivAt_sin α).neg.mul_const (v.ofLp 1)
+      convert this using 2 <;> ring
+    convert h1.add h2 using 1 <;> first | (funext x; simp only [Pi.add_apply]; ring) | ring
+
+/-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₀ gives rotR' -/
+lemma fderiv_rotR_rotM_in_e0 (S : Euc(3)) (y : E 3)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 0 1) =
+    rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) := by
+  rw [← hf_diff.lineDeriv_eq_fderiv]
+  have h0 := fun t => coord_e0_same y t
+  have h1 := coord_e0_at1 y
+  have h2 := coord_e0_at2 y
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
+      (rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 0 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 0 1).ofLp 0)
+        (rotM ((y + t • EuclideanSpace.single 0 1).ofLp 1)
+             ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
+        rotR (y.ofLp 0 + t) (rotM (y.ofLp 1) (y.ofLp 2) S) := by
+      intro t; rw [h0, h1, h2]
+    simp_rw [hsimp]
+    have hrotR : HasDerivAt (fun α => rotR α (rotM (y.ofLp 1) (y.ofLp 2) S))
+        (rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0) := HasDerivAt_rotR _ _
+    have hid : HasDerivAt (fun t : ℝ => y.ofLp 0 + t) 1 0 := by
+      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 0)
+    have hrotR' : HasDerivAt (fun α => rotR α (rotM (y.ofLp 1) (y.ofLp 2) S))
+        (rotR' (y.ofLp 0 + 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0 + 0) := by
+      simp only [add_zero]; exact hrotR
+    have hcomp := hrotR'.scomp 0 hid
+    simp only [one_smul, add_zero] at hcomp
+    have heq_fun : ((fun α ↦ rotR α (rotM (y.ofLp 1) (y.ofLp 2) S)) ∘ HAdd.hAdd (y.ofLp 0)) =
+        (fun t => rotR (y.ofLp 0 + t) (rotM (y.ofLp 1) (y.ofLp 2) S)) := by
+      ext t; simp only [Function.comp_apply]
+    rw [heq_fun] at hcomp
+    exact hcomp
+  exact hline.lineDeriv
+
+/-- fderiv of rotR with any M in direction e₀ gives rotR' -/
+lemma fderiv_rotR_any_M_in_e0 (S : Euc(3)) (y : E 3) (M : ℝ → ℝ → ℝ³ →L[ℝ] ℝ²)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (M (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (M (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 0 1) =
+    rotR' (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S) := by
+  rw [← hf_diff.lineDeriv_eq_fderiv]
+  have h0 := fun t => coord_e0_same y t
+  have h1 := coord_e0_at1 y
+  have h2 := coord_e0_at2 y
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (M (z.ofLp 1) (z.ofLp 2) S))
+      (rotR' (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 0 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 0 1).ofLp 0) (M ((y + t • EuclideanSpace.single 0 1).ofLp 1) ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
+        rotR (y.ofLp 0 + t) (M (y.ofLp 1) (y.ofLp 2) S) := by intro t; rw [h0, h1, h2]
+    simp_rw [hsimp]
+    have hrotR : HasDerivAt (fun α => rotR α (M (y.ofLp 1) (y.ofLp 2) S)) (rotR' (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0) := HasDerivAt_rotR _ _
+    have hid : HasDerivAt (fun t : ℝ => y.ofLp 0 + t) 1 0 := by simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 0)
+    have hrotR' : HasDerivAt (fun α => rotR α (M (y.ofLp 1) (y.ofLp 2) S)) (rotR' (y.ofLp 0 + 0) (M (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0 + 0) := by simp only [add_zero]; exact hrotR
+    have hcomp := hrotR'.scomp 0 hid
+    simp only [one_smul, add_zero] at hcomp
+    have heq_fun : ((fun α ↦ rotR α (M (y.ofLp 1) (y.ofLp 2) S)) ∘ HAdd.hAdd (y.ofLp 0)) = (fun t => rotR (y.ofLp 0 + t) (M (y.ofLp 1) (y.ofLp 2) S)) := by ext t; simp only [Function.comp_apply]
+    rw [heq_fun] at hcomp; exact hcomp
+  exact hline.lineDeriv
+
+/-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₂ gives rotR ∘ rotMφ -/
+lemma fderiv_rotR_rotM_in_e2 (S : Euc(3)) (y : E 3)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 2 1) =
+    rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S) := by
+  rw [← hf_diff.lineDeriv_eq_fderiv]
+  have h0 := coord_e2_at0 y
+  have h1 := coord_e2_at1 y
+  have h2 := fun t => coord_e2_same y t
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
+      (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 2 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 2 1).ofLp 0)
+        (rotM ((y + t • EuclideanSpace.single 2 1).ofLp 1) ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
+        rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2 + t) S) := by intro t; rw [h0, h1, h2]
+    simp_rw [hsimp]
+    have hrotM : HasDerivAt (fun φ => rotM (y.ofLp 1) φ S) (rotMφ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 2) :=
+      hasDerivAt_rotM_φ _ _ _
+    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotM (y.ofLp 1) (y.ofLp 2) S) :=
+      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
+    have hrotM_fderiv : HasFDerivAt (fun φ : ℝ => rotM (y.ofLp 1) φ S)
+        (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 2) := hrotM.hasFDerivAt
+    have hcomp_inner := hR.comp (y.ofLp 2) hrotM_fderiv
+    have heq_comp : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ (y.ofLp 1) (y.ofLp 2) S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq_comp] at hcomp_inner
+    have hcomp_deriv : HasDerivAt ((fun v => rotR (y.ofLp 0) v) ∘ (fun φ => rotM (y.ofLp 1) φ S))
+        (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 2) := by
+      have h := hcomp_inner.hasDerivAt (x := y.ofLp 2)
+      simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at h
+      exact h
+    have hid : HasDerivAt (fun t : ℝ => y.ofLp 2 + t) 1 0 := by
+      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 2)
+    have hcomp_deriv' : HasDerivAt (fun φ => rotR (y.ofLp 0) (rotM (y.ofLp 1) φ S))
+        (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2 + 0) S)) (y.ofLp 2 + 0) := by
+      simp only [add_zero] at hcomp_deriv ⊢; exact hcomp_deriv
+    have hfinal := hcomp_deriv'.scomp 0 hid
+    simp only [one_smul, add_zero] at hfinal
+    have heq_fun : ((fun φ => rotR (y.ofLp 0) (rotM (y.ofLp 1) φ S)) ∘ HAdd.hAdd (y.ofLp 2)) =
+        (fun t => rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2 + t) S)) := by ext t; simp only [Function.comp_apply]
+    rw [heq_fun] at hfinal; exact hfinal
+  exact hline.lineDeriv
+
+/-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₁ gives rotR ∘ rotMθ -/
+lemma fderiv_rotR_rotM_in_e1 (S : Euc(3)) (y : E 3)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 1 1) =
+    rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S) := by
+  rw [← hf_diff.lineDeriv_eq_fderiv]
+  have h0 := coord_e1_at0 y
+  have h1 := fun t => coord_e1_same y t
+  have h2 := coord_e1_at2 y
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
+      (rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 1 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 1 1).ofLp 0)
+        (rotM ((y + t • EuclideanSpace.single 1 1).ofLp 1) ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
+        rotR (y.ofLp 0) (rotM (y.ofLp 1 + t) (y.ofLp 2) S) := by intro t; rw [h0, h1, h2]
+    simp_rw [hsimp]
+    have hrotM : HasDerivAt (fun θ => rotM θ (y.ofLp 2) S) (rotMθ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 1) :=
+      hasDerivAt_rotM_θ _ _ _
+    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotM (y.ofLp 1) (y.ofLp 2) S) :=
+      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
+    have hrotM_fderiv : HasFDerivAt (fun θ : ℝ => rotM θ (y.ofLp 2) S)
+        (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 1) := hrotM.hasFDerivAt
+    have hcomp_inner := hR.comp (y.ofLp 1) hrotM_fderiv
+    have heq_comp : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ (y.ofLp 1) (y.ofLp 2) S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq_comp] at hcomp_inner
+    have hcomp_deriv : HasDerivAt ((fun v => rotR (y.ofLp 0) v) ∘ (fun θ => rotM θ (y.ofLp 2) S))
+        (rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 1) := by
+      have h := hcomp_inner.hasDerivAt (x := y.ofLp 1)
+      simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at h
+      exact h
+    have hid : HasDerivAt (fun t : ℝ => y.ofLp 1 + t) 1 0 := by
+      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 1)
+    have hcomp_deriv' : HasDerivAt (fun θ => rotR (y.ofLp 0) (rotM θ (y.ofLp 2) S))
+        (rotR (y.ofLp 0) (rotMθ (y.ofLp 1 + 0) (y.ofLp 2) S)) (y.ofLp 1 + 0) := by
+      simp only [add_zero] at hcomp_deriv ⊢; exact hcomp_deriv
+    have hfinal := hcomp_deriv'.scomp 0 hid
+    simp only [one_smul, add_zero] at hfinal
+    have heq_fun : ((fun θ => rotR (y.ofLp 0) (rotM θ (y.ofLp 2) S)) ∘ HAdd.hAdd (y.ofLp 1)) =
+        (fun t => rotR (y.ofLp 0) (rotM (y.ofLp 1 + t) (y.ofLp 2) S)) := by ext t; simp only [Function.comp_apply]
+    rw [heq_fun] at hfinal; exact hfinal
+  exact hline.lineDeriv
+
+/-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₀ gives -rotR -/
+lemma fderiv_rotR'_rotM_in_e0 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
+    (hα : y.ofLp 0 = α) (hθ : y.ofLp 1 = θ) (hφ : y.ofLp 2 = φ)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 0 1) =
+    -(rotR α (rotM θ φ S)) := by
+  rw [← hf_diff.lineDeriv_eq_fderiv]
+  have h0 := fun t => coord_e0_same y t
+  have h1 := coord_e0_at1 y
+  have h2 := coord_e0_at2 y
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
+      (-(rotR α (rotM θ φ S))) y (EuclideanSpace.single 0 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR' ((y + t • EuclideanSpace.single 0 1).ofLp 0)
+        (rotM ((y + t • EuclideanSpace.single 0 1).ofLp 1)
+             ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
+        rotR' (y.ofLp 0 + t) (rotM (y.ofLp 1) (y.ofLp 2) S) := by
+      intro t; rw [h0, h1, h2]
+    simp_rw [hsimp, hθ, hφ]
+    have hrotR' : HasDerivAt (fun α' => rotR' α' (rotM θ φ S))
+        (-(rotR α (rotM θ φ S))) α := HasDerivAt_rotR' α (rotM θ φ S)
+    have hid : HasDerivAt (fun t : ℝ => y.ofLp 0 + t) 1 0 := by
+      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 0)
+    have hrotR'0 : HasDerivAt (fun α' => rotR' α' (rotM θ φ S))
+        (-(rotR α (rotM θ φ S))) (y.ofLp 0 + 0) := by
+      simp only [add_zero, hα]; exact hrotR'
+    have hcomp := hrotR'0.scomp 0 hid
+    simp only [one_smul] at hcomp
+    have heq_fun : ((fun α' ↦ rotR' α' (rotM θ φ S)) ∘ HAdd.hAdd (y.ofLp 0)) =
+        (fun t => rotR' (y.ofLp 0 + t) (rotM θ φ S)) := by
+      ext t; simp only [Function.comp_apply]
+    rw [heq_fun] at hcomp
+    simp only [hα] at hcomp ⊢
+    exact hcomp
+  exact hline.lineDeriv
+
+/-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₁ gives rotR' α (rotMθ θ φ S) -/
+lemma fderiv_rotR'_rotM_in_e1 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
+    (hα : y.ofLp 0 = α) (hθ : y.ofLp 1 = θ) (hφ : y.ofLp 2 = φ)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 1 1) =
+    rotR' α (rotMθ θ φ S) := by
+  rw [← hf_diff.lineDeriv_eq_fderiv]
+  have h0 := coord_e1_at0 y
+  have h1 := fun t => coord_e1_same y t
+  have h2 := coord_e1_at2 y
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
+      (rotR' α (rotMθ θ φ S)) y (EuclideanSpace.single 1 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR' ((y + t • EuclideanSpace.single 1 1).ofLp 0)
+        (rotM ((y + t • EuclideanSpace.single 1 1).ofLp 1)
+             ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
+        rotR' α (rotM (θ + t) φ S) := by
+      intro t; rw [h0, h1, h2, hα, hθ, hφ, add_comm]
+    simp_rw [hsimp]
+    -- rotR' α is a constant linear map, so d/dt[rotR' α (rotM (θ+t) φ S)] = rotR' α (d/dt[rotM (θ+t) φ S])
+    have hrotM : HasDerivAt (fun θ' => rotM θ' φ S) (rotMθ θ φ S) θ := hasDerivAt_rotM_θ θ φ S
+    have hR : HasFDerivAt (fun v => rotR' α v) (rotR' α) (rotM θ φ S) := ContinuousLinearMap.hasFDerivAt (rotR' α)
+    have hrotM_fderiv : HasFDerivAt (fun θ' : ℝ => rotM θ' φ S)
+        (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ θ φ S)) θ := hrotM.hasFDerivAt
+    have hcomp_inner := hR.comp θ hrotM_fderiv
+    have heq_comp : (rotR' α).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ θ φ S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq_comp] at hcomp_inner
+    have hcomp_deriv : HasDerivAt ((fun v => rotR' α v) ∘ (fun θ' => rotM θ' φ S))
+        (rotR' α (rotMθ θ φ S)) θ := by
+      have h := hcomp_inner.hasDerivAt (x := θ)
+      simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at h
+      exact h
+    have hid : HasDerivAt (fun t : ℝ => θ + t) 1 0 := by
+      simpa using (hasDerivAt_id (0 : ℝ)).const_add θ
+    have hcomp_deriv' : HasDerivAt (fun θ' => rotR' α (rotM θ' φ S))
+        (rotR' α (rotMθ (θ + 0) φ S)) (θ + 0) := by
+      simp only [add_zero] at hcomp_deriv ⊢; exact hcomp_deriv
+    have hfinal := hcomp_deriv'.scomp 0 hid
+    simp only [one_smul, add_zero] at hfinal
+    have heq_fun : ((fun θ' => rotR' α (rotM θ' φ S)) ∘ HAdd.hAdd θ) =
+        (fun t => rotR' α (rotM (θ + t) φ S)) := by ext t; simp only [Function.comp_apply]
+    rw [heq_fun] at hfinal; exact hfinal
+  exact hline.lineDeriv
+
+end GlobalTheorem

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -57,15 +57,13 @@ lemma fderiv_rotR_any_M_in_e0 (S : Euc(3)) (y : E 3) (M : ℝ → ℝ → ℝ³ 
       (EuclideanSpace.single 0 1) =
     rotR' (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S) := by
   rw [← hf_diff.lineDeriv_eq_fderiv]
-  have h0 := fun t => coord_e0_same y t
-  have h1 := coord_e0_at1 y
-  have h2 := coord_e0_at2 y
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (M (z.ofLp 1) (z.ofLp 2) S))
       (rotR' (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 0 1) := by
     unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 0 1).ofLp 0) (M ((y + t • EuclideanSpace.single 0 1).ofLp 1) ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
-        rotR (y.ofLp 0 + t) (M (y.ofLp 1) (y.ofLp 2) S) := by intro t; rw [h0, h1, h2]
-    simp_rw [hsimp]
+    simp_rw [fun t => show rotR ((y + t • EuclideanSpace.single 0 1).ofLp 0)
+        (M ((y + t • EuclideanSpace.single 0 1).ofLp 1) ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
+        rotR (y.ofLp 0 + t) (M (y.ofLp 1) (y.ofLp 2) S) by
+      rw [coord_e0_same, coord_e0_at1, coord_e0_at2]]
     have hrotR : HasDerivAt (fun α => rotR α (M (y.ofLp 1) (y.ofLp 2) S)) (rotR' (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0) := HasDerivAt_rotR _ _
     have hid : HasDerivAt (fun t : ℝ => y.ofLp 0 + t) 1 0 := by simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 0)
     have hrotR' : HasDerivAt (fun α => rotR α (M (y.ofLp 1) (y.ofLp 2) S)) (rotR' (y.ofLp 0 + 0) (M (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0 + 0) := by simp only [add_zero]; exact hrotR

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -89,10 +89,9 @@ lemma fderiv_rotR_rotM_in_e2 (S : Euc(3)) (y : E 3)
         (rotM ((y + t • EuclideanSpace.single 2 1).ofLp 1) ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
         rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2 + t) S) by
       rw [coord_e2_at0, coord_e2_at1, coord_e2_same]]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
-        (y.ofLp 2) (hasDerivAt_rotM_φ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 2) (hasDerivAt_rotM_φ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₁ gives rotR ∘ rotMθ -/
@@ -109,10 +108,9 @@ lemma fderiv_rotR_rotM_in_e1 (S : Euc(3)) (y : E 3)
         (rotM ((y + t • EuclideanSpace.single 1 1).ofLp 1) ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
         rotR (y.ofLp 0) (rotM (y.ofLp 1 + t) (y.ofLp 2) S) by
       rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
-        (y.ofLp 1) (hasDerivAt_rotM_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 1) (hasDerivAt_rotM_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₀ gives -rotR -/
@@ -131,8 +129,7 @@ lemma fderiv_rotR'_rotM_in_e0 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
              ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
         rotR' (y.ofLp 0 + t) (rotM θ φ S) by
       rw [coord_e0_same, coord_e0_at1, coord_e0_at2, hθ, hφ]]
-    have hrotR' := HasDerivAt_rotR' α (rotM θ φ S)
-    simpa [hα] using hasDerivAt_comp_add _ _ _ hrotR'
+    simpa [hα] using hasDerivAt_comp_add _ _ _ (HasDerivAt_rotR' α (rotM θ φ S))
   exact hline.lineDeriv
 
 /-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₁ gives rotR' α (rotMθ θ φ S) -/
@@ -151,9 +148,8 @@ lemma fderiv_rotR'_rotM_in_e1 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
              ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
         rotR' α (rotM (θ + t) φ S) by
       rw [coord_e1_at0, coord_e1_same, coord_e1_at2, hα, hθ, hφ, add_comm]]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR' α)).comp θ (hasDerivAt_rotM_θ θ φ S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR' α)).comp θ (hasDerivAt_rotM_θ θ φ S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₂ gives rotR' α (rotMφ θ φ S) -/
@@ -172,9 +168,8 @@ lemma fderiv_rotR'_rotM_in_e2 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
              ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
         rotR' α (rotM θ (φ + t) S) by
       rw [coord_e2_at0, coord_e2_at1, coord_e2_same, hα, hθ, hφ, add_comm]]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR' α)).comp φ (hasDerivAt_rotM_φ θ φ S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR' α)).comp φ (hasDerivAt_rotM_φ θ φ S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 end GlobalTheorem

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -67,41 +67,6 @@ lemma HasDerivAt_rotR' (α : ℝ) (v : ℝ²) :
       convert this using 2 <;> ring
     convert h1.add h2 using 1 <;> first | (funext x; simp only [Pi.add_apply]; ring) | ring
 
-/-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₀ gives rotR' -/
-lemma fderiv_rotR_rotM_in_e0 (S : Euc(3)) (y : E 3)
-    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
-    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
-      (EuclideanSpace.single 0 1) =
-    rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) := by
-  rw [← hf_diff.lineDeriv_eq_fderiv]
-  have h0 := fun t => coord_e0_same y t
-  have h1 := coord_e0_at1 y
-  have h2 := coord_e0_at2 y
-  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
-      (rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 0 1) := by
-    unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 0 1).ofLp 0)
-        (rotM ((y + t • EuclideanSpace.single 0 1).ofLp 1)
-             ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
-        rotR (y.ofLp 0 + t) (rotM (y.ofLp 1) (y.ofLp 2) S) := by
-      intro t; rw [h0, h1, h2]
-    simp_rw [hsimp]
-    have hrotR : HasDerivAt (fun α => rotR α (rotM (y.ofLp 1) (y.ofLp 2) S))
-        (rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0) := HasDerivAt_rotR _ _
-    have hid : HasDerivAt (fun t : ℝ => y.ofLp 0 + t) 1 0 := by
-      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 0)
-    have hrotR' : HasDerivAt (fun α => rotR α (rotM (y.ofLp 1) (y.ofLp 2) S))
-        (rotR' (y.ofLp 0 + 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0 + 0) := by
-      simp only [add_zero]; exact hrotR
-    have hcomp := hrotR'.scomp 0 hid
-    simp only [one_smul, add_zero] at hcomp
-    have heq_fun : ((fun α ↦ rotR α (rotM (y.ofLp 1) (y.ofLp 2) S)) ∘ HAdd.hAdd (y.ofLp 0)) =
-        (fun t => rotR (y.ofLp 0 + t) (rotM (y.ofLp 1) (y.ofLp 2) S)) := by
-      ext t; simp only [Function.comp_apply]
-    rw [heq_fun] at hcomp
-    exact hcomp
-  exact hline.lineDeriv
-
 /-- fderiv of rotR with any M in direction e₀ gives rotR' -/
 lemma fderiv_rotR_any_M_in_e0 (S : Euc(3)) (y : E 3) (M : ℝ → ℝ → ℝ³ →L[ℝ] ℝ²)
     (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (M (z.ofLp 1) (z.ofLp 2) S)) y) :
@@ -126,6 +91,14 @@ lemma fderiv_rotR_any_M_in_e0 (S : Euc(3)) (y : E 3) (M : ℝ → ℝ → ℝ³ 
     have heq_fun : ((fun α ↦ rotR α (M (y.ofLp 1) (y.ofLp 2) S)) ∘ HAdd.hAdd (y.ofLp 0)) = (fun t => rotR (y.ofLp 0 + t) (M (y.ofLp 1) (y.ofLp 2) S)) := by ext t; simp only [Function.comp_apply]
     rw [heq_fun] at hcomp; exact hcomp
   exact hline.lineDeriv
+
+/-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₀ gives rotR' -/
+lemma fderiv_rotR_rotM_in_e0 (S : Euc(3)) (y : E 3)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 0 1) =
+    rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) :=
+  fderiv_rotR_any_M_in_e0 S y rotM hf_diff
 
 /-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₂ gives rotR ∘ rotMφ -/
 lemma fderiv_rotR_rotM_in_e2 (S : Euc(3)) (y : E 3)
@@ -299,6 +272,36 @@ lemma fderiv_rotR'_rotM_in_e1 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
     have heq_fun : ((fun θ' => rotR' α (rotM θ' φ S)) ∘ HAdd.hAdd θ) =
         (fun t => rotR' α (rotM (θ + t) φ S)) := by ext t; simp only [Function.comp_apply]
     rw [heq_fun] at hfinal; exact hfinal
+  exact hline.lineDeriv
+
+/-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₂ gives rotR' α (rotMφ θ φ S) -/
+lemma fderiv_rotR'_rotM_in_e2 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
+    (hα : y.ofLp 0 = α) (hθ : y.ofLp 1 = θ) (hφ : y.ofLp 2 = φ)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 2 1) =
+    rotR' α (rotMφ θ φ S) := by
+  rw [← hf_diff.lineDeriv_eq_fderiv]
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
+      (rotR' α (rotMφ θ φ S)) y (EuclideanSpace.single 2 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR' ((y + t • EuclideanSpace.single 2 1).ofLp 0)
+        (rotM ((y + t • EuclideanSpace.single 2 1).ofLp 1)
+             ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
+        rotR' α (rotM θ (φ + t) S) := by
+      intro t; rw [coord_e2_at0, coord_e2_at1, coord_e2_same, hα, hθ, hφ, add_comm]
+    simp_rw [hsimp]
+    have hrotM : HasDerivAt (fun φ' => rotM θ φ' S) (rotMφ θ φ S) φ := hasDerivAt_rotM_φ θ φ S
+    have hR : HasFDerivAt (fun v => rotR' α v) (rotR' α) (rotM θ φ S) :=
+      ContinuousLinearMap.hasFDerivAt (rotR' α)
+    have hcomp := hR.comp φ hrotM.hasFDerivAt
+    have heq_comp : (rotR' α).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ θ φ S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMφ θ φ S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq_comp] at hcomp
+    have hderiv := hcomp.hasDerivAt
+    simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at hderiv
+    exact hasDerivAt_comp_add _ _ _ hderiv
   exact hline.lineDeriv
 
 end GlobalTheorem

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -31,15 +31,8 @@ private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 
 -- Derivative of rotR' with respect to α: d/dα(rotR' α v) = -rotR α v
 -- This is needed for the second derivative ∂²/∂α² of rotproj_inner
--- Note: Linter reports false positives about seq focus and unused/unreachable tactics
-set_option linter.unnecessarySeqFocus false in
-set_option linter.unusedTactic false in
-set_option linter.unreachableTactic false in
 lemma HasDerivAt_rotR' (α : ℝ) (v : ℝ²) :
     HasDerivAt (rotR' · v) (-(rotR α v)) α := by
-  -- rotR' α v = !₂[-sin α * v 0 - cos α * v 1, cos α * v 0 - sin α * v 1]
-  -- d/dα = !₂[-cos α * v 0 + sin α * v 1, -sin α * v 0 - cos α * v 1]
-  --      = -!₂[cos α * v 0 - sin α * v 1, sin α * v 0 + cos α * v 1] = -rotR α v
   have h_f : (rotR' · v) = (fun α' => !₂[-Real.sin α' * v 0 - Real.cos α' * v 1,
       Real.cos α' * v 0 - Real.sin α' * v 1]) := by
     ext α' i
@@ -50,22 +43,12 @@ lemma HasDerivAt_rotR' (α : ℝ) (v : ℝ²) :
     fin_cases i <;> simp [rotR, rotR_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail] <;> ring
   rw [h_f, h_f']
   refine hasDerivAt_lp2 ?_ ?_
-  · -- Component 0: d/dα(-sin α * v 0 - cos α * v 1) = -cos α * v 0 + sin α * v 1
-    have h1 : HasDerivAt (fun x => -Real.sin x * v.ofLp 0) (-Real.cos α * v.ofLp 0) α := by
-      have := (Real.hasDerivAt_sin α).neg.mul_const (v.ofLp 0)
-      convert this using 2 <;> ring
-    have h2 : HasDerivAt (fun x => -Real.cos x * v.ofLp 1) (Real.sin α * v.ofLp 1) α := by
-      have := (Real.hasDerivAt_cos α).neg.mul_const (v.ofLp 1)
-      convert this using 2 <;> ring
-    convert h1.add h2 using 1 <;> first | (funext x; simp only [Pi.add_apply]; ring) | ring
-  · -- Component 1: d/dα(cos α * v 0 - sin α * v 1) = -sin α * v 0 - cos α * v 1
-    have h1 : HasDerivAt (fun x => Real.cos x * v.ofLp 0) (-Real.sin α * v.ofLp 0) α := by
-      have := (Real.hasDerivAt_cos α).mul_const (v.ofLp 0)
-      convert this using 2 <;> ring
-    have h2 : HasDerivAt (fun x => -Real.sin x * v.ofLp 1) (-Real.cos α * v.ofLp 1) α := by
-      have := (Real.hasDerivAt_sin α).neg.mul_const (v.ofLp 1)
-      convert this using 2 <;> ring
-    convert h1.add h2 using 1 <;> first | (funext x; simp only [Pi.add_apply]; ring) | ring
+  · convert hasDerivAt_sin_cos_lincomb (-v 0) (-v 1) α using 1
+    · funext; ring
+    · ring
+  · convert hasDerivAt_cos_sin_lincomb (v 0) (-v 1) α using 1
+    · funext; ring
+    · ring
 
 /-- fderiv of rotR with any M in direction e₀ gives rotR' -/
 lemma fderiv_rotR_any_M_in_e0 (S : Euc(3)) (y : E 3) (M : ℝ → ℝ → ℝ³ →L[ℝ] ℝ²)

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -107,42 +107,17 @@ lemma fderiv_rotR_rotM_in_e2 (S : Euc(3)) (y : E 3)
       (EuclideanSpace.single 2 1) =
     rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S) := by
   rw [← hf_diff.lineDeriv_eq_fderiv]
-  have h0 := coord_e2_at0 y
-  have h1 := coord_e2_at1 y
-  have h2 := fun t => coord_e2_same y t
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
       (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 2 1) := by
     unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 2 1).ofLp 0)
+    simp_rw [fun t => show rotR ((y + t • EuclideanSpace.single 2 1).ofLp 0)
         (rotM ((y + t • EuclideanSpace.single 2 1).ofLp 1) ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
-        rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2 + t) S) := by intro t; rw [h0, h1, h2]
-    simp_rw [hsimp]
-    have hrotM : HasDerivAt (fun φ => rotM (y.ofLp 1) φ S) (rotMφ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 2) :=
-      hasDerivAt_rotM_φ _ _ _
-    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotM (y.ofLp 1) (y.ofLp 2) S) :=
-      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
-    have hrotM_fderiv : HasFDerivAt (fun φ : ℝ => rotM (y.ofLp 1) φ S)
-        (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 2) := hrotM.hasFDerivAt
-    have hcomp_inner := hR.comp (y.ofLp 2) hrotM_fderiv
-    have heq_comp : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ (y.ofLp 1) (y.ofLp 2) S)) =
-        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) := by
-      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
-    rw [heq_comp] at hcomp_inner
-    have hcomp_deriv : HasDerivAt ((fun v => rotR (y.ofLp 0) v) ∘ (fun φ => rotM (y.ofLp 1) φ S))
-        (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 2) := by
-      have h := hcomp_inner.hasDerivAt (x := y.ofLp 2)
-      simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at h
-      exact h
-    have hid : HasDerivAt (fun t : ℝ => y.ofLp 2 + t) 1 0 := by
-      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 2)
-    have hcomp_deriv' : HasDerivAt (fun φ => rotR (y.ofLp 0) (rotM (y.ofLp 1) φ S))
-        (rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2 + 0) S)) (y.ofLp 2 + 0) := by
-      simp only [add_zero] at hcomp_deriv ⊢; exact hcomp_deriv
-    have hfinal := hcomp_deriv'.scomp 0 hid
-    simp only [one_smul, add_zero] at hfinal
-    have heq_fun : ((fun φ => rotR (y.ofLp 0) (rotM (y.ofLp 1) φ S)) ∘ HAdd.hAdd (y.ofLp 2)) =
-        (fun t => rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2 + t) S)) := by ext t; simp only [Function.comp_apply]
-    rw [heq_fun] at hfinal; exact hfinal
+        rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2 + t) S) by
+      rw [coord_e2_at0, coord_e2_at1, coord_e2_same]]
+    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 2) (hasDerivAt_rotM_φ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
+    simp only [comp_toSpanSingleton] at hcomp
+    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₁ gives rotR ∘ rotMθ -/
@@ -152,42 +127,17 @@ lemma fderiv_rotR_rotM_in_e1 (S : Euc(3)) (y : E 3)
       (EuclideanSpace.single 1 1) =
     rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S) := by
   rw [← hf_diff.lineDeriv_eq_fderiv]
-  have h0 := coord_e1_at0 y
-  have h1 := fun t => coord_e1_same y t
-  have h2 := coord_e1_at2 y
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
       (rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 1 1) := by
     unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 1 1).ofLp 0)
+    simp_rw [fun t => show rotR ((y + t • EuclideanSpace.single 1 1).ofLp 0)
         (rotM ((y + t • EuclideanSpace.single 1 1).ofLp 1) ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
-        rotR (y.ofLp 0) (rotM (y.ofLp 1 + t) (y.ofLp 2) S) := by intro t; rw [h0, h1, h2]
-    simp_rw [hsimp]
-    have hrotM : HasDerivAt (fun θ => rotM θ (y.ofLp 2) S) (rotMθ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 1) :=
-      hasDerivAt_rotM_θ _ _ _
-    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotM (y.ofLp 1) (y.ofLp 2) S) :=
-      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
-    have hrotM_fderiv : HasFDerivAt (fun θ : ℝ => rotM θ (y.ofLp 2) S)
-        (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 1) := hrotM.hasFDerivAt
-    have hcomp_inner := hR.comp (y.ofLp 1) hrotM_fderiv
-    have heq_comp : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ (y.ofLp 1) (y.ofLp 2) S)) =
-        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) := by
-      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
-    rw [heq_comp] at hcomp_inner
-    have hcomp_deriv : HasDerivAt ((fun v => rotR (y.ofLp 0) v) ∘ (fun θ => rotM θ (y.ofLp 2) S))
-        (rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 1) := by
-      have h := hcomp_inner.hasDerivAt (x := y.ofLp 1)
-      simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at h
-      exact h
-    have hid : HasDerivAt (fun t : ℝ => y.ofLp 1 + t) 1 0 := by
-      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 1)
-    have hcomp_deriv' : HasDerivAt (fun θ => rotR (y.ofLp 0) (rotM θ (y.ofLp 2) S))
-        (rotR (y.ofLp 0) (rotMθ (y.ofLp 1 + 0) (y.ofLp 2) S)) (y.ofLp 1 + 0) := by
-      simp only [add_zero] at hcomp_deriv ⊢; exact hcomp_deriv
-    have hfinal := hcomp_deriv'.scomp 0 hid
-    simp only [one_smul, add_zero] at hfinal
-    have heq_fun : ((fun θ => rotR (y.ofLp 0) (rotM θ (y.ofLp 2) S)) ∘ HAdd.hAdd (y.ofLp 1)) =
-        (fun t => rotR (y.ofLp 0) (rotM (y.ofLp 1 + t) (y.ofLp 2) S)) := by ext t; simp only [Function.comp_apply]
-    rw [heq_fun] at hfinal; exact hfinal
+        rotR (y.ofLp 0) (rotM (y.ofLp 1 + t) (y.ofLp 2) S) by
+      rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]]
+    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 1) (hasDerivAt_rotM_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
+    simp only [comp_toSpanSingleton] at hcomp
+    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₀ gives -rotR -/
@@ -198,33 +148,16 @@ lemma fderiv_rotR'_rotM_in_e0 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
       (EuclideanSpace.single 0 1) =
     -(rotR α (rotM θ φ S)) := by
   rw [← hf_diff.lineDeriv_eq_fderiv]
-  have h0 := fun t => coord_e0_same y t
-  have h1 := coord_e0_at1 y
-  have h2 := coord_e0_at2 y
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
       (-(rotR α (rotM θ φ S))) y (EuclideanSpace.single 0 1) := by
     unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR' ((y + t • EuclideanSpace.single 0 1).ofLp 0)
+    simp_rw [fun t => show rotR' ((y + t • EuclideanSpace.single 0 1).ofLp 0)
         (rotM ((y + t • EuclideanSpace.single 0 1).ofLp 1)
              ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
-        rotR' (y.ofLp 0 + t) (rotM (y.ofLp 1) (y.ofLp 2) S) := by
-      intro t; rw [h0, h1, h2]
-    simp_rw [hsimp, hθ, hφ]
-    have hrotR' : HasDerivAt (fun α' => rotR' α' (rotM θ φ S))
-        (-(rotR α (rotM θ φ S))) α := HasDerivAt_rotR' α (rotM θ φ S)
-    have hid : HasDerivAt (fun t : ℝ => y.ofLp 0 + t) 1 0 := by
-      simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 0)
-    have hrotR'0 : HasDerivAt (fun α' => rotR' α' (rotM θ φ S))
-        (-(rotR α (rotM θ φ S))) (y.ofLp 0 + 0) := by
-      simp only [add_zero, hα]; exact hrotR'
-    have hcomp := hrotR'0.scomp 0 hid
-    simp only [one_smul] at hcomp
-    have heq_fun : ((fun α' ↦ rotR' α' (rotM θ φ S)) ∘ HAdd.hAdd (y.ofLp 0)) =
-        (fun t => rotR' (y.ofLp 0 + t) (rotM θ φ S)) := by
-      ext t; simp only [Function.comp_apply]
-    rw [heq_fun] at hcomp
-    simp only [hα] at hcomp ⊢
-    exact hcomp
+        rotR' (y.ofLp 0 + t) (rotM θ φ S) by
+      rw [coord_e0_same, coord_e0_at1, coord_e0_at2, hθ, hφ]]
+    have hrotR' := HasDerivAt_rotR' α (rotM θ φ S)
+    simpa [hα] using hasDerivAt_comp_add _ _ _ hrotR'
   exact hline.lineDeriv
 
 /-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₁ gives rotR' α (rotMθ θ φ S) -/
@@ -235,43 +168,17 @@ lemma fderiv_rotR'_rotM_in_e1 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
       (EuclideanSpace.single 1 1) =
     rotR' α (rotMθ θ φ S) := by
   rw [← hf_diff.lineDeriv_eq_fderiv]
-  have h0 := coord_e1_at0 y
-  have h1 := fun t => coord_e1_same y t
-  have h2 := coord_e1_at2 y
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
       (rotR' α (rotMθ θ φ S)) y (EuclideanSpace.single 1 1) := by
     unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR' ((y + t • EuclideanSpace.single 1 1).ofLp 0)
+    simp_rw [fun t => show rotR' ((y + t • EuclideanSpace.single 1 1).ofLp 0)
         (rotM ((y + t • EuclideanSpace.single 1 1).ofLp 1)
              ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
-        rotR' α (rotM (θ + t) φ S) := by
-      intro t; rw [h0, h1, h2, hα, hθ, hφ, add_comm]
-    simp_rw [hsimp]
-    -- rotR' α is a constant linear map, so d/dt[rotR' α (rotM (θ+t) φ S)] = rotR' α (d/dt[rotM (θ+t) φ S])
-    have hrotM : HasDerivAt (fun θ' => rotM θ' φ S) (rotMθ θ φ S) θ := hasDerivAt_rotM_θ θ φ S
-    have hR : HasFDerivAt (fun v => rotR' α v) (rotR' α) (rotM θ φ S) := ContinuousLinearMap.hasFDerivAt (rotR' α)
-    have hrotM_fderiv : HasFDerivAt (fun θ' : ℝ => rotM θ' φ S)
-        (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ θ φ S)) θ := hrotM.hasFDerivAt
-    have hcomp_inner := hR.comp θ hrotM_fderiv
-    have heq_comp : (rotR' α).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMθ θ φ S)) =
-        ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S)) := by
-      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
-    rw [heq_comp] at hcomp_inner
-    have hcomp_deriv : HasDerivAt ((fun v => rotR' α v) ∘ (fun θ' => rotM θ' φ S))
-        (rotR' α (rotMθ θ φ S)) θ := by
-      have h := hcomp_inner.hasDerivAt (x := θ)
-      simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at h
-      exact h
-    have hid : HasDerivAt (fun t : ℝ => θ + t) 1 0 := by
-      simpa using (hasDerivAt_id (0 : ℝ)).const_add θ
-    have hcomp_deriv' : HasDerivAt (fun θ' => rotR' α (rotM θ' φ S))
-        (rotR' α (rotMθ (θ + 0) φ S)) (θ + 0) := by
-      simp only [add_zero] at hcomp_deriv ⊢; exact hcomp_deriv
-    have hfinal := hcomp_deriv'.scomp 0 hid
-    simp only [one_smul, add_zero] at hfinal
-    have heq_fun : ((fun θ' => rotR' α (rotM θ' φ S)) ∘ HAdd.hAdd θ) =
-        (fun t => rotR' α (rotM (θ + t) φ S)) := by ext t; simp only [Function.comp_apply]
-    rw [heq_fun] at hfinal; exact hfinal
+        rotR' α (rotM (θ + t) φ S) by
+      rw [coord_e1_at0, coord_e1_same, coord_e1_at2, hα, hθ, hφ, add_comm]]
+    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR' α)).comp θ (hasDerivAt_rotM_θ θ φ S).hasFDerivAt
+    simp only [comp_toSpanSingleton] at hcomp
+    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₂ gives rotR' α (rotMφ θ φ S) -/
@@ -285,23 +192,14 @@ lemma fderiv_rotR'_rotM_in_e2 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S))
       (rotR' α (rotMφ θ φ S)) y (EuclideanSpace.single 2 1) := by
     unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR' ((y + t • EuclideanSpace.single 2 1).ofLp 0)
+    simp_rw [fun t => show rotR' ((y + t • EuclideanSpace.single 2 1).ofLp 0)
         (rotM ((y + t • EuclideanSpace.single 2 1).ofLp 1)
              ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
-        rotR' α (rotM θ (φ + t) S) := by
-      intro t; rw [coord_e2_at0, coord_e2_at1, coord_e2_same, hα, hθ, hφ, add_comm]
-    simp_rw [hsimp]
-    have hrotM : HasDerivAt (fun φ' => rotM θ φ' S) (rotMφ θ φ S) φ := hasDerivAt_rotM_φ θ φ S
-    have hR : HasFDerivAt (fun v => rotR' α v) (rotR' α) (rotM θ φ S) :=
-      ContinuousLinearMap.hasFDerivAt (rotR' α)
-    have hcomp := hR.comp φ hrotM.hasFDerivAt
-    have heq_comp : (rotR' α).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ θ φ S)) =
-        ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMφ θ φ S)) := by
-      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
-    rw [heq_comp] at hcomp
-    have hderiv := hcomp.hasDerivAt
-    simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at hderiv
-    exact hasDerivAt_comp_add _ _ _ hderiv
+        rotR' α (rotM θ (φ + t) S) by
+      rw [coord_e2_at0, coord_e2_at1, coord_e2_same, hα, hθ, hφ, add_comm]]
+    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR' α)).comp φ (hasDerivAt_rotM_φ θ φ S).hasFDerivAt
+    simp only [comp_toSpanSingleton] at hcomp
+    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
   exact hline.lineDeriv
 
 end GlobalTheorem

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.Calculus.FDeriv.WithLp
 import Mathlib.Analysis.Calculus.LineDeriv.Basic
 import Noperthedron.RotationDerivs
 import Noperthedron.Global.SecondPartialHelpers
+import Noperthedron.Global.Definitions
 
 /-!
 # FDeriv Helper Lemmas for Global Theorem
@@ -171,5 +172,39 @@ lemma fderiv_rotR'_rotM_in_e2 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
     exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
       ((ContinuousLinearMap.hasFDerivAt (rotR' α)).comp φ (hasDerivAt_rotM_φ θ φ S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
+
+/-!
+## fderiv of rotproj_inner in coordinate directions
+
+These combine `fderiv_inner_const` with `fderiv_rotR_rotM_in_e*` to give
+formulas for partial derivatives of rotproj_inner directly.
+-/
+
+/-- fderiv of rotproj_inner in direction e₀ -/
+lemma fderiv_rotproj_inner_in_e0 (S : ℝ³) (w : ℝ²) (y : E 3)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
+    ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+  have heq : rotproj_inner S w = fun z => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ := by
+    ext z; simp [rotproj_inner, rotprojRM]
+  rw [heq, fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
+
+/-- fderiv of rotproj_inner in direction e₁ -/
+lemma fderiv_rotproj_inner_in_e1 (S : ℝ³) (w : ℝ²) (y : E 3)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
+    ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+  have heq : rotproj_inner S w = fun z => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ := by
+    ext z; simp [rotproj_inner, rotprojRM]
+  rw [heq, fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
+
+/-- fderiv of rotproj_inner in direction e₂ -/
+lemma fderiv_rotproj_inner_in_e2 (S : ℝ³) (w : ℝ²) (y : E 3)
+    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
+    (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
+    ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+  have heq : rotproj_inner S w = fun z => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ := by
+    ext z; simp [rotproj_inner, rotprojRM]
+  rw [heq, fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
 
 end GlobalTheorem

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -64,13 +64,7 @@ lemma fderiv_rotR_any_M_in_e0 (S : Euc(3)) (y : E 3) (M : ℝ → ℝ → ℝ³ 
         (M ((y + t • EuclideanSpace.single 0 1).ofLp 1) ((y + t • EuclideanSpace.single 0 1).ofLp 2) S) =
         rotR (y.ofLp 0 + t) (M (y.ofLp 1) (y.ofLp 2) S) by
       rw [coord_e0_same, coord_e0_at1, coord_e0_at2]]
-    have hrotR : HasDerivAt (fun α => rotR α (M (y.ofLp 1) (y.ofLp 2) S)) (rotR' (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0) := HasDerivAt_rotR _ _
-    have hid : HasDerivAt (fun t : ℝ => y.ofLp 0 + t) 1 0 := by simpa using (hasDerivAt_id (0 : ℝ)).const_add (y.ofLp 0)
-    have hrotR' : HasDerivAt (fun α => rotR α (M (y.ofLp 1) (y.ofLp 2) S)) (rotR' (y.ofLp 0 + 0) (M (y.ofLp 1) (y.ofLp 2) S)) (y.ofLp 0 + 0) := by simp only [add_zero]; exact hrotR
-    have hcomp := hrotR'.scomp 0 hid
-    simp only [one_smul, add_zero] at hcomp
-    have heq_fun : ((fun α ↦ rotR α (M (y.ofLp 1) (y.ofLp 2) S)) ∘ HAdd.hAdd (y.ofLp 0)) = (fun t => rotR (y.ofLp 0 + t) (M (y.ofLp 1) (y.ofLp 2) S)) := by ext t; simp only [Function.comp_apply]
-    rw [heq_fun] at hcomp; exact hcomp
+    exact hasDerivAt_comp_add _ _ _ (HasDerivAt_rotR (y.ofLp 0) (M (y.ofLp 1) (y.ofLp 2) S))
   exact hline.lineDeriv
 
 /-- fderiv of rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S) in direction e₀ gives rotR' -/

--- a/Noperthedron/Global/RotationPartials.lean
+++ b/Noperthedron/Global/RotationPartials.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+
+import Noperthedron.Global.RotationPartials.Rotproj
+import Noperthedron.Global.RotationPartials.RotMOuter
+import Noperthedron.Global.RotationPartials.SecondPartialOuter
+import Noperthedron.Global.RotationPartials.SecondPartialInner
+
+/-!
+# Rotation Partial Derivatives
+
+This module aggregates all the rotation partial derivative lemmas:
+- `Rotproj.lean`: HasFDerivAt.rotproj_inner and supporting lemmas
+- `RotMOuter.lean`: HasFDerivAt.rotM_outer and related lemmas
+- `SecondPartialOuter.lean`: second_partial_inner_rotM_outer, rotation_partials_bounded_outer
+- `SecondPartialInner.lean`: second_partial_inner_rotM_inner, rotation_partials_bounded
+-/

--- a/Noperthedron/Global/RotationPartials/RotMOuter.lean
+++ b/Noperthedron/Global/RotationPartials/RotMOuter.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Noperthedron.Global.RotationPartials.Rotproj
+
+/-!
+# RotM Outer HasFDerivAt Lemmas
+
+This file contains:
+- `rotM'` definition
+- `Differentiable.rotM_outer`
+- **`HasFDerivAt.rotM_outer`**
+- `rotMθ'`, **`HasFDerivAt.rotMθ_outer`**
+- `rotMφ'`, **`HasFDerivAt.rotMφ_outer`**
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
+
+/-- The fderiv of rotM applied to a fixed vector P, as a function of (θ, φ). -/
+noncomputable
+def rotM' (pbar : Pose) (P : ℝ³) : ℝ² →L[ℝ] ℝ² :=
+  let M : Matrix (Fin 2) (Fin 2) ℝ := Matrix.of fun i j =>
+    match j with
+    | 0 => (rotMθ pbar.θ₂ pbar.φ₂ P) i
+    | 1 => (rotMφ pbar.θ₂ pbar.φ₂ P) i
+  M.toEuclideanLin.toContinuousLinearMap
+
+lemma Differentiable.rotM_outer (P : ℝ³) :
+    Differentiable ℝ fun (x : ℝ²) => (rotM (x 0) (x 1)) P := by
+  rw [differentiable_piLp]
+  intro i
+  fin_cases i <;> simp [rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+
+lemma HasFDerivAt.rotM_outer (pbar : Pose) (P : ℝ³) :
+    HasFDerivAt (fun x => (rotM (x.ofLp 0) (x.ofLp 1)) P) (rotM' pbar P) pbar.outerParams := by
+  sorry
+
+-- Fréchet derivative of rotMθ: columns are [rotMθθ, rotMθφ]
+noncomputable def rotMθ' (pbar : Pose) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
+  let M : Matrix (Fin 2) (Fin 2) ℝ := Matrix.of fun i j =>
+    match j with
+    | 0 => (rotMθθ pbar.θ₂ pbar.φ₂ P) i
+    | 1 => (rotMθφ pbar.θ₂ pbar.φ₂ P) i
+  LinearMap.toContinuousLinearMap (Matrix.toEuclideanLin M)
+
+lemma HasFDerivAt.rotMθ_outer (pbar : Pose) (P : ℝ³) :
+    HasFDerivAt (fun x => (rotMθ (x.ofLp 0) (x.ofLp 1)) P) (rotMθ' pbar P) pbar.outerParams := by
+  sorry
+
+-- Fréchet derivative of rotMφ: columns are [rotMθφ, rotMφφ]
+noncomputable def rotMφ' (pbar : Pose) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
+  let M : Matrix (Fin 2) (Fin 2) ℝ := Matrix.of fun i j =>
+    match j with
+    | 0 => (rotMθφ pbar.θ₂ pbar.φ₂ P) i
+    | 1 => (rotMφφ pbar.θ₂ pbar.φ₂ P) i
+  LinearMap.toContinuousLinearMap (Matrix.toEuclideanLin M)
+
+lemma HasFDerivAt.rotMφ_outer (pbar : Pose) (P : ℝ³) :
+    HasFDerivAt (fun x => (rotMφ (x.ofLp 0) (x.ofLp 1)) P) (rotMφ' pbar P) pbar.outerParams := by
+  sorry
+
+end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/Rotproj.lean
+++ b/Noperthedron/Global/RotationPartials/Rotproj.lean
@@ -57,6 +57,16 @@ lemma Differentiable.rotproj_inner (S : ℝ³) (w : ℝ²) : Differentiable ℝ 
 
 lemma HasFDerivAt.rotproj_inner (pbar : Pose) (S : ℝ³) (w : ℝ²) :
     HasFDerivAt (rotproj_inner S w) (rotproj_inner' pbar S w) pbar.innerParams := by
-  sorry
+  have z1 : HasFDerivAt (fun x => (rotprojRM (x.ofLp 1) (x.ofLp 2) (x.ofLp 0)) S) (rotprojRM' pbar S) pbar.innerParams := by
+    sorry
+
+  have step :
+    (rotproj_inner' pbar S w) = ((fderivInnerCLM ℝ
+            ((rotprojRM (pbar.innerParams.ofLp 1) (pbar.innerParams.ofLp 2) (pbar.innerParams.ofLp 0)) S, w)).comp
+        ((rotprojRM' pbar S).prod 0)) := by
+    sorry
+
+  rw [step]
+  exact HasFDerivAt.inner ℝ z1 (hasFDerivAt_const w pbar.innerParams)
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/Rotproj.lean
+++ b/Noperthedron/Global/RotationPartials/Rotproj.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Noperthedron.Global.FDerivHelpers
+import Noperthedron.Global.Definitions
+
+/-!
+# Rotproj HasFDerivAt Lemmas
+
+This file contains:
+- `Differentiable.rotprojRM`, `Differentiable.rotproj_inner`
+- `rotproj_inner'`, `rotprojRM'` definitions
+- Component lemmas for rotR, rotM applications
+- **`HasFDerivAt.rotproj_inner`** (main theorem)
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+/--
+An explicit formula for the full derivative of rotproj_inner as a function ℝ³ → ℝ
+-/
+noncomputable
+def rotproj_inner' (pbar : Pose) (S : ℝ³) (w : ℝ²) : ℝ³ →L[ℝ] ℝ :=
+  let grad : Fin 3 → ℝ := ![
+    ⟪pbar.rotR' (pbar.rotM₁ S), w⟫,
+    ⟪pbar.rotR (pbar.rotM₁θ S), w⟫,
+    ⟪pbar.rotR (pbar.rotM₁φ S), w⟫
+  ]
+  EuclideanSpace.basisFun (Fin 3) ℝ |>.toBasis.constr ℝ grad |>.toContinuousLinearMap
+
+/--
+The Fréchet derivative of `fun x => rotprojRM (x 1) (x 2) (x 0) S` at `pbar.innerParams`.
+-/
+noncomputable
+def rotprojRM' (pbar : Pose) (S : ℝ³) : ℝ³ →L[ℝ] ℝ² :=
+  let M : Matrix (Fin 2) (Fin 3) ℝ := Matrix.of fun i j =>
+    match j with
+    | 0 => (pbar.rotR' (pbar.rotM₁ S)) i
+    | 1 => (pbar.rotR (pbar.rotM₁θ S)) i
+    | 2 => (pbar.rotR (pbar.rotM₁φ S)) i
+  M.toEuclideanLin.toContinuousLinearMap
+
+lemma Differentiable.rotprojRM (S : ℝ³) :
+    Differentiable ℝ fun (x : ℝ³) ↦ (rotprojRM (x 1) (x 2) (x 0)) S := by
+  unfold _root_.rotprojRM
+  rw [differentiable_piLp]
+  intro i
+  fin_cases i <;> simp [rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+
+@[fun_prop]
+lemma Differentiable.rotproj_inner (S : ℝ³) (w : ℝ²) : Differentiable ℝ (rotproj_inner S w) :=
+  Differentiable.inner ℝ (Differentiable.rotprojRM S) (by fun_prop)
+
+lemma HasFDerivAt.rotproj_inner (pbar : Pose) (S : ℝ³) (w : ℝ²) :
+    HasFDerivAt (rotproj_inner S w) (rotproj_inner' pbar S w) pbar.innerParams := by
+  sorry
+
+end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Noperthedron.Global.RotationPartials.SecondPartialOuter
+
+/-!
+# Second Partial Inner Lemmas
+
+This file contains:
+- **`second_partial_inner_rotM_inner`** (9 cases)
+- **`rotation_partials_bounded`** (the main theorem from [SY25] Lemma 19)
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+/- [SY25] Lemma 19 (inner part) -/
+theorem second_partial_inner_rotM_inner (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 3) (y : ℝ³) :
+    |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_inner_unit S w) z) (EuclideanSpace.single i 1)) y)
+      (EuclideanSpace.single j 1)| ≤ 1 := by
+  sorry
+
+/- [SY25] Lemma 19 -/
+theorem rotation_partials_bounded (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
+    mixed_partials_bounded (rotproj_inner_unit S w) := by
+  sorry
+
+end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Noperthedron.Global.RotationPartials.RotMOuter
+import Noperthedron.Global.Basic
+
+/-!
+# Second Partial Outer Lemmas
+
+This file contains:
+- `comp_norm_le_one`, `neg_comp_norm_le_one` (private helpers)
+- **`second_partial_inner_rotM_outer`** (4 cases: θθ, θφ, φθ, φφ)
+- **`rotation_partials_bounded_outer`**
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+/- [SY25] Lemma 19 (outer part) -/
+theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 2) (y : ℝ²) :
+    |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
+      (EuclideanSpace.single j 1)| ≤ 1 := by
+  sorry
+
+theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
+    mixed_partials_bounded (rotproj_outer_unit S w) := by
+  sorry
+
+end GlobalTheorem

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -108,8 +108,7 @@ lemma fderiv_inner_const {n : ℕ} (f : E n → ℝ²) (w : ℝ²) (y : E n) (d 
     (hf : DifferentiableAt ℝ f y) :
     (fderiv ℝ (fun z => ⟪f z, w⟫) y) d = ⟪(fderiv ℝ f y) d, w⟫ := by
   have hInner := fderiv_inner_apply ℝ hf (differentiableAt_const w) d
-  have hw : HasFDerivAt (fun _ : E n ↦ w) (0 : E n →L[ℝ] ℝ²) y := hasFDerivAt_const w y
-  rw [hw.fderiv] at hInner
+  rw [(hasFDerivAt_const w y).fderiv] at hInner
   simp only [ContinuousLinearMap.zero_apply, inner_zero_right, zero_add] at hInner
   exact hInner
 

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -210,8 +210,7 @@ lemma fderiv_rotR_rotMθ_in_e1 (S : ℝ³) (y : E 3) :
     (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y)
       (EuclideanSpace.single 1 1) =
     rotR (y.ofLp 0) (rotMθθ (y.ofLp 1) (y.ofLp 2) S) := by
-  have hf_diff := differentiableAt_rotR_rotMθ S y
-  rw [← DifferentiableAt.lineDeriv_eq_fderiv hf_diff]
+  rw [← (differentiableAt_rotR_rotMθ S y).lineDeriv_eq_fderiv]
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S))
       (rotR (y.ofLp 0) (rotMθθ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 1 1) := by
     unfold HasLineDerivAt

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -35,14 +35,14 @@ pattern that appears ~30+ times in second_partial_inner_rotM_inner.
 lemma differentiableAt_rotMθ_outer (S : ℝ³) (y : E 2) :
     DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y := by
   rw [differentiableAt_piLp]; intro i
-  simp only [rotMθ, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+  simp only [rotMθ, rotMθ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
   fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
 
 /-- DifferentiableAt for rotMφ (outer, E 2) -/
 lemma differentiableAt_rotMφ_outer (S : ℝ³) (y : E 2) :
     DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y := by
   rw [differentiableAt_piLp]; intro i
-  simp only [rotMφ, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+  simp only [rotMφ, rotMφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
   fin_cases i
   · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
   · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
@@ -65,28 +65,28 @@ lemma differentiableAt_rotR'_rotM (S : ℝ³) (y : E 3) :
 lemma differentiableAt_rotR_rotMθ (S : ℝ³) (y : E 3) :
     DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
   rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθ, Matrix.toEuclideanLin_apply,
+  fin_cases i <;> (simp [rotR, rotR_mat, rotMθ, rotMθ_mat, Matrix.toEuclideanLin_apply,
     Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
 
 /-- DifferentiableAt for rotR ∘ rotMφ -/
 lemma differentiableAt_rotR_rotMφ (S : ℝ³) (y : E 3) :
     DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
   rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMφ, Matrix.toEuclideanLin_apply,
+  fin_cases i <;> (simp [rotR, rotR_mat, rotMφ, rotMφ_mat, Matrix.toEuclideanLin_apply,
     Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
 
 /-- DifferentiableAt for rotR' ∘ rotMθ -/
 lemma differentiableAt_rotR'_rotMθ (S : ℝ³) (y : E 3) :
     DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
   rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMθ, Matrix.toEuclideanLin_apply,
+  fin_cases i <;> (simp [rotR', rotR'_mat, rotMθ, rotMθ_mat, Matrix.toEuclideanLin_apply,
     Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
 
 /-- DifferentiableAt for rotR' ∘ rotMφ -/
 lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
     DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
   rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMφ, Matrix.toEuclideanLin_apply,
+  fin_cases i <;> (simp [rotR', rotR'_mat, rotMφ, rotMφ_mat, Matrix.toEuclideanLin_apply,
     Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
 
 /-!
@@ -136,71 +136,55 @@ lemma inner_bound_helper (A : ℝ³ →L[ℝ] ℝ²) (S : ℝ³) (w : ℝ²)
 These factor out the repeated `(y + t • EuclideanSpace.single k 1).ofLp j` simplifications.
 -/
 
-/-- Coordinate extraction: direction e0, coordinate 0 (moves) -/
-lemma coord_e0_same (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (0 : Fin 3) (1 : ℝ) : E 3)).ofLp 0 = y.ofLp 0 + t := by
+/-- Coordinate extraction: direction e_i, same coordinate (moves) -/
+lemma coord_ei_same (i : Fin 3) (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single i 1 : E 3)).ofLp i = y.ofLp i + t := by
   simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply, Pi.single_apply,
     ↓reduceIte, smul_eq_mul, mul_one, add_comm]
 
-/-- Coordinate extraction: direction e0, coordinate 1 (fixed) -/
+/-- Coordinate extraction: direction e_i, different coordinate j (fixed) -/
+@[simp]
+lemma coord_ei_at_other (i j : Fin 3) (hij : j ≠ i) (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single i 1 : E 3)).ofLp j = y.ofLp j := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply, Pi.single_apply, hij,
+    ↓reduceIte, smul_eq_mul, mul_zero, add_zero]
+
+/-- Shorthand for coord_ei_same 0 -/
+abbrev coord_e0_same := coord_ei_same 0
+/-- Shorthand for coord_ei_same 1 -/
+abbrev coord_e1_same := coord_ei_same 1
+/-- Shorthand for coord_ei_same 2 -/
+abbrev coord_e2_same := coord_ei_same 2
+
 @[simp]
 lemma coord_e0_at1 (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (0 : Fin 3) (1 : ℝ) : E 3)).ofLp 1 = y.ofLp 1 := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
-    Pi.single_apply, smul_eq_mul, show (1 : Fin 3) ≠ 0 from by decide,
-    ↓reduceIte, mul_zero, add_zero]
+    (y + t • (EuclideanSpace.single (0 : Fin 3) 1 : E 3)).ofLp 1 = y.ofLp 1 :=
+  coord_ei_at_other 0 1 (by decide) y t
 
-/-- Coordinate extraction: direction e0, coordinate 2 (fixed) -/
 @[simp]
 lemma coord_e0_at2 (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (0 : Fin 3) (1 : ℝ) : E 3)).ofLp 2 = y.ofLp 2 := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
-    Pi.single_apply, smul_eq_mul, show (2 : Fin 3) ≠ 0 from by decide,
-    ↓reduceIte, mul_zero, add_zero]
+    (y + t • (EuclideanSpace.single (0 : Fin 3) 1 : E 3)).ofLp 2 = y.ofLp 2 :=
+  coord_ei_at_other 0 2 (by decide) y t
 
-/-- Coordinate extraction: direction e1, coordinate 0 (fixed) -/
 @[simp]
 lemma coord_e1_at0 (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (1 : Fin 3) (1 : ℝ) : E 3)).ofLp 0 = y.ofLp 0 := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
-    Pi.single_apply, smul_eq_mul, show (0 : Fin 3) ≠ 1 from by decide,
-    ↓reduceIte, mul_zero, add_zero]
+    (y + t • (EuclideanSpace.single (1 : Fin 3) 1 : E 3)).ofLp 0 = y.ofLp 0 :=
+  coord_ei_at_other 1 0 (by decide) y t
 
-/-- Coordinate extraction: direction e1, coordinate 1 (moves) -/
-lemma coord_e1_same (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (1 : Fin 3) (1 : ℝ) : E 3)).ofLp 1 = y.ofLp 1 + t := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
-    Pi.single_apply, smul_eq_mul, mul_one, ↓reduceIte, add_comm]
-
-/-- Coordinate extraction: direction e1, coordinate 2 (fixed) -/
 @[simp]
 lemma coord_e1_at2 (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (1 : Fin 3) (1 : ℝ) : E 3)).ofLp 2 = y.ofLp 2 := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
-    Pi.single_apply, smul_eq_mul, show (2 : Fin 3) ≠ 1 from by decide,
-    ↓reduceIte, mul_zero, add_zero]
+    (y + t • (EuclideanSpace.single (1 : Fin 3) 1 : E 3)).ofLp 2 = y.ofLp 2 :=
+  coord_ei_at_other 1 2 (by decide) y t
 
-/-- Coordinate extraction: direction e2, coordinate 0 (fixed) -/
 @[simp]
 lemma coord_e2_at0 (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (2 : Fin 3) (1 : ℝ) : E 3)).ofLp 0 = y.ofLp 0 := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
-    Pi.single_apply, smul_eq_mul, show (0 : Fin 3) ≠ 2 from by decide,
-    ↓reduceIte, mul_zero, add_zero]
+    (y + t • (EuclideanSpace.single (2 : Fin 3) 1 : E 3)).ofLp 0 = y.ofLp 0 :=
+  coord_ei_at_other 2 0 (by decide) y t
 
-/-- Coordinate extraction: direction e2, coordinate 1 (fixed) -/
 @[simp]
 lemma coord_e2_at1 (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (2 : Fin 3) (1 : ℝ) : E 3)).ofLp 1 = y.ofLp 1 := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
-    Pi.single_apply, smul_eq_mul, show (1 : Fin 3) ≠ 2 from by decide,
-    ↓reduceIte, mul_zero, add_zero]
-
-/-- Coordinate extraction: direction e2, coordinate 2 (moves) -/
-lemma coord_e2_same (y : E 3) (t : ℝ) :
-    (y + t • (EuclideanSpace.single (2 : Fin 3) (1 : ℝ) : E 3)).ofLp 2 = y.ofLp 2 + t := by
-  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply, Pi.single_apply,
-    ↓reduceIte, smul_eq_mul, mul_one, add_comm]
+    (y + t • (EuclideanSpace.single (2 : Fin 3) 1 : E 3)).ofLp 1 = y.ofLp 1 :=
+  coord_ei_at_other 2 1 (by decide) y t
 
 /-!
 ## Directional fderiv lemmas for second partials

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -220,10 +220,9 @@ lemma fderiv_rotR_rotMθ_in_e1 (S : ℝ³) (y : E 3) :
         rotR (y.ofLp 0) (rotMθ (y.ofLp 1 + t) (y.ofLp 2) S) := by
       intro t; rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]
     simp_rw [hsimp]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
-        (y.ofLp 1) (hasDerivAt_rotMθ_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 1) (hasDerivAt_rotMθ_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR ∘ rotMθ in direction e2 gives rotR ∘ rotMθφ -/
@@ -239,10 +238,9 @@ lemma fderiv_rotR_rotMθ_in_e2 (S : ℝ³) (y : E 3) :
         (rotMθ ((y + t • EuclideanSpace.single 2 1).ofLp 1) ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
         rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2 + t) S) by
       rw [coord_e2_at0, coord_e2_at1, coord_e2_same, add_comm]]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
-        (y.ofLp 2) (hasDerivAt_rotMθ_φ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 2) (hasDerivAt_rotMθ_φ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR ∘ rotMφ in direction e1 gives rotR ∘ rotMθφ -/
@@ -258,10 +256,9 @@ lemma fderiv_rotR_rotMφ_in_e1 (S : ℝ³) (y : E 3) :
         (rotMφ ((y + t • EuclideanSpace.single 1 1).ofLp 1) ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
         rotR (y.ofLp 0) (rotMφ (y.ofLp 1 + t) (y.ofLp 2) S) by
       rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
-        (y.ofLp 1) (hasDerivAt_rotMφ_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 1) (hasDerivAt_rotMφ_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 /-- fderiv of rotR ∘ rotMφ in direction e2 gives rotR ∘ rotMφφ -/
@@ -277,10 +274,9 @@ lemma fderiv_rotR_rotMφ_in_e2 (S : ℝ³) (y : E 3) :
         (rotMφ ((y + t • EuclideanSpace.single 2 1).ofLp 1) ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
         rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2 + t) S) by
       rw [coord_e2_at0, coord_e2_at1, coord_e2_same, add_comm]]
-    have hcomp := (ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
-        (y.ofLp 2) (hasDerivAt_rotMφ_φ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt
-    simp only [comp_toSpanSingleton] at hcomp
-    exact hasDerivAt_comp_add _ _ _ (by simpa using hcomp.hasDerivAt)
+    exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
+      ((ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
+        (y.ofLp 2) (hasDerivAt_rotMφ_φ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt).hasDerivAt)
   exact hline.lineDeriv
 
 /-!

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -1,0 +1,376 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Mathlib.Analysis.InnerProductSpace.Calculus
+import Mathlib.Analysis.Calculus.FDeriv.WithLp
+import Mathlib.Analysis.Calculus.LineDeriv.Basic
+import Noperthedron.RotationDerivs
+import Noperthedron.Bounding.OpNorm
+
+/-!
+# Second Partial Helper Lemmas
+
+Helper lemmas for second partial derivative computations in Global.lean.
+
+These lemmas factor out repeated DifferentiableAt proofs and first partial
+computations to reduce heartbeat usage in second_partial_inner_rotM_inner.
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
+
+/-!
+## DifferentiableAt lemmas for rotation compositions
+
+These lemmas eliminate the repeated `rw [differentiableAt_piLp]; intro i; fin_cases i ...`
+pattern that appears ~30+ times in second_partial_inner_rotM_inner.
+-/
+
+/-- DifferentiableAt for rotMθ (outer, E 2) -/
+lemma differentiableAt_rotMθ_outer (S : ℝ³) (y : E 2) :
+    DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y := by
+  rw [differentiableAt_piLp]; intro i
+  simp only [rotMθ, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+  fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- DifferentiableAt for rotMφ (outer, E 2) -/
+lemma differentiableAt_rotMφ_outer (S : ℝ³) (y : E 2) :
+    DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y := by
+  rw [differentiableAt_piLp]; intro i
+  simp only [rotMφ, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+  fin_cases i
+  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
+  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+
+/-- DifferentiableAt for rotR ∘ rotM -/
+lemma differentiableAt_rotR_rotM (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
+  rw [differentiableAt_piLp]; intro i
+  fin_cases i <;> (simp [rotR, rotR_mat, rotM, rotM_mat, Matrix.toEuclideanLin_apply,
+    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- DifferentiableAt for rotR' ∘ rotM -/
+lemma differentiableAt_rotR'_rotM (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
+  rw [differentiableAt_piLp]; intro i
+  fin_cases i <;> (simp [rotR', rotR'_mat, rotM, rotM_mat, Matrix.toEuclideanLin_apply,
+    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- DifferentiableAt for rotR ∘ rotMθ -/
+lemma differentiableAt_rotR_rotMθ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
+  rw [differentiableAt_piLp]; intro i
+  fin_cases i <;> (simp [rotR, rotR_mat, rotMθ, Matrix.toEuclideanLin_apply,
+    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- DifferentiableAt for rotR ∘ rotMφ -/
+lemma differentiableAt_rotR_rotMφ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
+  rw [differentiableAt_piLp]; intro i
+  fin_cases i <;> (simp [rotR, rotR_mat, rotMφ, Matrix.toEuclideanLin_apply,
+    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- DifferentiableAt for rotR' ∘ rotMθ -/
+lemma differentiableAt_rotR'_rotMθ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
+  rw [differentiableAt_piLp]; intro i
+  fin_cases i <;> (simp [rotR', rotR'_mat, rotMθ, Matrix.toEuclideanLin_apply,
+    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- DifferentiableAt for rotR' ∘ rotMφ -/
+lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
+  rw [differentiableAt_piLp]; intro i
+  fin_cases i <;> (simp [rotR', rotR'_mat, rotMφ, Matrix.toEuclideanLin_apply,
+    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-!
+## Inner product fderiv helper
+
+This lemma factors out the repeated pattern:
+```
+have hInner := fderiv_inner_apply ℝ hf_diff (differentiableAt_const w) (e_i)
+have hw := hasFDerivAt_const w y
+rw [hw.fderiv] at hInner
+simp only [ContinuousLinearMap.zero_apply, inner_zero_right, zero_add] at hInner
+```
+
+The result is: `fderiv (⟪f·, w⟫) y d = ⟪fderiv f y d, w⟫` when `w` is constant.
+-/
+
+/-- fderiv of inner product with constant second argument equals inner product of fderiv -/
+lemma fderiv_inner_const {n : ℕ} (f : E n → ℝ²) (w : ℝ²) (y : E n) (d : E n)
+    (hf : DifferentiableAt ℝ f y) :
+    (fderiv ℝ (fun z => ⟪f z, w⟫) y) d = ⟪(fderiv ℝ f y) d, w⟫ := by
+  have hInner := fderiv_inner_apply ℝ hf (differentiableAt_const w) d
+  have hw : HasFDerivAt (fun _ : E n ↦ w) (0 : E n →L[ℝ] ℝ²) y := hasFDerivAt_const w y
+  rw [hw.fderiv] at hInner
+  simp only [ContinuousLinearMap.zero_apply, inner_zero_right, zero_add] at hInner
+  exact hInner
+
+/-!
+## Coordinate extraction lemmas
+
+These factor out the repeated `(y + t • EuclideanSpace.single k 1).ofLp j` simplifications.
+-/
+
+/-- Coordinate extraction: direction e0, coordinate 0 (moves) -/
+lemma coord_e0_same (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (0 : Fin 3) (1 : ℝ) : E 3)).ofLp 0 = y.ofLp 0 + t := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply, Pi.single_apply,
+    ↓reduceIte, smul_eq_mul, mul_one, add_comm]
+
+/-- Coordinate extraction: direction e0, coordinate 1 (fixed) -/
+@[simp]
+lemma coord_e0_at1 (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (0 : Fin 3) (1 : ℝ) : E 3)).ofLp 1 = y.ofLp 1 := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
+    Pi.single_apply, smul_eq_mul, show (1 : Fin 3) ≠ 0 from by decide,
+    ↓reduceIte, mul_zero, add_zero]
+
+/-- Coordinate extraction: direction e0, coordinate 2 (fixed) -/
+@[simp]
+lemma coord_e0_at2 (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (0 : Fin 3) (1 : ℝ) : E 3)).ofLp 2 = y.ofLp 2 := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
+    Pi.single_apply, smul_eq_mul, show (2 : Fin 3) ≠ 0 from by decide,
+    ↓reduceIte, mul_zero, add_zero]
+
+/-- Coordinate extraction: direction e1, coordinate 0 (fixed) -/
+@[simp]
+lemma coord_e1_at0 (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (1 : Fin 3) (1 : ℝ) : E 3)).ofLp 0 = y.ofLp 0 := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
+    Pi.single_apply, smul_eq_mul, show (0 : Fin 3) ≠ 1 from by decide,
+    ↓reduceIte, mul_zero, add_zero]
+
+/-- Coordinate extraction: direction e1, coordinate 1 (moves) -/
+lemma coord_e1_same (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (1 : Fin 3) (1 : ℝ) : E 3)).ofLp 1 = y.ofLp 1 + t := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
+    Pi.single_apply, smul_eq_mul, mul_one, ↓reduceIte, add_comm]
+
+/-- Coordinate extraction: direction e1, coordinate 2 (fixed) -/
+@[simp]
+lemma coord_e1_at2 (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (1 : Fin 3) (1 : ℝ) : E 3)).ofLp 2 = y.ofLp 2 := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
+    Pi.single_apply, smul_eq_mul, show (2 : Fin 3) ≠ 1 from by decide,
+    ↓reduceIte, mul_zero, add_zero]
+
+/-- Coordinate extraction: direction e2, coordinate 0 (fixed) -/
+@[simp]
+lemma coord_e2_at0 (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (2 : Fin 3) (1 : ℝ) : E 3)).ofLp 0 = y.ofLp 0 := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
+    Pi.single_apply, smul_eq_mul, show (0 : Fin 3) ≠ 2 from by decide,
+    ↓reduceIte, mul_zero, add_zero]
+
+/-- Coordinate extraction: direction e2, coordinate 1 (fixed) -/
+@[simp]
+lemma coord_e2_at1 (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (2 : Fin 3) (1 : ℝ) : E 3)).ofLp 1 = y.ofLp 1 := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply,
+    Pi.single_apply, smul_eq_mul, show (1 : Fin 3) ≠ 2 from by decide,
+    ↓reduceIte, mul_zero, add_zero]
+
+/-- Coordinate extraction: direction e2, coordinate 2 (moves) -/
+lemma coord_e2_same (y : E 3) (t : ℝ) :
+    (y + t • (EuclideanSpace.single (2 : Fin 3) (1 : ℝ) : E 3)).ofLp 2 = y.ofLp 2 + t := by
+  simp only [EuclideanSpace.single, PiLp.add_apply, PiLp.smul_apply, Pi.single_apply,
+    ↓reduceIte, smul_eq_mul, mul_one, add_comm]
+
+/-!
+## Directional fderiv lemmas for second partials
+
+These factor out the lineDeriv_eq_fderiv + HasLineDerivAt pattern.
+-/
+
+/-- Helper for deriv → fderiv composition pattern -/
+private lemma hasDerivAt_comp_add (f : ℝ → ℝ²) (f' : ℝ²) (a : ℝ) (hf : HasDerivAt f f' a) :
+    HasDerivAt (fun t => f (a + t)) f' 0 := by
+  have hid : HasDerivAt (fun t : ℝ => a + t) 1 0 := by simpa using (hasDerivAt_id 0).const_add a
+  have hf' : HasDerivAt f f' (a + 0) := by simp only [add_zero]; exact hf
+  have hcomp := hf'.scomp 0 hid
+  simp only [one_smul] at hcomp
+  exact hcomp
+
+/-- fderiv of rotR ∘ rotMθ in direction e1 gives rotR ∘ rotMθθ -/
+lemma fderiv_rotR_rotMθ_in_e1 (S : ℝ³) (y : E 3) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 1 1) =
+    rotR (y.ofLp 0) (rotMθθ (y.ofLp 1) (y.ofLp 2) S) := by
+  have hf_diff := differentiableAt_rotR_rotMθ S y
+  rw [← DifferentiableAt.lineDeriv_eq_fderiv hf_diff]
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S))
+      (rotR (y.ofLp 0) (rotMθθ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 1 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 1 1).ofLp 0)
+        (rotMθ ((y + t • EuclideanSpace.single 1 1).ofLp 1) ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
+        rotR (y.ofLp 0) (rotMθ (y.ofLp 1 + t) (y.ofLp 2) S) := by
+      intro t; rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]
+    simp_rw [hsimp]
+    have hrotMθ : HasDerivAt (fun θ' => rotMθ θ' (y.ofLp 2) S) (rotMθθ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 1) :=
+      hasDerivAt_rotMθ_θ _ _ _
+    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotMθ (y.ofLp 1) (y.ofLp 2) S) :=
+      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
+    have hcomp := hR.comp (y.ofLp 1) hrotMθ.hasFDerivAt
+    have heq : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMθθ (y.ofLp 1) (y.ofLp 2) S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMθθ (y.ofLp 1) (y.ofLp 2) S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq] at hcomp
+    have hderiv := hcomp.hasDerivAt
+    simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at hderiv
+    exact hasDerivAt_comp_add _ _ _ hderiv
+  exact hline.lineDeriv
+
+/-- fderiv of rotR ∘ rotMθ in direction e2 gives rotR ∘ rotMθφ -/
+lemma fderiv_rotR_rotMθ_in_e2 (S : ℝ³) (y : E 3) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 2 1) =
+    rotR (y.ofLp 0) (rotMθφ (y.ofLp 1) (y.ofLp 2) S) := by
+  have hf_diff := differentiableAt_rotR_rotMθ S y
+  rw [← DifferentiableAt.lineDeriv_eq_fderiv hf_diff]
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S))
+      (rotR (y.ofLp 0) (rotMθφ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 2 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 2 1).ofLp 0)
+        (rotMθ ((y + t • EuclideanSpace.single 2 1).ofLp 1) ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
+        rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2 + t) S) := by
+      intro t; rw [coord_e2_at0, coord_e2_at1, coord_e2_same, add_comm]
+    simp_rw [hsimp]
+    have hrotMθ : HasDerivAt (fun φ' => rotMθ (y.ofLp 1) φ' S) (rotMθφ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 2) :=
+      hasDerivAt_rotMθ_φ _ _ _
+    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotMθ (y.ofLp 1) (y.ofLp 2) S) :=
+      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
+    have hcomp := hR.comp (y.ofLp 2) hrotMθ.hasFDerivAt
+    have heq : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMθφ (y.ofLp 1) (y.ofLp 2) S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMθφ (y.ofLp 1) (y.ofLp 2) S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq] at hcomp
+    have hderiv := hcomp.hasDerivAt
+    simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at hderiv
+    exact hasDerivAt_comp_add _ _ _ hderiv
+  exact hline.lineDeriv
+
+/-- fderiv of rotR ∘ rotMφ in direction e1 gives rotR ∘ rotMθφ -/
+lemma fderiv_rotR_rotMφ_in_e1 (S : ℝ³) (y : E 3) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 1 1) =
+    rotR (y.ofLp 0) (rotMθφ (y.ofLp 1) (y.ofLp 2) S) := by
+  have hf_diff := differentiableAt_rotR_rotMφ S y
+  rw [← DifferentiableAt.lineDeriv_eq_fderiv hf_diff]
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S))
+      (rotR (y.ofLp 0) (rotMθφ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 1 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 1 1).ofLp 0)
+        (rotMφ ((y + t • EuclideanSpace.single 1 1).ofLp 1) ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
+        rotR (y.ofLp 0) (rotMφ (y.ofLp 1 + t) (y.ofLp 2) S) := by
+      intro t; rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]
+    simp_rw [hsimp]
+    have hrotMφ : HasDerivAt (fun θ' => rotMφ θ' (y.ofLp 2) S) (rotMθφ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 1) :=
+      hasDerivAt_rotMφ_θ _ _ _
+    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotMφ (y.ofLp 1) (y.ofLp 2) S) :=
+      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
+    have hcomp := hR.comp (y.ofLp 1) hrotMφ.hasFDerivAt
+    have heq : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMθφ (y.ofLp 1) (y.ofLp 2) S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMθφ (y.ofLp 1) (y.ofLp 2) S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq] at hcomp
+    have hderiv := hcomp.hasDerivAt
+    simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at hderiv
+    exact hasDerivAt_comp_add _ _ _ hderiv
+  exact hline.lineDeriv
+
+/-- fderiv of rotR ∘ rotMφ in direction e2 gives rotR ∘ rotMφφ -/
+lemma fderiv_rotR_rotMφ_in_e2 (S : ℝ³) (y : E 3) :
+    (fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y)
+      (EuclideanSpace.single 2 1) =
+    rotR (y.ofLp 0) (rotMφφ (y.ofLp 1) (y.ofLp 2) S) := by
+  have hf_diff := differentiableAt_rotR_rotMφ S y
+  rw [← DifferentiableAt.lineDeriv_eq_fderiv hf_diff]
+  have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S))
+      (rotR (y.ofLp 0) (rotMφφ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 2 1) := by
+    unfold HasLineDerivAt
+    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 2 1).ofLp 0)
+        (rotMφ ((y + t • EuclideanSpace.single 2 1).ofLp 1) ((y + t • EuclideanSpace.single 2 1).ofLp 2) S) =
+        rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2 + t) S) := by
+      intro t; rw [coord_e2_at0, coord_e2_at1, coord_e2_same, add_comm]
+    simp_rw [hsimp]
+    have hrotMφ : HasDerivAt (fun φ' => rotMφ (y.ofLp 1) φ' S) (rotMφφ (y.ofLp 1) (y.ofLp 2) S) (y.ofLp 2) :=
+      hasDerivAt_rotMφ_φ _ _ _
+    have hR : HasFDerivAt (fun v => rotR (y.ofLp 0) v) (rotR (y.ofLp 0)) (rotMφ (y.ofLp 1) (y.ofLp 2) S) :=
+      ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))
+    have hcomp := hR.comp (y.ofLp 2) hrotMφ.hasFDerivAt
+    have heq : (rotR (y.ofLp 0)).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMφφ (y.ofLp 1) (y.ofLp 2) S)) =
+        ContinuousLinearMap.toSpanSingleton ℝ (rotR (y.ofLp 0) (rotMφφ (y.ofLp 1) (y.ofLp 2) S)) := by
+      ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+    rw [heq] at hcomp
+    have hderiv := hcomp.hasDerivAt
+    simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at hderiv
+    exact hasDerivAt_comp_add _ _ _ hderiv
+  exact hline.lineDeriv
+
+/-!
+## A[i,j] Table for Second Partials
+
+This defines the operator A_{i,j}(α, θ, φ) such that
+  ∂²(rotproj_inner S w)/∂x_i∂x_j = ⟪A_{i,j} S, w⟫
+
+where x₀ = α, x₁ = θ, x₂ = φ.
+
+The table is:
+| i\j |    0                    |    1                  |    2                  |
+|-----|-------------------------|-----------------------|-----------------------|
+|  0  | -(rotR α ∘L rotM θ φ)   | rotR' α ∘L rotMθ θ φ  | rotR' α ∘L rotMφ θ φ  |
+|  1  | rotR' α ∘L rotMθ θ φ    | rotR α ∘L rotMθθ θ φ  | rotR α ∘L rotMθφ θ φ  |
+|  2  | rotR' α ∘L rotMφ θ φ    | rotR α ∘L rotMθφ θ φ  | rotR α ∘L rotMφφ θ φ  |
+
+All have operator norm ≤ 1 since ‖rotR‖ = ‖rotR'‖ = 1 and ‖rotM*‖ ≤ 1.
+-/
+
+/-- The operator A[i,j] for second partials of the inner rotation projection.
+    Returns the composition that appears in ⟪A S, w⟫. -/
+noncomputable def inner_second_partial_A (α θ φ : ℝ) (i j : Fin 3) : ℝ³ →L[ℝ] ℝ² :=
+  match i, j with
+  | 0, 0 => -(rotR α ∘L rotM θ φ)
+  | 0, 1 => rotR' α ∘L rotMθ θ φ
+  | 0, 2 => rotR' α ∘L rotMφ θ φ
+  | 1, 0 => rotR' α ∘L rotMθ θ φ   -- = A[0,1] by mixed partial symmetry
+  | 1, 1 => rotR α ∘L rotMθθ θ φ
+  | 1, 2 => rotR α ∘L rotMθφ θ φ
+  | 2, 0 => rotR' α ∘L rotMφ θ φ   -- = A[0,2] by mixed partial symmetry
+  | 2, 1 => rotR α ∘L rotMθφ θ φ   -- = A[1,2] by mixed partial symmetry
+  | 2, 2 => rotR α ∘L rotMφφ θ φ
+
+-- Helper for composition norm bounds
+private lemma comp_norm_le_one' {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
+    ‖A ∘L B‖ ≤ 1 :=
+  calc ‖A ∘L B‖ ≤ ‖A‖ * ‖B‖ := ContinuousLinearMap.opNorm_comp_le A B
+    _ ≤ 1 * 1 := mul_le_mul hA hB (norm_nonneg _) (by linarith)
+    _ = 1 := one_mul 1
+
+private lemma neg_comp_norm_le_one' {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
+    ‖-(A ∘L B)‖ ≤ 1 := by
+  rw [norm_neg]; exact comp_norm_le_one' hA hB
+
+/-- All A[i,j] have operator norm ≤ 1. -/
+lemma inner_second_partial_A_norm_le (α θ φ : ℝ) (i j : Fin 3) :
+    ‖inner_second_partial_A α θ φ i j‖ ≤ 1 := by
+  fin_cases i <;> fin_cases j
+  · exact neg_comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one _)) (le_of_eq (Bounding.rotM_norm_one _ _))
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMθ_norm_le_one _ _)
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMφ_norm_le_one _ _)
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMθ_norm_le_one _ _)
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMθθ_norm_le_one _ _)
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMθφ_norm_le_one _ _)
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMφ_norm_le_one _ _)
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMθφ_norm_le_one _ _)
+  · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMφφ_norm_le_one _ _)
+
+end GlobalTheorem

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -215,11 +215,10 @@ lemma fderiv_rotR_rotMθ_in_e1 (S : ℝ³) (y : E 3) :
   have hline : HasLineDerivAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S))
       (rotR (y.ofLp 0) (rotMθθ (y.ofLp 1) (y.ofLp 2) S)) y (EuclideanSpace.single 1 1) := by
     unfold HasLineDerivAt
-    have hsimp : ∀ t, rotR ((y + t • EuclideanSpace.single 1 1).ofLp 0)
+    simp_rw [fun t => show rotR ((y + t • EuclideanSpace.single 1 1).ofLp 0)
         (rotMθ ((y + t • EuclideanSpace.single 1 1).ofLp 1) ((y + t • EuclideanSpace.single 1 1).ofLp 2) S) =
-        rotR (y.ofLp 0) (rotMθ (y.ofLp 1 + t) (y.ofLp 2) S) := by
-      intro t; rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]
-    simp_rw [hsimp]
+        rotR (y.ofLp 0) (rotMθ (y.ofLp 1 + t) (y.ofLp 2) S) by
+      rw [coord_e1_at0, coord_e1_same, coord_e1_at2, add_comm]]
     exact hasDerivAt_comp_add _ _ _ (by simpa [comp_toSpanSingleton] using
       ((ContinuousLinearMap.hasFDerivAt (rotR (y.ofLp 0))).comp
         (y.ofLp 1) (hasDerivAt_rotMθ_θ (y.ofLp 1) (y.ofLp 2) S).hasFDerivAt).hasDerivAt)

--- a/Noperthedron/Pose.lean
+++ b/Noperthedron/Pose.lean
@@ -94,7 +94,7 @@ theorem is_rupert_imp_inner_in_outer (p : Pose)
 
 variable (X Y : Type) [TopologicalSpace X] [TopologicalSpace Y] {s t : Set X}
 
-example : (s ⊆ closure s) := by exact subset_closure
+example : (s ⊆ closure s) := subset_closure
 
 lemma inner_shadow_eq_img_inner (p : Pose) (S : Set ℝ³) :
     innerShadow p S = p.inner '' S := by

--- a/Noperthedron/RationalApprox/MatrixBounds.lean
+++ b/Noperthedron/RationalApprox/MatrixBounds.lean
@@ -87,7 +87,7 @@ theorem Mθ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
   let φ_ : Set.Icc (-4 : ℝ) 4 := ⟨φ, hφ⟩
 
   have h : rotMθ θ φ = clinActual rotMθ_approx θ_ φ_ := by
-    simp only [rotMθ, clinActual, rotMθ_approx,
+    simp only [rotMθ, rotMθ_mat, clinActual, rotMθ_approx,
        EmbeddingLike.apply_eq_iff_eq, θ_, φ_]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
@@ -106,7 +106,7 @@ theorem Mφ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
   let φ_ : Set.Icc (-4 : ℝ) 4 := ⟨φ, hφ⟩
 
   have h : rotMφ θ φ = clinActual rotMφ_approx θ_ φ_ := by
-    simp only [rotMφ, clinActual, rotMφ_approx,
+    simp only [rotMφ, rotMφ_mat, clinActual, rotMφ_approx,
        EmbeddingLike.apply_eq_iff_eq, θ_, φ_]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]

--- a/Noperthedron/RotationDerivs.lean
+++ b/Noperthedron/RotationDerivs.lean
@@ -35,3 +35,125 @@ theorem HasDerivAt_rotR_mat (α : ℝ) (v : ℝ²) :
 theorem HasDerivAt_rotR (α : ℝ) (v : ℝ²) :
     HasDerivAt (rotR · v) (rotR' α v) α := by
   simpa [Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail, rotR] using HasDerivAt_rotR_mat α v
+
+/-!
+## Derivatives of rotation matrices rotM, rotMθ, rotMφ w.r.t. angles
+
+These are needed for computing first and second partial derivatives of rotproj functions.
+Each proves HasDerivAt for the rotation matrix (or its derivative) applied to a fixed vector S.
+-/
+
+/-- Derivative of rotM w.r.t. θ gives rotMθ -/
+lemma hasDerivAt_rotM_θ (θ φ : ℝ) (S : ℝ³) :
+    HasDerivAt (fun θ' => rotM θ' φ S) (rotMθ θ φ S) θ := by
+  have h_f : (fun θ' => rotM θ' φ S) = (fun θ' => !₂[-Real.sin θ' * S 0 + Real.cos θ' * S 1,
+      -Real.cos θ' * Real.cos φ * S 0 - Real.sin θ' * Real.cos φ * S 1 + Real.sin φ * S 2]) := by
+    ext θ' i; fin_cases i <;> (simp [rotM, rotM_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  have h_f' : rotMθ θ φ S = !₂[-Real.cos θ * S 0 - Real.sin θ * S 1,
+      Real.sin θ * Real.cos φ * S 0 - Real.cos θ * Real.cos φ * S 1] := by
+    ext i; fin_cases i <;> (simp [rotMθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
+  · have h : deriv (fun x => -Real.sin x * S 0 + Real.cos x * S 1) θ = -Real.cos θ * S 0 - Real.sin θ * S 1 := by simp; ring
+    rw [← h]; exact DifferentiableAt.hasDerivAt (by fun_prop)
+  · have h1 : HasDerivAt (fun x => -Real.cos x * Real.cos φ * S 0) (Real.sin θ * Real.cos φ * S 0) θ := by
+      have := (Real.hasDerivAt_cos θ).neg.mul_const (Real.cos φ * S 0)
+      simp only [neg_neg, mul_assoc] at this ⊢; exact this
+    have h2 : HasDerivAt (fun x => Real.sin x * Real.cos φ * S 1) (Real.cos θ * Real.cos φ * S 1) θ := by
+      have := (Real.hasDerivAt_sin θ).mul_const (Real.cos φ * S 1)
+      simp only [mul_assoc] at this ⊢; exact this
+    have h3 : HasDerivAt (fun _ : ℝ => Real.sin φ * S 2) 0 θ := hasDerivAt_const _ _
+    convert (h1.sub h2).add h3 using 1; ring
+
+/-- Derivative of rotM w.r.t. φ gives rotMφ -/
+lemma hasDerivAt_rotM_φ (θ φ : ℝ) (S : ℝ³) :
+    HasDerivAt (fun φ' => rotM θ φ' S) (rotMφ θ φ S) φ := by
+  have h_f : (fun φ' => rotM θ φ' S) = (fun φ' => !₂[-Real.sin θ * S 0 + Real.cos θ * S 1,
+      -Real.cos θ * Real.cos φ' * S 0 - Real.sin θ * Real.cos φ' * S 1 + Real.sin φ' * S 2]) := by
+    ext φ' i; fin_cases i <;> (simp [rotM, rotM_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  have h_f' : rotMφ θ φ S = !₂[(0 : ℝ),
+      Real.cos θ * Real.sin φ * S 0 + Real.sin θ * Real.sin φ * S 1 + Real.cos φ * S 2] := by
+    ext i; fin_cases i <;> (simp [rotMφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
+  · exact hasDerivAt_const _ _
+  · have h1 : HasDerivAt (fun x => -Real.cos θ * Real.cos x * S 0) (Real.cos θ * Real.sin φ * S 0) φ := by
+      have := ((Real.hasDerivAt_cos φ).const_mul (-Real.cos θ)).mul_const (S 0)
+      simp only [neg_mul, mul_neg, neg_neg, mul_assoc] at this ⊢; exact this
+    have h2 : HasDerivAt (fun x => Real.sin θ * Real.cos x * S 1) (-Real.sin θ * Real.sin φ * S 1) φ := by
+      have := ((Real.hasDerivAt_cos φ).const_mul (Real.sin θ)).mul_const (S 1)
+      simp only [neg_mul, mul_neg, mul_assoc] at this ⊢; exact this
+    have h3 : HasDerivAt (fun x => Real.sin x * S 2) (Real.cos φ * S 2) φ := (Real.hasDerivAt_sin φ).mul_const (S 2)
+    convert (h1.sub h2).add h3 using 1; ring
+
+/-- Derivative of rotMθ w.r.t. θ gives rotMθθ -/
+lemma hasDerivAt_rotMθ_θ (θ φ : ℝ) (S : ℝ³) :
+    HasDerivAt (fun θ' => rotMθ θ' φ S) (rotMθθ θ φ S) θ := by
+  have h_f : (fun θ' => rotMθ θ' φ S) = (fun θ' => !₂[-Real.cos θ' * S 0 - Real.sin θ' * S 1,
+      Real.sin θ' * Real.cos φ * S 0 - Real.cos θ' * Real.cos φ * S 1]) := by
+    ext θ' i; fin_cases i <;> (simp [rotMθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  have h_f' : rotMθθ θ φ S = !₂[Real.sin θ * S 0 - Real.cos θ * S 1,
+      Real.cos θ * Real.cos φ * S 0 + Real.sin θ * Real.cos φ * S 1] := by
+    ext i; fin_cases i <;> (simp [rotMθθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
+  · have h : deriv (fun x => -Real.cos x * S 0 - Real.sin x * S 1) θ = Real.sin θ * S 0 - Real.cos θ * S 1 := by simp
+    rw [← h]; exact DifferentiableAt.hasDerivAt (by fun_prop)
+  · have h1 : HasDerivAt (fun x => Real.sin x * Real.cos φ * S 0) (Real.cos θ * Real.cos φ * S 0) θ := by
+      have := (Real.hasDerivAt_sin θ).mul_const (Real.cos φ * S 0); simp only [mul_assoc] at this ⊢; exact this
+    have h2 : HasDerivAt (fun x => Real.cos x * Real.cos φ * S 1) (-Real.sin θ * Real.cos φ * S 1) θ := by
+      have := (Real.hasDerivAt_cos θ).mul_const (Real.cos φ * S 1); simp only [mul_assoc, neg_mul] at this ⊢; exact this
+    convert h1.sub h2 using 1; ring
+
+/-- Derivative of rotMθ w.r.t. φ gives rotMθφ -/
+lemma hasDerivAt_rotMθ_φ (θ φ : ℝ) (S : ℝ³) :
+    HasDerivAt (fun φ' => rotMθ θ φ' S) (rotMθφ θ φ S) φ := by
+  have h_f : (fun φ' => rotMθ θ φ' S) = (fun φ' => !₂[-Real.cos θ * S 0 - Real.sin θ * S 1,
+      Real.sin θ * Real.cos φ' * S 0 - Real.cos θ * Real.cos φ' * S 1]) := by
+    ext φ' i; fin_cases i <;> (simp [rotMθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  have h_f' : rotMθφ θ φ S = !₂[(0 : ℝ), -Real.sin θ * Real.sin φ * S 0 + Real.cos θ * Real.sin φ * S 1] := by
+    ext i; fin_cases i <;> simp [rotMθφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
+  rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
+  · exact hasDerivAt_const _ _
+  · have h1 : HasDerivAt (fun x => Real.sin θ * Real.cos x * S 0) (-Real.sin θ * Real.sin φ * S 0) φ := by
+      have := ((Real.hasDerivAt_cos φ).const_mul (Real.sin θ)).mul_const (S 0)
+      simp only [neg_mul, mul_neg, mul_assoc] at this ⊢; exact this
+    have h2 : HasDerivAt (fun x => Real.cos θ * Real.cos x * S 1) (-Real.cos θ * Real.sin φ * S 1) φ := by
+      have := ((Real.hasDerivAt_cos φ).const_mul (Real.cos θ)).mul_const (S 1)
+      simp only [neg_mul, mul_neg, mul_assoc] at this ⊢; exact this
+    convert h1.sub h2 using 1; ring
+
+/-- Derivative of rotMφ w.r.t. θ gives rotMθφ -/
+lemma hasDerivAt_rotMφ_θ (θ φ : ℝ) (S : ℝ³) :
+    HasDerivAt (fun θ' => rotMφ θ' φ S) (rotMθφ θ φ S) θ := by
+  have h_f : (fun θ' => rotMφ θ' φ S) = (fun θ' => !₂[(0 : ℝ),
+      Real.cos θ' * Real.sin φ * S 0 + Real.sin θ' * Real.sin φ * S 1 + Real.cos φ * S 2]) := by
+    ext θ' i; fin_cases i <;> (simp [rotMφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  have h_f' : rotMθφ θ φ S = !₂[(0 : ℝ), -Real.sin θ * Real.sin φ * S 0 + Real.cos θ * Real.sin φ * S 1] := by
+    ext i; fin_cases i <;> simp [rotMθφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
+  rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
+  · exact hasDerivAt_const _ _
+  · have h1 : HasDerivAt (fun x => Real.cos x * Real.sin φ * S 0) (-Real.sin θ * Real.sin φ * S 0) θ := by
+      have := (Real.hasDerivAt_cos θ).mul_const (Real.sin φ * S 0); simp only [mul_assoc, neg_mul] at this ⊢; exact this
+    have h2 : HasDerivAt (fun x => Real.sin x * Real.sin φ * S 1) (Real.cos θ * Real.sin φ * S 1) θ := by
+      have := (Real.hasDerivAt_sin θ).mul_const (Real.sin φ * S 1); simp only [mul_assoc] at this ⊢; exact this
+    have h3 : HasDerivAt (fun _ : ℝ => Real.cos φ * S 2) 0 θ := hasDerivAt_const _ _
+    convert (h1.add h2).add h3 using 1; ring
+
+/-- Derivative of rotMφ w.r.t. φ gives rotMφφ -/
+lemma hasDerivAt_rotMφ_φ (θ φ : ℝ) (S : ℝ³) :
+    HasDerivAt (fun φ' => rotMφ θ φ' S) (rotMφφ θ φ S) φ := by
+  have h_f : (fun φ' => rotMφ θ φ' S) = (fun φ' => !₂[(0 : ℝ),
+      Real.cos θ * Real.sin φ' * S 0 + Real.sin θ * Real.sin φ' * S 1 + Real.cos φ' * S 2]) := by
+    ext φ' i; fin_cases i <;> (simp [rotMφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  have h_f' : rotMφφ θ φ S = !₂[(0 : ℝ),
+      Real.cos θ * Real.cos φ * S 0 + Real.sin θ * Real.cos φ * S 1 - Real.sin φ * S 2] := by
+    ext i; fin_cases i <;> (simp [rotMφφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+  rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
+  · exact hasDerivAt_const _ _
+  · have h1 : HasDerivAt (fun x => Real.cos θ * Real.sin x * S 0) (Real.cos θ * Real.cos φ * S 0) φ := by
+      have := ((Real.hasDerivAt_sin φ).const_mul (Real.cos θ)).mul_const (S 0)
+      simp only [mul_assoc] at this ⊢; exact this
+    have h2 : HasDerivAt (fun x => Real.sin θ * Real.sin x * S 1) (Real.sin θ * Real.cos φ * S 1) φ := by
+      have := ((Real.hasDerivAt_sin φ).const_mul (Real.sin θ)).mul_const (S 1)
+      simp only [mul_assoc] at this ⊢; exact this
+    have h3 : HasDerivAt (fun x => Real.cos x * S 2) (-Real.sin φ * S 2) φ := by
+      have := (Real.hasDerivAt_cos φ).mul_const (S 2); simp only [neg_mul] at this ⊢; exact this
+    convert (h1.add h2).add h3 using 1; ring

--- a/Noperthedron/RotationDerivs.lean
+++ b/Noperthedron/RotationDerivs.lean
@@ -65,14 +65,11 @@ lemma hasDerivAt_rotM_θ (θ φ : ℝ) (S : ℝ³) :
       Real.sin θ * Real.cos φ * S 0 - Real.cos θ * Real.cos φ * S 1] := by
     ext i; fin_cases i <;> (simp [rotMθ, rotMθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
-  · have := hasDerivAt_sin_cos_lincomb (-S 0) (S 1) θ
-    simp only [neg_mul] at this
-    convert this using 1
+  · convert hasDerivAt_sin_cos_lincomb (-S 0) (S 1) θ using 1
     · funext; ring
     · ring
-  · have h12 := hasDerivAt_cos_sin_lincomb (-Real.cos φ * S 0) (-Real.cos φ * S 1) θ
-    have h3 : HasDerivAt (fun _ : ℝ => Real.sin φ * S 2) 0 θ := hasDerivAt_const _ _
-    convert h12.add h3 using 1
+  · convert (hasDerivAt_cos_sin_lincomb (-Real.cos φ * S 0) (-Real.cos φ * S 1) θ).add
+        (hasDerivAt_const θ (Real.sin φ * S 2)) using 1
     · funext; simp only [Pi.add_apply]; ring
     · ring
 
@@ -87,8 +84,7 @@ lemma hasDerivAt_rotM_φ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> (simp [rotMφ, rotMφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have := hasDerivAt_cos_sin_lincomb (-Real.cos θ * S 0 - Real.sin θ * S 1) (S 2) φ
-    convert this using 1
+  · convert hasDerivAt_cos_sin_lincomb (-Real.cos θ * S 0 - Real.sin θ * S 1) (S 2) φ using 1
     · funext; ring
     · ring
 
@@ -102,13 +98,10 @@ lemma hasDerivAt_rotMθ_θ (θ φ : ℝ) (S : ℝ³) :
       Real.cos θ * Real.cos φ * S 0 + Real.sin θ * Real.cos φ * S 1] := by
     ext i; fin_cases i <;> (simp [rotMθθ, rotMθθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
-  · have := hasDerivAt_cos_sin_lincomb (-S 0) (-S 1) θ
-    simp only [neg_neg, neg_mul] at this
-    convert this using 1
+  · convert hasDerivAt_cos_sin_lincomb (-S 0) (-S 1) θ using 1
     · funext; ring
     · ring
-  · have := hasDerivAt_sin_cos_lincomb (Real.cos φ * S 0) (-Real.cos φ * S 1) θ
-    convert this using 1
+  · convert hasDerivAt_sin_cos_lincomb (Real.cos φ * S 0) (-Real.cos φ * S 1) θ using 1
     · funext; ring
     · ring
 
@@ -122,8 +115,7 @@ lemma hasDerivAt_rotMθ_φ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> simp [rotMθφ, rotMθφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have := hasDerivAt_cos_sin_lincomb (Real.sin θ * S 0 - Real.cos θ * S 1) 0 φ
-    convert this using 1
+  · convert hasDerivAt_cos_sin_lincomb (Real.sin θ * S 0 - Real.cos θ * S 1) 0 φ using 1
     · funext; ring
     · ring
 
@@ -137,9 +129,8 @@ lemma hasDerivAt_rotMφ_θ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> simp [rotMθφ, rotMθφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have h12 := hasDerivAt_cos_sin_lincomb (Real.sin φ * S 0) (Real.sin φ * S 1) θ
-    have h3 : HasDerivAt (fun _ : ℝ => Real.cos φ * S 2) 0 θ := hasDerivAt_const _ _
-    convert h12.add h3 using 1
+  · convert (hasDerivAt_cos_sin_lincomb (Real.sin φ * S 0) (Real.sin φ * S 1) θ).add
+        (hasDerivAt_const θ (Real.cos φ * S 2)) using 1
     · funext; simp only [Pi.add_apply]; ring
     · ring
 
@@ -154,7 +145,6 @@ lemma hasDerivAt_rotMφ_φ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> (simp [rotMφφ, rotMφφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have := hasDerivAt_sin_cos_lincomb (Real.cos θ * S 0 + Real.sin θ * S 1) (S 2) φ
-    convert this using 1
+  · convert hasDerivAt_sin_cos_lincomb (Real.cos θ * S 0 + Real.sin θ * S 1) (S 2) φ using 1
     · funext; ring
     · ring

--- a/Noperthedron/RotationDerivs.lean
+++ b/Noperthedron/RotationDerivs.lean
@@ -70,14 +70,11 @@ lemma hasDerivAt_rotM_θ (θ φ : ℝ) (S : ℝ³) :
     convert this using 1
     · funext; ring
     · ring
-  · have h1 : HasDerivAt (fun x => -Real.cos x * Real.cos φ * S 0) (Real.sin θ * Real.cos φ * S 0) θ := by
-      have := (Real.hasDerivAt_cos θ).neg.mul_const (Real.cos φ * S 0)
-      simp only [neg_neg, mul_assoc] at this ⊢; exact this
-    have h2 : HasDerivAt (fun x => Real.sin x * Real.cos φ * S 1) (Real.cos θ * Real.cos φ * S 1) θ := by
-      have := (Real.hasDerivAt_sin θ).mul_const (Real.cos φ * S 1)
-      simp only [mul_assoc] at this ⊢; exact this
+  · have h12 := hasDerivAt_cos_sin_lincomb (-Real.cos φ * S 0) (-Real.cos φ * S 1) θ
     have h3 : HasDerivAt (fun _ : ℝ => Real.sin φ * S 2) 0 θ := hasDerivAt_const _ _
-    convert (h1.sub h2).add h3 using 1; ring
+    convert h12.add h3 using 1
+    · funext; simp only [Pi.add_apply]; ring
+    · ring
 
 /-- Derivative of rotM w.r.t. φ gives rotMφ -/
 lemma hasDerivAt_rotM_φ (θ φ : ℝ) (S : ℝ³) :
@@ -90,14 +87,10 @@ lemma hasDerivAt_rotM_φ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> (simp [rotMφ, rotMφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have h1 : HasDerivAt (fun x => -Real.cos θ * Real.cos x * S 0) (Real.cos θ * Real.sin φ * S 0) φ := by
-      have := ((Real.hasDerivAt_cos φ).const_mul (-Real.cos θ)).mul_const (S 0)
-      simp only [neg_mul, mul_neg, neg_neg, mul_assoc] at this ⊢; exact this
-    have h2 : HasDerivAt (fun x => Real.sin θ * Real.cos x * S 1) (-Real.sin θ * Real.sin φ * S 1) φ := by
-      have := ((Real.hasDerivAt_cos φ).const_mul (Real.sin θ)).mul_const (S 1)
-      simp only [neg_mul, mul_neg, mul_assoc] at this ⊢; exact this
-    have h3 : HasDerivAt (fun x => Real.sin x * S 2) (Real.cos φ * S 2) φ := (Real.hasDerivAt_sin φ).mul_const (S 2)
-    convert (h1.sub h2).add h3 using 1; ring
+  · have := hasDerivAt_cos_sin_lincomb (-Real.cos θ * S 0 - Real.sin θ * S 1) (S 2) φ
+    convert this using 1
+    · funext; ring
+    · ring
 
 /-- Derivative of rotMθ w.r.t. θ gives rotMθθ -/
 lemma hasDerivAt_rotMθ_θ (θ φ : ℝ) (S : ℝ³) :
@@ -114,11 +107,10 @@ lemma hasDerivAt_rotMθ_θ (θ φ : ℝ) (S : ℝ³) :
     convert this using 1
     · funext; ring
     · ring
-  · have h1 : HasDerivAt (fun x => Real.sin x * Real.cos φ * S 0) (Real.cos θ * Real.cos φ * S 0) θ := by
-      have := (Real.hasDerivAt_sin θ).mul_const (Real.cos φ * S 0); simp only [mul_assoc] at this ⊢; exact this
-    have h2 : HasDerivAt (fun x => Real.cos x * Real.cos φ * S 1) (-Real.sin θ * Real.cos φ * S 1) θ := by
-      have := (Real.hasDerivAt_cos θ).mul_const (Real.cos φ * S 1); simp only [mul_assoc, neg_mul] at this ⊢; exact this
-    convert h1.sub h2 using 1; ring
+  · have := hasDerivAt_sin_cos_lincomb (Real.cos φ * S 0) (-Real.cos φ * S 1) θ
+    convert this using 1
+    · funext; ring
+    · ring
 
 /-- Derivative of rotMθ w.r.t. φ gives rotMθφ -/
 lemma hasDerivAt_rotMθ_φ (θ φ : ℝ) (S : ℝ³) :
@@ -130,13 +122,10 @@ lemma hasDerivAt_rotMθ_φ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> simp [rotMθφ, rotMθφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have h1 : HasDerivAt (fun x => Real.sin θ * Real.cos x * S 0) (-Real.sin θ * Real.sin φ * S 0) φ := by
-      have := ((Real.hasDerivAt_cos φ).const_mul (Real.sin θ)).mul_const (S 0)
-      simp only [neg_mul, mul_neg, mul_assoc] at this ⊢; exact this
-    have h2 : HasDerivAt (fun x => Real.cos θ * Real.cos x * S 1) (-Real.cos θ * Real.sin φ * S 1) φ := by
-      have := ((Real.hasDerivAt_cos φ).const_mul (Real.cos θ)).mul_const (S 1)
-      simp only [neg_mul, mul_neg, mul_assoc] at this ⊢; exact this
-    convert h1.sub h2 using 1; ring
+  · have := hasDerivAt_cos_sin_lincomb (Real.sin θ * S 0 - Real.cos θ * S 1) 0 φ
+    convert this using 1
+    · funext; ring
+    · ring
 
 /-- Derivative of rotMφ w.r.t. θ gives rotMθφ -/
 lemma hasDerivAt_rotMφ_θ (θ φ : ℝ) (S : ℝ³) :
@@ -148,12 +137,11 @@ lemma hasDerivAt_rotMφ_θ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> simp [rotMθφ, rotMθφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have h1 : HasDerivAt (fun x => Real.cos x * Real.sin φ * S 0) (-Real.sin θ * Real.sin φ * S 0) θ := by
-      have := (Real.hasDerivAt_cos θ).mul_const (Real.sin φ * S 0); simp only [mul_assoc, neg_mul] at this ⊢; exact this
-    have h2 : HasDerivAt (fun x => Real.sin x * Real.sin φ * S 1) (Real.cos θ * Real.sin φ * S 1) θ := by
-      have := (Real.hasDerivAt_sin θ).mul_const (Real.sin φ * S 1); simp only [mul_assoc] at this ⊢; exact this
+  · have h12 := hasDerivAt_cos_sin_lincomb (Real.sin φ * S 0) (Real.sin φ * S 1) θ
     have h3 : HasDerivAt (fun _ : ℝ => Real.cos φ * S 2) 0 θ := hasDerivAt_const _ _
-    convert (h1.add h2).add h3 using 1; ring
+    convert h12.add h3 using 1
+    · funext; simp only [Pi.add_apply]; ring
+    · ring
 
 /-- Derivative of rotMφ w.r.t. φ gives rotMφφ -/
 lemma hasDerivAt_rotMφ_φ (θ φ : ℝ) (S : ℝ³) :
@@ -166,12 +154,7 @@ lemma hasDerivAt_rotMφ_φ (θ φ : ℝ) (S : ℝ³) :
     ext i; fin_cases i <;> (simp [rotMφφ, rotMφφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
-  · have h1 : HasDerivAt (fun x => Real.cos θ * Real.sin x * S 0) (Real.cos θ * Real.cos φ * S 0) φ := by
-      have := ((Real.hasDerivAt_sin φ).const_mul (Real.cos θ)).mul_const (S 0)
-      simp only [mul_assoc] at this ⊢; exact this
-    have h2 : HasDerivAt (fun x => Real.sin θ * Real.sin x * S 1) (Real.sin θ * Real.cos φ * S 1) φ := by
-      have := ((Real.hasDerivAt_sin φ).const_mul (Real.sin θ)).mul_const (S 1)
-      simp only [mul_assoc] at this ⊢; exact this
-    have h3 : HasDerivAt (fun x => Real.cos x * S 2) (-Real.sin φ * S 2) φ := by
-      have := (Real.hasDerivAt_cos φ).mul_const (S 2); simp only [neg_mul] at this ⊢; exact this
-    convert (h1.add h2).add h3 using 1; ring
+  · have := hasDerivAt_sin_cos_lincomb (Real.cos θ * S 0 + Real.sin θ * S 1) (S 2) φ
+    convert this using 1
+    · funext; ring
+    · ring

--- a/Noperthedron/RotationDerivs.lean
+++ b/Noperthedron/RotationDerivs.lean
@@ -51,7 +51,7 @@ lemma hasDerivAt_rotM_θ (θ φ : ℝ) (S : ℝ³) :
     ext θ' i; fin_cases i <;> (simp [rotM, rotM_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   have h_f' : rotMθ θ φ S = !₂[-Real.cos θ * S 0 - Real.sin θ * S 1,
       Real.sin θ * Real.cos φ * S 0 - Real.cos θ * Real.cos φ * S 1] := by
-    ext i; fin_cases i <;> (simp [rotMθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext i; fin_cases i <;> (simp [rotMθ, rotMθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · have h : deriv (fun x => -Real.sin x * S 0 + Real.cos x * S 1) θ = -Real.cos θ * S 0 - Real.sin θ * S 1 := by simp; ring
     rw [← h]; exact DifferentiableAt.hasDerivAt (by fun_prop)
@@ -72,7 +72,7 @@ lemma hasDerivAt_rotM_φ (θ φ : ℝ) (S : ℝ³) :
     ext φ' i; fin_cases i <;> (simp [rotM, rotM_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   have h_f' : rotMφ θ φ S = !₂[(0 : ℝ),
       Real.cos θ * Real.sin φ * S 0 + Real.sin θ * Real.sin φ * S 1 + Real.cos φ * S 2] := by
-    ext i; fin_cases i <;> (simp [rotMφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext i; fin_cases i <;> (simp [rotMφ, rotMφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
   · have h1 : HasDerivAt (fun x => -Real.cos θ * Real.cos x * S 0) (Real.cos θ * Real.sin φ * S 0) φ := by
@@ -89,10 +89,10 @@ lemma hasDerivAt_rotMθ_θ (θ φ : ℝ) (S : ℝ³) :
     HasDerivAt (fun θ' => rotMθ θ' φ S) (rotMθθ θ φ S) θ := by
   have h_f : (fun θ' => rotMθ θ' φ S) = (fun θ' => !₂[-Real.cos θ' * S 0 - Real.sin θ' * S 1,
       Real.sin θ' * Real.cos φ * S 0 - Real.cos θ' * Real.cos φ * S 1]) := by
-    ext θ' i; fin_cases i <;> (simp [rotMθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext θ' i; fin_cases i <;> (simp [rotMθ, rotMθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   have h_f' : rotMθθ θ φ S = !₂[Real.sin θ * S 0 - Real.cos θ * S 1,
       Real.cos θ * Real.cos φ * S 0 + Real.sin θ * Real.cos φ * S 1] := by
-    ext i; fin_cases i <;> (simp [rotMθθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext i; fin_cases i <;> (simp [rotMθθ, rotMθθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · have h : deriv (fun x => -Real.cos x * S 0 - Real.sin x * S 1) θ = Real.sin θ * S 0 - Real.cos θ * S 1 := by simp
     rw [← h]; exact DifferentiableAt.hasDerivAt (by fun_prop)
@@ -107,9 +107,9 @@ lemma hasDerivAt_rotMθ_φ (θ φ : ℝ) (S : ℝ³) :
     HasDerivAt (fun φ' => rotMθ θ φ' S) (rotMθφ θ φ S) φ := by
   have h_f : (fun φ' => rotMθ θ φ' S) = (fun φ' => !₂[-Real.cos θ * S 0 - Real.sin θ * S 1,
       Real.sin θ * Real.cos φ' * S 0 - Real.cos θ * Real.cos φ' * S 1]) := by
-    ext φ' i; fin_cases i <;> (simp [rotMθ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext φ' i; fin_cases i <;> (simp [rotMθ, rotMθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   have h_f' : rotMθφ θ φ S = !₂[(0 : ℝ), -Real.sin θ * Real.sin φ * S 0 + Real.cos θ * Real.sin φ * S 1] := by
-    ext i; fin_cases i <;> simp [rotMθφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
+    ext i; fin_cases i <;> simp [rotMθφ, rotMθφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
   · have h1 : HasDerivAt (fun x => Real.sin θ * Real.cos x * S 0) (-Real.sin θ * Real.sin φ * S 0) φ := by
@@ -125,9 +125,9 @@ lemma hasDerivAt_rotMφ_θ (θ φ : ℝ) (S : ℝ³) :
     HasDerivAt (fun θ' => rotMφ θ' φ S) (rotMθφ θ φ S) θ := by
   have h_f : (fun θ' => rotMφ θ' φ S) = (fun θ' => !₂[(0 : ℝ),
       Real.cos θ' * Real.sin φ * S 0 + Real.sin θ' * Real.sin φ * S 1 + Real.cos φ * S 2]) := by
-    ext θ' i; fin_cases i <;> (simp [rotMφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext θ' i; fin_cases i <;> (simp [rotMφ, rotMφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   have h_f' : rotMθφ θ φ S = !₂[(0 : ℝ), -Real.sin θ * Real.sin φ * S 0 + Real.cos θ * Real.sin φ * S 1] := by
-    ext i; fin_cases i <;> simp [rotMθφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
+    ext i; fin_cases i <;> simp [rotMθφ, rotMθφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
   · have h1 : HasDerivAt (fun x => Real.cos x * Real.sin φ * S 0) (-Real.sin θ * Real.sin φ * S 0) θ := by
@@ -142,10 +142,10 @@ lemma hasDerivAt_rotMφ_φ (θ φ : ℝ) (S : ℝ³) :
     HasDerivAt (fun φ' => rotMφ θ φ' S) (rotMφφ θ φ S) φ := by
   have h_f : (fun φ' => rotMφ θ φ' S) = (fun φ' => !₂[(0 : ℝ),
       Real.cos θ * Real.sin φ' * S 0 + Real.sin θ * Real.sin φ' * S 1 + Real.cos φ' * S 2]) := by
-    ext φ' i; fin_cases i <;> (simp [rotMφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext φ' i; fin_cases i <;> (simp [rotMφ, rotMφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   have h_f' : rotMφφ θ φ S = !₂[(0 : ℝ),
       Real.cos θ * Real.cos φ * S 0 + Real.sin θ * Real.cos φ * S 1 - Real.sin φ * S 2] := by
-    ext i; fin_cases i <;> (simp [rotMφφ, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
+    ext i; fin_cases i <;> (simp [rotMφφ, rotMφφ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
   · exact hasDerivAt_const _ _
   · have h1 : HasDerivAt (fun x => Real.cos θ * Real.sin x * S 0) (Real.cos θ * Real.cos φ * S 0) φ := by

--- a/Noperthedron/RotationDerivs.lean
+++ b/Noperthedron/RotationDerivs.lean
@@ -37,12 +37,12 @@ theorem HasDerivAt_rotR_mat (α : ℝ) (v : ℝ²) :
     HasDerivAt (fun α ↦ !₂[Real.cos α * v 0 + -(Real.sin α * v 1), Real.sin α * v 0 + Real.cos α * v 1])
     !₂[-(Real.sin α * v 0) + -(Real.cos α * v 1), Real.cos α * v 0 + -(Real.sin α * v 1)] α := by
   refine hasDerivAt_lp2 ?_ ?_
-  · let f (x : ℝ) := Real.cos x * v 0 + -(Real.sin x * v 1)
-    rw [show -(Real.sin α * v 0) + -(Real.cos α * v 1) = deriv f α by simp [f]]
-    refine DifferentiableAt.hasDerivAt ?_; simp
-  · let f (x : ℝ) := Real.sin x * v 0 + Real.cos x * v 1
-    rw [show (Real.cos α * v 0) + -(Real.sin α * v 1) = deriv f α by simp [f]]
-    refine DifferentiableAt.hasDerivAt ?_; simp
+  · convert hasDerivAt_cos_sin_lincomb (v 0) (-v 1) α using 1
+    · funext; ring
+    · ring
+  · convert hasDerivAt_sin_cos_lincomb (v 0) (v 1) α using 1
+    · funext; ring
+    · ring
 
 theorem HasDerivAt_rotR (α : ℝ) (v : ℝ²) :
     HasDerivAt (rotR · v) (rotR' α v) α := by

--- a/Noperthedron/RotationDerivs.lean
+++ b/Noperthedron/RotationDerivs.lean
@@ -21,6 +21,18 @@ lemma hasDerivAt_lp2 {f g : ℝ → ℝ} {f' g' t : ℝ}
   let lpmap := WithLp.linearEquiv 2 ℝ (Fin 2 → ℝ) |>.symm.toContinuousLinearMap
   exact (hasDerivAt_clm_pi2 f g f' g' t lpmap) hf hg
 
+/-- Derivative of a * sin t + b * cos t is a * cos t - b * sin t -/
+lemma hasDerivAt_sin_cos_lincomb (a b t : ℝ) :
+    HasDerivAt (fun x => a * Real.sin x + b * Real.cos x) (a * Real.cos t - b * Real.sin t) t := by
+  convert (Real.hasDerivAt_sin t).const_mul a |>.add ((Real.hasDerivAt_cos t).const_mul b) using 1
+  ring
+
+/-- Derivative of a * cos t + b * sin t is -a * sin t + b * cos t -/
+lemma hasDerivAt_cos_sin_lincomb (a b t : ℝ) :
+    HasDerivAt (fun x => a * Real.cos x + b * Real.sin x) (-a * Real.sin t + b * Real.cos t) t := by
+  convert (Real.hasDerivAt_cos t).const_mul a |>.add ((Real.hasDerivAt_sin t).const_mul b) using 1
+  ring
+
 theorem HasDerivAt_rotR_mat (α : ℝ) (v : ℝ²) :
     HasDerivAt (fun α ↦ !₂[Real.cos α * v 0 + -(Real.sin α * v 1), Real.sin α * v 0 + Real.cos α * v 1])
     !₂[-(Real.sin α * v 0) + -(Real.cos α * v 1), Real.cos α * v 0 + -(Real.sin α * v 1)] α := by
@@ -53,8 +65,11 @@ lemma hasDerivAt_rotM_θ (θ φ : ℝ) (S : ℝ³) :
       Real.sin θ * Real.cos φ * S 0 - Real.cos θ * Real.cos φ * S 1] := by
     ext i; fin_cases i <;> (simp [rotMθ, rotMθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
-  · have h : deriv (fun x => -Real.sin x * S 0 + Real.cos x * S 1) θ = -Real.cos θ * S 0 - Real.sin θ * S 1 := by simp; ring
-    rw [← h]; exact DifferentiableAt.hasDerivAt (by fun_prop)
+  · have := hasDerivAt_sin_cos_lincomb (-S 0) (S 1) θ
+    simp only [neg_mul] at this
+    convert this using 1
+    · funext; ring
+    · ring
   · have h1 : HasDerivAt (fun x => -Real.cos x * Real.cos φ * S 0) (Real.sin θ * Real.cos φ * S 0) θ := by
       have := (Real.hasDerivAt_cos θ).neg.mul_const (Real.cos φ * S 0)
       simp only [neg_neg, mul_assoc] at this ⊢; exact this
@@ -94,8 +109,11 @@ lemma hasDerivAt_rotMθ_θ (θ φ : ℝ) (S : ℝ³) :
       Real.cos θ * Real.cos φ * S 0 + Real.sin θ * Real.cos φ * S 1] := by
     ext i; fin_cases i <;> (simp [rotMθθ, rotMθθ_mat, Matrix.toEuclideanLin_apply, Matrix.vecHead, Matrix.vecTail]; try ring)
   rw [h_f, h_f']; refine hasDerivAt_lp2 ?_ ?_
-  · have h : deriv (fun x => -Real.cos x * S 0 - Real.sin x * S 1) θ = Real.sin θ * S 0 - Real.cos θ * S 1 := by simp
-    rw [← h]; exact DifferentiableAt.hasDerivAt (by fun_prop)
+  · have := hasDerivAt_cos_sin_lincomb (-S 0) (-S 1) θ
+    simp only [neg_neg, neg_mul] at this
+    convert this using 1
+    · funext; ring
+    · ring
   · have h1 : HasDerivAt (fun x => Real.sin x * Real.cos φ * S 0) (Real.cos θ * Real.cos φ * S 0) θ := by
       have := (Real.hasDerivAt_sin θ).mul_const (Real.cos φ * S 0); simp only [mul_assoc] at this ⊢; exact this
     have h2 : HasDerivAt (fun x => Real.cos x * Real.cos φ * S 1) (-Real.sin θ * Real.cos φ * S 1) θ := by


### PR DESCRIPTION
## Summary

- Add foundation infrastructure for Lemma 19 (rotation partials bounded)
- All subsequent PRs build on these shared helpers

## Changes

**Modified files:**
- `Noperthedron/Basic.lean`: rotMθθ, rotMθφ, rotMφφ definitions
- `Noperthedron/Bounding/OpNorm.lean`: norm bounds for rotR', rotMθ, rotMφ, second partials
- `Noperthedron/RotationDerivs.lean`: HasDerivAt lemmas for rotM/rotMθ/rotMφ w.r.t. θ,φ

**New files:**
- `Noperthedron/Global/Definitions.lean`: rotproj_inner, rotproj_outer definitions
- `Noperthedron/Global/FDerivHelpers.lean`: fderiv helper lemmas for rotR, rotR', rotM in coordinate directions (e0, e1, e2)
- `Noperthedron/Global/SecondPartialHelpers.lean`: DifferentiableAt helpers, coordinate extraction lemmas, `inner_bound_helper`, `comp_norm_le_one`, `hasDerivAt_comp_add` (public for reuse)
- `Noperthedron/Global/RotationPartials/`: implementation files for subsequent PRs

## Test plan

- [x] `lake build Noperthedron.Global` passes