### PR TITLE
Implement second_partial_inner_rotM_outer and rotation_partials_bounded_outer

### DIFF
--- a/Noperthedron/Global/RotationPartials/RotMOuter.lean
+++ b/Noperthedron/Global/RotationPartials/RotMOuter.lean
@@ -73,7 +73,7 @@ def rotM' (pbar : Pose) (P : ℝ³) : ℝ² →L[ℝ] ℝ² :=
     | 1 => (rotMφ pbar.θ₂ pbar.φ₂ P) i
   M.toEuclideanLin.toContinuousLinearMap
 
-private lemma rotM'_apply (pbar : Pose) (P : ℝ³) (d : ℝ²) (i : Fin 2) :
+lemma rotM'_apply (pbar : Pose) (P : ℝ³) (d : ℝ²) (i : Fin 2) :
     (rotM' pbar P d) i = d 0 * (rotMθ pbar.θ₂ pbar.φ₂ P) i + d 1 * (rotMφ pbar.θ₂ pbar.φ₂ P) i := by
   simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply,
     Matrix.mulVec, dotProduct, Fin.sum_univ_two, Matrix.of_apply, Fin.isValue]
@@ -185,7 +185,7 @@ noncomputable def rotMθ' (pbar : Pose) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
     | 1 => (rotMθφ pbar.θ₂ pbar.φ₂ P) i
   LinearMap.toContinuousLinearMap (Matrix.toEuclideanLin M)
 
-private lemma rotMθ'_apply (pbar : Pose) (P : ℝ³) (d : ℝ²) (i : Fin 2) :
+lemma rotMθ'_apply (pbar : Pose) (P : ℝ³) (d : ℝ²) (i : Fin 2) :
     (rotMθ' pbar P d) i = d 0 * (rotMθθ pbar.θ₂ pbar.φ₂ P) i + d 1 * (rotMθφ pbar.θ₂ pbar.φ₂ P) i := by
   simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply,
     Matrix.mulVec, dotProduct, Fin.sum_univ_two, Matrix.of_apply, Fin.isValue]
@@ -275,7 +275,7 @@ noncomputable def rotMφ' (pbar : Pose) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
     | 1 => (rotMφφ pbar.θ₂ pbar.φ₂ P) i
   LinearMap.toContinuousLinearMap (Matrix.toEuclideanLin M)
 
-private lemma rotMφ'_apply (pbar : Pose) (P : ℝ³) (d : ℝ²) (i : Fin 2) :
+lemma rotMφ'_apply (pbar : Pose) (P : ℝ³) (d : ℝ²) (i : Fin 2) :
     (rotMφ' pbar P d) i = d 0 * (rotMθφ pbar.θ₂ pbar.φ₂ P) i + d 1 * (rotMφφ pbar.θ₂ pbar.φ₂ P) i := by
   simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply,
     Matrix.mulVec, dotProduct, Fin.sum_univ_two, Matrix.of_apply, Fin.isValue]

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -159,8 +159,7 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
     exact nth_partial_div_const j _ ‖S‖ y (hg_diff y)
   rw [hscale]
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-  rw [hAeq]
-  exact inner_bound_helper A S w w_unit hAnorm
+  simpa [f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -62,7 +62,9 @@ private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
@@ -70,7 +72,9 @@ private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -78,7 +82,9 @@ private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -86,7 +92,9 @@ private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -94,7 +102,9 @@ private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -102,7 +112,9 @@ private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 /-!
 ## Private lemma: second partials as inner products

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -5,28 +5,310 @@ Authors: Cameron Freer
 -/
 import Noperthedron.Global.RotationPartials.RotMOuter
 import Noperthedron.Global.Basic
+import Noperthedron.Global.SecondPartialHelpers
 
 /-!
 # Second Partial Outer Lemmas
 
 This file contains:
-- `comp_norm_le_one`, `neg_comp_norm_le_one` (private helpers)
+- `outer_second_partial_A` definition
 - **`second_partial_inner_rotM_outer`** (4 cases: θθ, θφ, φθ, φφ)
 - **`rotation_partials_bounded_outer`**
+
+Helper lemmas `comp_norm_le_one`, `neg_comp_norm_le_one`, `inner_bound_helper` are imported
+from SecondPartialHelpers.
 -/
 
 open scoped RealInnerProductSpace
 
 namespace GlobalTheorem
 
+private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
+
+/-!
+## The A[i,j] table for outer second partials
+
+For the outer function (2 variables: θ, φ), we have:
+| i\j |    0 (θ)        |    1 (φ)        |
+|-----|-----------------|-----------------|
+|  0  | rotMθθ θ φ      | rotMθφ θ φ      |
+|  1  | rotMθφ θ φ      | rotMφφ θ φ      |
+
+All have operator norm ≤ 1.
+-/
+
+/-- The operator A[i,j] for second partials of the outer rotation projection. -/
+noncomputable def outer_second_partial_A (θ φ : ℝ) (i j : Fin 2) : ℝ³ →L[ℝ] ℝ² :=
+  match i, j with
+  | 0, 0 => rotMθθ θ φ
+  | 0, 1 => rotMθφ θ φ
+  | 1, 0 => rotMθφ θ φ  -- = A[0,1] by mixed partial symmetry
+  | 1, 1 => rotMφφ θ φ
+
+/-- All A[i,j] have operator norm ≤ 1 for outer partials. -/
+lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
+    ‖outer_second_partial_A θ φ i j‖ ≤ 1 := by
+  fin_cases i <;> fin_cases j
+  · exact Bounding.rotMθθ_norm_le_one θ φ
+  · exact Bounding.rotMθφ_norm_le_one θ φ
+  · exact Bounding.rotMθφ_norm_le_one θ φ
+  · exact Bounding.rotMφφ_norm_le_one θ φ
+
+/-!
+## Private lemma: second partials as inner products
+
+The second partial derivatives of ⟪rotM θ φ S, w⟫ equal ⟪A S, w⟫
+where A ∈ {rotMθθ, rotMθφ, rotMφφ} with ‖A‖ ≤ 1.
+-/
+
+private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i j : Fin 2) :
+    ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
+      nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
+  -- Each pair (i, j) corresponds to a specific second derivative matrix
+  -- (0, 0) → rotMθθ, (0, 1) → rotMθφ, (1, 0) → rotMθφ, (1, 1) → rotMφφ
+  fin_cases i <;> fin_cases j
+  · -- (0, 0): uses rotMθθ
+    refine ⟨rotMθθ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθθ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    -- First partial in direction e₀ gives ⟪rotMθ S, w⟫
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMθ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
+      have h := HasFDerivAt.rotMθ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMθ]
+    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    rfl
+  · -- (0, 1): uses rotMθφ
+    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMφ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
+      have h := HasFDerivAt.rotMφ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMφ]
+    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    rfl
+  · -- (1, 0): uses rotMθφ
+    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMθ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
+      have h := HasFDerivAt.rotMθ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMθ]
+    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    rfl
+  · -- (1, 1): uses rotMφφ
+    refine ⟨rotMφφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMφφ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMφ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
+      have h := HasFDerivAt.rotMφ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMφ]
+    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    rfl
+
+/-!
+## Main theorems
+-/
+
 /- [SY25] Lemma 19 (outer part) -/
 theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 2) (y : ℝ²) :
     |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
       (EuclideanSpace.single j 1)| ≤ 1 := by
-  sorry
+  -- Handle the case when ‖S‖ = 0
+  by_cases hS : ‖S‖ = 0
+  · -- When ‖S‖ = 0, the function is constantly 0
+    have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
+    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]
+    norm_num
+  · -- When ‖S‖ ≠ 0, use the helper lemma
+    have S_pos : ‖S‖ > 0 := (norm_nonneg S).lt_of_ne' hS
+    -- The function is rotproj_outer_unit S w = (fun y => ⟪rotM (y 0) (y 1) S, w⟫) / ‖S‖
+    -- The second partial of f/c is (second partial of f) / c
+    have heq : rotproj_outer_unit S w = fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫ / ‖S‖ := by
+      ext z; rfl
+    -- Rewrite using nth_partial definition
+    have hgoal : (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
+        (EuclideanSpace.single j 1) = nth_partial j (nth_partial i (rotproj_outer_unit S w)) y := by
+      unfold nth_partial
+      rfl
+    rw [hgoal]
+    -- The second partial of f/‖S‖ is (second partial of f) / ‖S‖
+    let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
+    have hfun : rotproj_outer_unit S w = ‖S‖⁻¹ • f := by
+      ext z; simp [smul_eq_mul, div_eq_inv_mul, rotproj_outer_unit, f]
+    -- f is smooth
+    have hf_smooth : ContDiff ℝ ⊤ f := by
+      apply ContDiff.inner ℝ _ contDiff_const
+      rw [contDiff_piLp]; intro k
+      simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+      fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
+    have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
+    -- nth_partial of c⁻¹ • f = c⁻¹ • nth_partial f
+    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f := by
+      ext z
+      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
+      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hf_diff z)]
+      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
+    have hg : ContDiff ℝ ⊤ (nth_partial i f) := by
+      unfold nth_partial
+      exact hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const
+    have hg_diff : Differentiable ℝ (nth_partial i f) := hg.differentiable WithTop.top_ne_zero
+    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) := by
+      ext z
+      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
+      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hg_diff z)]
+      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
+    -- Combine scaling
+    have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
+        nth_partial j (nth_partial i f) y / ‖S‖ := by
+      rw [hfun, hpartial_smul, hpartial_smul2]
+      simp only [Pi.smul_apply, smul_eq_mul, div_eq_inv_mul]
+    rw [hscale]
+    -- Get the existence of A with norm bound
+    -- Note: swap indices to match nth_partial j (nth_partial i f)
+    obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
+    -- Now apply the bound
+    rw [hAeq]
+    exact inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_outer_unit S w) := by
-  sorry
+  intro x i j
+  -- Rewrite the goal in terms of fderiv
+  have hgoal : (nth_partial i <| nth_partial j <| rotproj_outer_unit S w) x =
+      (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single j 1)) x)
+        (EuclideanSpace.single i 1) := by
+    unfold nth_partial
+    rfl
+  rw [hgoal]
+  -- Swap indices to match second_partial_inner_rotM_outer's convention
+  exact second_partial_inner_rotM_outer S w_unit j i x
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -42,7 +42,7 @@ noncomputable def outer_second_partial_A (θ φ : ℝ) (i j : Fin 2) : ℝ³ →
   match i, j with
   | 0, 0 => rotMθθ θ φ
   | 0, 1 => rotMθφ θ φ
-  | 1, 0 => rotMθφ θ φ  -- = A[0,1] by mixed partial symmetry
+  | 1, 0 => rotMθφ θ φ
   | 1, 1 => rotMφφ θ φ
 
 /-- All A[i,j] have operator norm ≤ 1 for outer partials. -/
@@ -55,183 +55,107 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
   · exact Bounding.rotMφφ_norm_le_one θ φ
 
 /-!
-## Private lemma: second partials as inner products
+## Helper lemmas: first partials of ⟪rotM S, w⟫ in coordinate directions
+-/
 
-The second partial derivatives of ⟪rotM θ φ S, w⟫ equal ⟪A S, w⟫
-where A ∈ {rotMθθ, rotMθφ, rotMφφ} with ‖A‖ ≤ 1.
+private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
+    (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+      (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
+  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+  rw [this]; congr 1; ext i
+  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (1 : Fin 2) ≠ 0 from by decide]
+  ring
+
+private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
+    (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+      (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
+  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+  rw [this]; congr 1; ext i
+  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (0 : Fin 2) ≠ 1 from by decide]
+  ring
+
+/-!
+## Private lemma: second partials as inner products
 -/
 
 private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i j : Fin 2) :
     ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
       nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
-  -- Each pair (i, j) corresponds to a specific second derivative matrix
-  -- (0, 0) → rotMθθ, (0, 1) → rotMθφ, (1, 0) → rotMθφ, (1, 1) → rotMφφ
   fin_cases i <;> fin_cases j
-  · -- (0, 0): uses rotMθθ
+  · -- (0, 0): rotMθθ
     refine ⟨rotMθθ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθθ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    -- First partial in direction e₀ gives ⟪rotMθ S, w⟫
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMθ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
-      have h := HasFDerivAt.rotMθ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMθ]
-    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
-    rfl
-  · -- (0, 1): uses rotMθφ
+    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+    ring
+  · -- (0, 1): rotMθφ
     refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMφ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
-      have h := HasFDerivAt.rotMφ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMφ]
-    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
-    rfl
-  · -- (1, 0): uses rotMθφ
+    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+    ring
+  · -- (1, 0): rotMθφ
     refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMθ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
-      have h := HasFDerivAt.rotMθ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMθ]
-    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
-    rfl
-  · -- (1, 1): uses rotMφφ
+    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+    ring
+  · -- (1, 1): rotMφφ
     refine ⟨rotMφφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMφφ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMφ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
-      have h := HasFDerivAt.rotMφ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMφ]
-    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
-    rfl
+    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+    ring
 
 /-!
 ## Main theorems
@@ -241,74 +165,38 @@ private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i 
 theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 2) (y : ℝ²) :
     |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
       (EuclideanSpace.single j 1)| ≤ 1 := by
-  -- Handle the case when ‖S‖ = 0
   by_cases hS : ‖S‖ = 0
-  · -- When ‖S‖ = 0, the function is constantly 0
-    have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
-    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]
-    norm_num
-  · -- When ‖S‖ ≠ 0, use the helper lemma
-    have S_pos : ‖S‖ > 0 := (norm_nonneg S).lt_of_ne' hS
-    -- The function is rotproj_outer_unit S w = (fun y => ⟪rotM (y 0) (y 1) S, w⟫) / ‖S‖
-    -- The second partial of f/c is (second partial of f) / c
-    have heq : rotproj_outer_unit S w = fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫ / ‖S‖ := by
-      ext z; rfl
-    -- Rewrite using nth_partial definition
-    have hgoal : (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
-        (EuclideanSpace.single j 1) = nth_partial j (nth_partial i (rotproj_outer_unit S w)) y := by
-      unfold nth_partial
-      rfl
-    rw [hgoal]
-    -- The second partial of f/‖S‖ is (second partial of f) / ‖S‖
+  · have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
+    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]; norm_num
+  · show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
     let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
     have hfun : rotproj_outer_unit S w = ‖S‖⁻¹ • f := by
       ext z; simp [smul_eq_mul, div_eq_inv_mul, rotproj_outer_unit, f]
-    -- f is smooth
     have hf_smooth : ContDiff ℝ ⊤ f := by
       apply ContDiff.inner ℝ _ contDiff_const
       rw [contDiff_piLp]; intro k
       simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
       fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
     have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
-    -- nth_partial of c⁻¹ • f = c⁻¹ • nth_partial f
-    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f := by
-      ext z
-      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
-      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hf_diff z)]
-      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
     have hg : ContDiff ℝ ⊤ (nth_partial i f) := by
       unfold nth_partial
       exact hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const
     have hg_diff : Differentiable ℝ (nth_partial i f) := hg.differentiable WithTop.top_ne_zero
-    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) := by
-      ext z
-      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
-      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hg_diff z)]
-      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
-    -- Combine scaling
+    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f :=
+      funext fun z => nth_partial_const_smul i _ _ z (hf_diff z)
+    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) :=
+      funext fun z => nth_partial_const_smul j _ _ z (hg_diff z)
     have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
         nth_partial j (nth_partial i f) y / ‖S‖ := by
       rw [hfun, hpartial_smul, hpartial_smul2]
       simp only [Pi.smul_apply, smul_eq_mul, div_eq_inv_mul]
     rw [hscale]
-    -- Get the existence of A with norm bound
-    -- Note: swap indices to match nth_partial j (nth_partial i f)
     obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-    -- Now apply the bound
     rw [hAeq]
     exact inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
-    mixed_partials_bounded (rotproj_outer_unit S w) := by
-  intro x i j
-  -- Rewrite the goal in terms of fderiv
-  have hgoal : (nth_partial i <| nth_partial j <| rotproj_outer_unit S w) x =
-      (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single j 1)) x)
-        (EuclideanSpace.single i 1) := by
-    unfold nth_partial
-    rfl
-  rw [hgoal]
-  -- Swap indices to match second_partial_inner_rotM_outer's convention
-  exact second_partial_inner_rotM_outer S w_unit j i x
+    mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>
+  second_partial_inner_rotM_outer S w_unit j i x
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -11,12 +11,9 @@ import Noperthedron.Global.SecondPartialHelpers
 # Second Partial Outer Lemmas
 
 This file contains:
-- `outer_second_partial_A` definition
+- `outer_second_partial_A` definition and norm bound
 - **`second_partial_inner_rotM_outer`** (4 cases: θθ, θφ, φθ, φφ)
 - **`rotation_partials_bounded_outer`**
-
-Helper lemmas `comp_norm_le_one`, `neg_comp_norm_le_one`, `inner_bound_helper` are imported
-from SecondPartialHelpers.
 -/
 
 open scoped RealInnerProductSpace
@@ -85,77 +82,84 @@ private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
   ring
 
 /-!
+## Helper lemmas: second partials of ⟪rotMθ/rotMφ S, w⟫ via fderiv
+-/
+
+private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+  ring
+
+private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+  ring
+
+private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+  ring
+
+private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+  ring
+
+/-!
 ## Private lemma: second partials as inner products
 -/
 
 private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i j : Fin 2) :
     ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
       nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
-  fin_cases i <;> fin_cases j
-  · -- (0, 0): rotMθθ
-    refine ⟨rotMθθ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθθ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+  refine ⟨outer_second_partial_A (x.ofLp 0) (x.ofLp 1) i j,
+    outer_second_partial_A_norm_le _ _ _ _, ?_⟩
+  let θ := x.ofLp 0; let φ := x.ofLp 1
+  fin_cases i <;> fin_cases j <;> unfold nth_partial
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-    ring
-  · -- (0, 1): rotMθφ
-    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e0]
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-    ring
-  · -- (1, 0): rotMθφ
-    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e0]
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-    ring
-  · -- (1, 1): rotMφφ
-    refine ⟨rotMφφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMφφ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e1]
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-    ring
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e1]
 
 /-!
 ## Main theorems
@@ -165,35 +169,26 @@ private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i 
 theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 2) (y : ℝ²) :
     |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
       (EuclideanSpace.single j 1)| ≤ 1 := by
-  by_cases hS : ‖S‖ = 0
-  · have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
-    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]; norm_num
-  · show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
-    let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-    have hfun : rotproj_outer_unit S w = ‖S‖⁻¹ • f := by
-      ext z; simp [smul_eq_mul, div_eq_inv_mul, rotproj_outer_unit, f]
-    have hf_smooth : ContDiff ℝ ⊤ f := by
-      apply ContDiff.inner ℝ _ contDiff_const
-      rw [contDiff_piLp]; intro k
-      simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
-      fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
-    have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
-    have hg : ContDiff ℝ ⊤ (nth_partial i f) := by
-      unfold nth_partial
-      exact hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const
-    have hg_diff : Differentiable ℝ (nth_partial i f) := hg.differentiable WithTop.top_ne_zero
-    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f :=
-      funext fun z => nth_partial_const_smul i _ _ z (hf_diff z)
-    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) :=
-      funext fun z => nth_partial_const_smul j _ _ z (hg_diff z)
-    have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
-        nth_partial j (nth_partial i f) y / ‖S‖ := by
-      rw [hfun, hpartial_smul, hpartial_smul2]
-      simp only [Pi.smul_apply, smul_eq_mul, div_eq_inv_mul]
-    rw [hscale]
-    obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-    rw [hAeq]
-    exact inner_bound_helper A S w w_unit hAnorm
+  show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
+  let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
+  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by
+    ext z; simp [rotproj_outer_unit, f]
+  have hf_smooth : ContDiff ℝ ⊤ f := by
+    apply ContDiff.inner ℝ _ contDiff_const
+    rw [contDiff_piLp]; intro k
+    simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+    fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
+  have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
+  have hg_diff : Differentiable ℝ (nth_partial i f) :=
+    (hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero
+  have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
+      nth_partial j (nth_partial i f) y / ‖S‖ := by
+    rw [hfun, funext fun z => nth_partial_div_const i f ‖S‖ z (hf_diff z)]
+    exact nth_partial_div_const j _ ‖S‖ y (hg_diff y)
+  rw [hscale]
+  obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
+  rw [hAeq]
+  exact inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -50,90 +50,65 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
       Bounding.rotMθφ_norm_le_one, Bounding.rotMφφ_norm_le_one]
 
 /-!
-## Helper lemmas: first partials of ⟪rotM S, w⟫ in coordinate directions
+## Helper lemmas: partials of ⟪rotM S, w⟫ in coordinate directions
 -/
+
+private lemma outerPbar (x : E 2) : (⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ : Pose).outerParams = x := by
+  ext i; fin_cases i <;> rfl
 
 private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
-  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-  rw [this]; congr 1; ext i
-  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (1 : Fin 2) ≠ 0 from by decide]
-  ring
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
+    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
+      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
+  congr 1; ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
-  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-  rw [this]; congr 1; ext i
-  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (0 : Fin 2) ≠ 1 from by decide]
-  ring
-
-/-!
-## Helper lemmas: second partials of ⟪rotMθ/rotMφ S, w⟫ via fderiv
--/
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
+    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
+      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
+  congr 1; ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
+    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-  ring
+  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
+    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-  ring
+  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
+    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-  ring
+  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
+    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-  ring
+  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
 
 /-!
 ## Private lemma: second partials as inner products

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -54,7 +54,7 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
 -/
 
 private lemma outerPbar (x : E 2) : (⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ : Pose).outerParams = x := by
-  ext i; fin_cases i <;> rfl
+  ext i; fin_cases i <;> simp [Pose.outerParams]
 
 private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
@@ -139,19 +139,17 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       (EuclideanSpace.single j 1)| ≤ 1 := by
   show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
   let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := rfl
   have hf_smooth : ContDiff ℝ ⊤ f := by
     apply ContDiff.inner ℝ _ contDiff_const
     rw [contDiff_piLp]; intro k
     simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
     fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
-  have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
-  have hg_diff : Differentiable ℝ (nth_partial i f) :=
-    (hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero
   have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
       nth_partial j (nth_partial i f) y / ‖S‖ := by
-    rw [hfun, funext fun z => nth_partial_div_const i f ‖S‖ z (hf_diff z)]
-    simpa using nth_partial_div_const j (nth_partial i f) ‖S‖ y (hg_diff y)
+    rw [show rotproj_outer_unit S w = fun z => f z / ‖S‖ from rfl,
+      funext fun z => nth_partial_div_const i f ‖S‖ z (hf_smooth.differentiable WithTop.top_ne_zero z)]
+    exact nth_partial_div_const j _ ‖S‖ y
+      ((hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero y)
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
   simpa [hscale, f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -56,65 +56,53 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
 private lemma outerPbar (x : E 2) : (⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ : Pose).outerParams = x := by
   ext i; fin_cases i <;> simp [Pose.outerParams]
 
+private lemma fderiv_rotM_outer_eq (S : ℝ³) (x : E 2) :
+    fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) x = rotM' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
+  (outerPbar x ▸ HasFDerivAt.rotM_outer _ S).fderiv
+
+private lemma fderiv_rotMθ_outer_eq (S : ℝ³) (x : E 2) :
+    fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
+  (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv
+
+private lemma fderiv_rotMφ_outer_eq (S : ℝ³) (x : E 2) :
+    fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
+  (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv
+
 private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
-    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
-      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y), fderiv_rotM_outer_eq S y]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
-    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
-      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y), fderiv_rotM_outer_eq S y]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
-    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x), fderiv_rotMθ_outer_eq S x]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
-    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x), fderiv_rotMθ_outer_eq S x]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
-    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x), fderiv_rotMφ_outer_eq S x]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
-    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x), fderiv_rotMφ_outer_eq S x]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 /-!
 ## Private lemma: second partials as inner products

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -62,8 +62,7 @@ private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
@@ -71,8 +70,7 @@ private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -80,8 +78,7 @@ private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -89,8 +86,7 @@ private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -98,8 +94,7 @@ private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -107,8 +102,7 @@ private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 /-!
 ## Private lemma: second partials as inner products
@@ -119,20 +113,9 @@ private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i 
       nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
   refine ⟨outer_second_partial_A (x.ofLp 0) (x.ofLp 1) i j,
     outer_second_partial_A_norm_le _ _ _ _, ?_⟩
-  let θ := x.ofLp 0; let φ := x.ofLp 1
-  fin_cases i <;> fin_cases j <;> unfold nth_partial
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e0]
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e0]
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e1]
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e1]
+  fin_cases i <;> fin_cases j <;> unfold nth_partial <;>
+    simp [outer_second_partial_A, fderiv_rotM_inner_e0, fderiv_rotM_inner_e1,
+      fderiv_rotMθ_inner_e0, fderiv_rotMθ_inner_e1, fderiv_rotMφ_inner_e0, fderiv_rotMφ_inner_e1]
 
 /-!
 ## Main theorems
@@ -144,7 +127,7 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       (EuclideanSpace.single j 1)| ≤ 1 := by
   show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
   let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by ext; rfl
+  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := rfl
   have hf_smooth : ContDiff ℝ ⊤ f := by
     apply ContDiff.inner ℝ _ contDiff_const
     rw [contDiff_piLp]; intro k
@@ -156,10 +139,9 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
   have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
       nth_partial j (nth_partial i f) y / ‖S‖ := by
     rw [hfun, funext fun z => nth_partial_div_const i f ‖S‖ z (hf_diff z)]
-    exact nth_partial_div_const j _ ‖S‖ y (hg_diff y)
-  rw [hscale]
+    simpa using nth_partial_div_const j (nth_partial i f) ‖S‖ y (hg_diff y)
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-  simpa [f, hAeq] using inner_bound_helper A S w w_unit hAnorm
+  simpa [hscale, f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -45,11 +45,9 @@ noncomputable def outer_second_partial_A (θ φ : ℝ) (i j : Fin 2) : ℝ³ →
 /-- All A[i,j] have operator norm ≤ 1 for outer partials. -/
 lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
     ‖outer_second_partial_A θ φ i j‖ ≤ 1 := by
-  fin_cases i <;> fin_cases j
-  · exact Bounding.rotMθθ_norm_le_one θ φ
-  · exact Bounding.rotMθφ_norm_le_one θ φ
-  · exact Bounding.rotMθφ_norm_le_one θ φ
-  · exact Bounding.rotMφφ_norm_le_one θ φ
+  fin_cases i <;> fin_cases j <;>
+    simp [outer_second_partial_A, Bounding.rotMθθ_norm_le_one,
+      Bounding.rotMθφ_norm_le_one, Bounding.rotMφφ_norm_le_one]
 
 /-!
 ## Helper lemmas: first partials of ⟪rotM S, w⟫ in coordinate directions
@@ -171,8 +169,7 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       (EuclideanSpace.single j 1)| ≤ 1 := by
   show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
   let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by
-    ext z; simp [rotproj_outer_unit, f]
+  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by ext; rfl
   have hf_smooth : ContDiff ℝ ⊤ f := by
     apply ContDiff.inner ℝ _ contDiff_const
     rw [contDiff_piLp]; intro k


### PR DESCRIPTION
## Summary

Implements [SY25] Lemma 19 (outer part) for the 2-variable case (θ, φ).

## Contents

- `outer_second_partial_A`: operator table {rotMθθ, rotMθφ, rotMφφ}
- `second_partial_rotM_outer_eq`: existential helper (4 cases)
- `second_partial_inner_rotM_outer`: direct bound on second partials
- `rotation_partials_bounded_outer`: mixed_partials_bounded for outer function

Uses shared helpers from SecondPartialHelpers and HasFDerivAt lemmas from RotMOuter.

## Depends on

- PR #20 (global-foundation)
- PR #22 (global-rotm-outer)

(Independent of PR #21)

## Test plan

- [x] `lake build Noperthedron.Global.RotationPartials.SecondPartialOuter` passes
- [x] No sorries