### PR TITLE
Implement rotation_partials_bounded (Lemma 19)

### DIFF
--- a/Noperthedron/Basic.lean
+++ b/Noperthedron/Basic.lean
@@ -291,6 +291,28 @@ noncomputable
 def rotMφφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
   (rotMφφ_mat θ φ).toEuclideanLin.toContinuousLinearMap
 
+-- Second partial derivatives of rotM
+-- ∂²rotM/∂θ² (derivative of rotMθ w.r.t. θ)
+noncomputable
+def rotMθθ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+  let A : Matrix (Fin 2) (Fin 3) ℝ :=
+    !![sin θ, -cos θ, 0; cos θ * cos φ, sin θ * cos φ, 0]
+  A.toEuclideanLin.toContinuousLinearMap
+
+-- ∂²rotM/∂θ∂φ (derivative of rotMθ w.r.t. φ, or rotMφ w.r.t. θ)
+noncomputable
+def rotMθφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+  let A : Matrix (Fin 2) (Fin 3) ℝ :=
+    !![0, 0, 0; -sin θ * sin φ, cos θ * sin φ, 0]
+  A.toEuclideanLin.toContinuousLinearMap
+
+-- ∂²rotM/∂φ² (derivative of rotMφ w.r.t. φ)
+noncomputable
+def rotMφφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+  let A : Matrix (Fin 2) (Fin 3) ℝ :=
+    !![0, 0, 0; cos θ * cos φ, sin θ * cos φ, -sin φ]
+  A.toEuclideanLin.toContinuousLinearMap
+
 theorem sin_neg_pi_div_two : Real.sin (-(π / 2)) = -1 := by
   simp only [Real.sin_neg, Real.sin_pi_div_two]
 

--- a/Noperthedron/Basic.lean
+++ b/Noperthedron/Basic.lean
@@ -291,28 +291,6 @@ noncomputable
 def rotMφφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
   (rotMφφ_mat θ φ).toEuclideanLin.toContinuousLinearMap
 
--- Second partial derivatives of rotM
--- ∂²rotM/∂θ² (derivative of rotMθ w.r.t. θ)
-noncomputable
-def rotMθθ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![sin θ, -cos θ, 0; cos θ * cos φ, sin θ * cos φ, 0]
-  A.toEuclideanLin.toContinuousLinearMap
-
--- ∂²rotM/∂θ∂φ (derivative of rotMθ w.r.t. φ, or rotMφ w.r.t. θ)
-noncomputable
-def rotMθφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![0, 0, 0; -sin θ * sin φ, cos θ * sin φ, 0]
-  A.toEuclideanLin.toContinuousLinearMap
-
--- ∂²rotM/∂φ² (derivative of rotMφ w.r.t. φ)
-noncomputable
-def rotMφφ (θ : ℝ) (φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
-  let A : Matrix (Fin 2) (Fin 3) ℝ :=
-    !![0, 0, 0; cos θ * cos φ, sin θ * cos φ, -sin φ]
-  A.toEuclideanLin.toContinuousLinearMap
-
 theorem sin_neg_pi_div_two : Real.sin (-(π / 2)) = -1 := by
   simp only [Real.sin_neg, Real.sin_pi_div_two]
 

--- a/Noperthedron/Global/Basic.lean
+++ b/Noperthedron/Global/Basic.lean
@@ -27,17 +27,11 @@ lemma nth_partial_div_const {n : ℕ} (i : Fin n) (f : E n → ℝ) (c : ℝ) (x
     smul_eq_mul, mul_comm]
 
 lemma nth_partial_nth_partial_div_const {n : ℕ} (i j : Fin n) (f : E n → ℝ) (c : ℝ) (x : E n)
-    (hf : Differentiable ℝ f) (hg : Differentiable ℝ (nth_partial j f)) :
-    nth_partial i (nth_partial j (fun y => f y / c)) x =
-      nth_partial i (nth_partial j f) x / c := by
-  rw [funext fun z => nth_partial_div_const j f c z (hf z)]
-  exact nth_partial_div_const i (nth_partial j f) c x (hg x)
-
-lemma nth_partial_nth_partial_div_const' {n : ℕ} (i j : Fin n) (f : E n → ℝ) (c : ℝ) (x : E n)
     (hf : Differentiable ℝ f) (hg : Differentiable ℝ (nth_partial i f)) :
     nth_partial j (nth_partial i (fun y => f y / c)) x =
-      nth_partial j (nth_partial i f) x / c :=
-  nth_partial_nth_partial_div_const j i f c x hf hg
+      nth_partial j (nth_partial i f) x / c := by
+  rw [funext fun z => nth_partial_div_const i f c z (hf z)]
+  exact nth_partial_div_const j (nth_partial i f) c x (hg x)
 
 def mixed_partials_bounded {n : ℕ} (f : E n → ℝ) : Prop :=
   ∀ (x : E n) (i j : Fin n), abs ((nth_partial i <| nth_partial j <| f) x) ≤ 1

--- a/Noperthedron/Global/Basic.lean
+++ b/Noperthedron/Global/Basic.lean
@@ -33,6 +33,12 @@ lemma nth_partial_nth_partial_div_const {n : ℕ} (i j : Fin n) (f : E n → ℝ
   rw [funext fun z => nth_partial_div_const j f c z (hf z)]
   exact nth_partial_div_const i (nth_partial j f) c x (hg x)
 
+lemma nth_partial_nth_partial_div_const' {n : ℕ} (i j : Fin n) (f : E n → ℝ) (c : ℝ) (x : E n)
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ (nth_partial i f)) :
+    nth_partial j (nth_partial i (fun y => f y / c)) x =
+      nth_partial j (nth_partial i f) x / c :=
+  nth_partial_nth_partial_div_const j i f c x hf hg
+
 def mixed_partials_bounded {n : ℕ} (f : E n → ℝ) : Prop :=
   ∀ (x : E n) (i j : Fin n), abs ((nth_partial i <| nth_partial j <| f) x) ≤ 1
 

--- a/Noperthedron/Global/Basic.lean
+++ b/Noperthedron/Global/Basic.lean
@@ -26,6 +26,13 @@ lemma nth_partial_div_const {n : ℕ} (i : Fin n) (f : E n → ℝ) (c : ℝ) (x
   simp only [div_eq_mul_inv, nth_partial, fderiv_mul_const hf, ContinuousLinearMap.smul_apply,
     smul_eq_mul, mul_comm]
 
+lemma nth_partial_nth_partial_div_const {n : ℕ} (i j : Fin n) (f : E n → ℝ) (c : ℝ) (x : E n)
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ (nth_partial j f)) :
+    nth_partial i (nth_partial j (fun y => f y / c)) x =
+      nth_partial i (nth_partial j f) x / c := by
+  rw [funext fun z => nth_partial_div_const j f c z (hf z)]
+  exact nth_partial_div_const i (nth_partial j f) c x (hg x)
+
 def mixed_partials_bounded {n : ℕ} (f : E n → ℝ) : Prop :=
   ∀ (x : E n) (i j : Fin n), abs ((nth_partial i <| nth_partial j <| f) x) ≤ 1
 

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.Calculus.LineDeriv.Basic
 import Noperthedron.RotationDerivs
 import Noperthedron.Global.SecondPartialHelpers
 import Noperthedron.Global.Definitions
+import Noperthedron.Global.Basic
 
 /-!
 # FDeriv Helper Lemmas for Global Theorem
@@ -206,5 +207,27 @@ lemma fderiv_rotproj_inner_in_e2 (S : ℝ³) (w : ℝ²) (y : E 3)
   have heq : rotproj_inner S w = fun z => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ := by
     ext z; simp [rotproj_inner, rotprojRM]
   rw [heq, fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
+
+/-!
+## nth_partial of rotproj_inner in coordinate directions
+
+These lift the pointwise `fderiv_rotproj_inner_in_e*` to function-level equalities
+of `nth_partial`, eliminating the `funext`/`congrArg` boilerplate at each use site.
+-/
+
+lemma nth_partial_rotproj_inner_e0 (S : ℝ³) (w : ℝ²) :
+    nth_partial 0 (rotproj_inner S w) =
+      fun (y : ℝ³) => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ :=
+  funext fun y => fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y)
+
+lemma nth_partial_rotproj_inner_e1 (S : ℝ³) (w : ℝ²) :
+    nth_partial 1 (rotproj_inner S w) =
+      fun (y : ℝ³) => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ :=
+  funext fun y => fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y)
+
+lemma nth_partial_rotproj_inner_e2 (S : ℝ³) (w : ℝ²) :
+    nth_partial 2 (rotproj_inner S w) =
+      fun (y : ℝ³) => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ :=
+  funext fun y => fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y)
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -53,9 +53,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨-(rotR α ∘L rotM θ φ), ?_, ?_⟩
     · exact neg_comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (le_of_eq (Bounding.rotM_norm_one θ φ))
     · show nth_partial 0 (nth_partial 0 (rotproj_inner S w)) x = ⟪(-(rotR α ∘L rotM θ φ)) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e0 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
         fderiv_rotR'_rotM_in_e0 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
       simp only [ContinuousLinearMap.neg_apply, ContinuousLinearMap.coe_comp',
@@ -64,9 +62,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
     · show nth_partial 0 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e1 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
         fderiv_rotR_any_M_in_e0 S x rotMθ (differentiableAt_rotR_rotMθ S x)]
       rfl
@@ -74,9 +70,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
     · show nth_partial 0 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
         fderiv_rotR_any_M_in_e0 S x rotMφ (differentiableAt_rotR_rotMφ S x)]
       rfl
@@ -84,9 +78,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
     · show nth_partial 1 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e0 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
         fderiv_rotR'_rotM_in_e1 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
       simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
@@ -94,9 +86,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR α ∘L rotMθθ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθθ_norm_le_one θ φ)
     · show nth_partial 1 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθθ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e1 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
         fderiv_rotR_rotMθ_in_e1 S x]
       rfl
@@ -104,9 +94,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
     · show nth_partial 1 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
         fderiv_rotR_rotMφ_in_e1 S x]
       rfl
@@ -114,9 +102,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
     · show nth_partial 2 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e0 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
         fderiv_rotR'_rotM_in_e2 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
       simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
@@ -124,9 +110,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
     · show nth_partial 2 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e1 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
         fderiv_rotR_rotMθ_in_e2 S x]
       rfl
@@ -134,9 +118,7 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨rotR α ∘L rotMφφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMφφ_norm_le_one θ φ)
     · show nth_partial 2 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMφφ θ φ) S, w⟫
-      unfold nth_partial
-      rw [congrArg (fderiv ℝ · x) (funext fun y =>
-        fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y))]
+      rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
       rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
         fderiv_rotR_rotMφ_in_e2 S x]
       rfl

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -53,188 +53,93 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
     refine ⟨-(rotR α ∘L rotM θ φ), ?_, ?_⟩
     · exact neg_comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (le_of_eq (Bounding.rotM_norm_one θ φ))
     · show nth_partial 0 (nth_partial 0 (rotproj_inner S w)) x = ⟪(-(rotR α ∘L rotM θ φ)) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
-          ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1)) =
-          fun y => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotR'_rotM S x)]
-      have hfderiv_rotR' : (fderiv ℝ (fun y => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 0 1) = -(rotR α (rotM θ φ S)) :=
-        fderiv_rotR'_rotM_in_e0 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)
-      rw [hfderiv_rotR']
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
+        fderiv_rotR'_rotM_in_e0 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
       simp only [ContinuousLinearMap.neg_apply, ContinuousLinearMap.coe_comp',
         Function.comp_apply, inner_neg_left]
   · -- (0, 1): ∂²/∂α∂θ → rotR' α ∘L rotMθ θ φ
     refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
     · show nth_partial 0 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
-          ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1)) =
-          fun y => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotR_rotMθ S x)]
-      have hfderiv_rotR : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 0 1) = rotR' α (rotMθ θ φ S) :=
-        fderiv_rotR_any_M_in_e0 S x rotMθ (differentiableAt_rotR_rotMθ S x)
-      rw [hfderiv_rotR]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
+        fderiv_rotR_any_M_in_e0 S x rotMθ (differentiableAt_rotR_rotMθ S x)]
+      rfl
   · -- (0, 2): ∂²/∂α∂φ → rotR' α ∘L rotMφ θ φ
     refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
     · show nth_partial 0 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
-          ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1)) =
-          fun y => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotR_rotMφ S x)]
-      have hfderiv_rotR : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 0 1) = rotR' α (rotMφ θ φ S) :=
-        fderiv_rotR_any_M_in_e0 S x rotMφ (differentiableAt_rotR_rotMφ S x)
-      rw [hfderiv_rotR]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
+        fderiv_rotR_any_M_in_e0 S x rotMφ (differentiableAt_rotR_rotMφ S x)]
+      rfl
   · -- (1, 0): ∂²/∂θ∂α → rotR' α ∘L rotMθ θ φ (same as (0,1))
     refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
     · show nth_partial 1 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
-          ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1)) =
-          fun y => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotR'_rotM S x)]
-      have hfderiv : (fderiv ℝ (fun y => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 1 1) = rotR' α (rotMθ θ φ S) :=
-        fderiv_rotR'_rotM_in_e1 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)
-      rw [hfderiv]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
+        fderiv_rotR'_rotM_in_e1 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
       simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
   · -- (1, 1): ∂²/∂θ² → rotR α ∘L rotMθθ θ φ
     refine ⟨rotR α ∘L rotMθθ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθθ_norm_le_one θ φ)
     · show nth_partial 1 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθθ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
-          ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1)) =
-          fun y => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotR_rotMθ S x)]
-      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 1 1) = rotR α (rotMθθ θ φ S) := fderiv_rotR_rotMθ_in_e1 S x
-      rw [hfderiv]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
+        fderiv_rotR_rotMθ_in_e1 S x]
+      rfl
   · -- (1, 2): ∂²/∂θ∂φ → rotR α ∘L rotMθφ θ φ
     refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
     · show nth_partial 1 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
-          ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1)) =
-          fun y => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotR_rotMφ S x)]
-      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 1 1) = rotR α (rotMθφ θ φ S) := fderiv_rotR_rotMφ_in_e1 S x
-      rw [hfderiv]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
+        fderiv_rotR_rotMφ_in_e1 S x]
+      rfl
   · -- (2, 0): ∂²/∂φ∂α → rotR' α ∘L rotMφ θ φ (same as (0,2))
     refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
     · show nth_partial 2 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
-          ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1)) =
-          fun y => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 2 1) (differentiableAt_rotR'_rotM S x)]
-      have hfderiv : (fderiv ℝ (fun y => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 2 1) = rotR' α (rotMφ θ φ S) :=
-        fderiv_rotR'_rotM_in_e2 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)
-      rw [hfderiv]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
+        fderiv_rotR'_rotM_in_e2 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
       simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
   · -- (2, 1): ∂²/∂φ∂θ → rotR α ∘L rotMθφ θ φ (same as (1,2))
     refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
     · show nth_partial 2 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
-          ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1)) =
-          fun y => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 2 1) (differentiableAt_rotR_rotMθ S x)]
-      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 2 1) = rotR α (rotMθφ θ φ S) := fderiv_rotR_rotMθ_in_e2 S x
-      rw [hfderiv]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
+        fderiv_rotR_rotMθ_in_e2 S x]
+      rfl
   · -- (2, 2): ∂²/∂φ² → rotR α ∘L rotMφφ θ φ
     refine ⟨rotR α ∘L rotMφφ θ φ, ?_, ?_⟩
     · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMφφ_norm_le_one θ φ)
     · show nth_partial 2 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMφφ θ φ) S, w⟫
-      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        ext y; simp [rotproj_inner, rotprojRM]
-      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
-          ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y; rw [heq_rotproj]
-        have hf_diff := differentiableAt_rotR_rotM S y
-        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
       unfold nth_partial
-      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1)) =
-          fun y => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
-      rw [congrArg (fderiv ℝ · x) hinner_eq]
-      rw [fderiv_inner_const _ w x (EuclideanSpace.single 2 1) (differentiableAt_rotR_rotMφ S x)]
-      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 2 1) = rotR α (rotMφφ θ φ S) := fderiv_rotR_rotMφ_in_e2 S x
-      rw [hfderiv]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+      rw [congrArg (fderiv ℝ · x) (funext fun y =>
+        fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y))]
+      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
+        fderiv_rotR_rotMφ_in_e2 S x]
+      rfl
 
 /-!
 ## Main theorems

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -142,7 +142,7 @@ theorem second_partial_inner_rotM_inner (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
   have hscale : nth_partial j (nth_partial i (rotproj_inner_unit S w)) y =
       nth_partial j (nth_partial i (rotproj_inner S w)) y / ‖S‖ := by
     simpa [rotproj_inner_unit_eq] using
-      nth_partial_nth_partial_div_const j i (rotproj_inner S w) ‖S‖ y
+      nth_partial_nth_partial_div_const' i j (rotproj_inner S w) ‖S‖ y
         (Differentiable.rotproj_inner S w) hg_diff
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_inner_eq S w y j i
   simpa [hscale, hAeq] using inner_bound_helper A S w w_unit hAnorm

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -17,15 +17,399 @@ open scoped RealInnerProductSpace
 
 namespace GlobalTheorem
 
+private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
+
+/-!
+## Helper lemmas for composition norm bounds
+-/
+
+private lemma comp_norm_le_one' {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
+    ‖A ∘L B‖ ≤ 1 := by
+  calc ‖A ∘L B‖ ≤ ‖A‖ * ‖B‖ := ContinuousLinearMap.opNorm_comp_le A B
+    _ ≤ 1 * 1 := by apply mul_le_mul hA hB (norm_nonneg _) (by linarith)
+    _ = 1 := by ring
+
+private lemma neg_comp_norm_le_one' {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
+    ‖-(A ∘L B)‖ ≤ 1 := by
+  rw [norm_neg]
+  exact comp_norm_le_one' hA hB
+
+/-- Bound for |⟪A S, w⟫ / ‖S‖| when ‖A‖ ≤ 1 and ‖w‖ = 1. -/
+private lemma inner_bound_helper' (A : ℝ³ →L[ℝ] ℝ²) (S : ℝ³) (w : ℝ²)
+    (hw : ‖w‖ = 1) (hA : ‖A‖ ≤ 1) : |⟪A S, w⟫ / ‖S‖| ≤ 1 := by
+  by_cases hS : ‖S‖ = 0
+  · simp [hS]
+  · rw [abs_div, abs_norm]
+    refine div_le_one_of_le₀ ?_ (norm_nonneg _)
+    calc |⟪A S, w⟫|
+      _ ≤ ‖A S‖ * ‖w‖ := abs_real_inner_le_norm _ _
+      _ ≤ ‖A‖ * ‖S‖ * ‖w‖ := by
+          apply mul_le_mul_of_nonneg_right (ContinuousLinearMap.le_opNorm _ _) (norm_nonneg _)
+      _ ≤ 1 * ‖S‖ * 1 := by
+          apply mul_le_mul (mul_le_mul_of_nonneg_right hA (norm_nonneg _)) (le_of_eq hw)
+            (norm_nonneg _)
+          positivity
+      _ = ‖S‖ := by ring
+
+/-!
+## Private lemma: second partials as inner products (inner case, 9 cases)
+
+The second partial derivatives of rotproj_inner S w equal ⟪A S, w⟫
+where A is a composition of rotR/rotR' with rotM/rotMθ/rotMφ/rotMθθ/rotMθφ/rotMφφ,
+all with ‖A‖ ≤ 1.
+
+Variables: x 0 = α, x 1 = θ, x 2 = φ (note: rotprojRM takes θ φ α)
+rotproj_inner S w x = ⟪rotprojRM (x 1) (x 2) (x 0) S, w⟫
+                    = ⟪rotR (x 0) (rotM (x 1) (x 2) S), w⟫
+
+The A[i,j] table:
+| i\j |    0                    |    1                  |    2                  |
+|-----|-------------------------|-----------------------|-----------------------|
+|  0  | -(rotR α ∘L rotM θ φ)   | rotR' α ∘L rotMθ θ φ  | rotR' α ∘L rotMφ θ φ  |
+|  1  | rotR' α ∘L rotMθ θ φ    | rotR α ∘L rotMθθ θ φ  | rotR α ∘L rotMθφ θ φ  |
+|  2  | rotR' α ∘L rotMφ θ φ    | rotR α ∘L rotMθφ θ φ  | rotR α ∘L rotMφφ θ φ  |
+-/
+
+set_option maxHeartbeats 400000 in
+private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i j : Fin 3) :
+    ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
+      nth_partial i (nth_partial j (rotproj_inner S w)) x = ⟪A S, w⟫ := by
+  let α := x.ofLp 0; let θ := x.ofLp 1; let φ := x.ofLp 2
+  fin_cases i <;> fin_cases j
+  · -- (0, 0): ∂²/∂α² → -(rotR α ∘L rotM θ φ)
+    refine ⟨-(rotR α ∘L rotM θ φ), ?_, ?_⟩
+    · exact neg_comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one α)) (le_of_eq (Bounding.rotM_norm_one θ φ))
+    · show nth_partial 0 (nth_partial 0 (rotproj_inner S w)) x = ⟪(-(rotR α ∘L rotM θ φ)) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
+          ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1)) =
+          fun y => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotR'_rotM S x)]
+      have hfderiv_rotR' : (fderiv ℝ (fun y => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 0 1) = -(rotR α (rotM θ φ S)) :=
+        fderiv_rotR'_rotM_in_e0 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)
+      rw [hfderiv_rotR']
+      simp only [ContinuousLinearMap.neg_apply, ContinuousLinearMap.coe_comp',
+        Function.comp_apply, inner_neg_left]
+  · -- (0, 1): ∂²/∂α∂θ → rotR' α ∘L rotMθ θ φ
+    refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
+    · show nth_partial 0 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
+          ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y
+        set pbar : Pose := ⟨y.ofLp 1, 0, y.ofLp 2, 0, y.ofLp 0⟩ with hpbar_def
+        have hpbar : pbar.innerParams = y := by ext i; fin_cases i <;> rfl
+        rw [← hpbar, (HasFDerivAt.rotproj_inner pbar S w).fderiv, hpbar]
+        simp only [rotproj_inner', hpbar_def, Pose.rotR, Pose.rotM₁θ,
+          LinearMap.coe_toContinuousLinearMap']
+        have hbasis : EuclideanSpace.single 1 1 = (EuclideanSpace.basisFun (Fin 3) ℝ).toBasis 1 := by
+          ext i; simp only [OrthonormalBasis.coe_toBasis, EuclideanSpace.basisFun_apply, EuclideanSpace.single_apply]
+        rw [hbasis, Module.Basis.constr_basis]
+        simp only [Matrix.cons_val_one, Matrix.cons_val_zero]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1)) =
+          fun y => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotR_rotMθ S x)]
+      have hfderiv_rotR : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 0 1) = rotR' α (rotMθ θ φ S) := by
+        let proj0 : ℝ³ →L[ℝ] ℝ := PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 3 => ℝ) (0 : Fin 3)
+        have hproj0 : HasFDerivAt (fun z : ℝ³ => z.ofLp 0) proj0 x :=
+          (PiLp.hasStrictFDerivAt_apply 2 x 0).hasFDerivAt
+        have hderiv : HasDerivAt (fun α' => rotR α' (rotMθ θ φ S)) (rotR' α (rotMθ θ φ S)) α :=
+          HasDerivAt_rotR α (rotMθ θ φ S)
+        have hfderiv : HasFDerivAt (fun α' : ℝ => rotR α' (rotMθ θ φ S))
+            (ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S))) α := hderiv.hasFDerivAt
+        have hcomp' : HasFDerivAt ((fun α' => rotR α' (rotMθ θ φ S)) ∘ (fun z : E 3 => z.ofLp 0))
+            (ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S)) ∘L proj0) x :=
+          hfderiv.comp x hproj0
+        have heq_form : ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S)) ∘L proj0 =
+            proj0.smulRight (rotR' α (rotMθ θ φ S)) := by
+          ext y; simp [ContinuousLinearMap.toSpanSingleton_apply, ContinuousLinearMap.smulRight_apply]
+        have hcomp : HasFDerivAt ((fun α' => rotR α' (rotMθ θ φ S)) ∘ (fun z : E 3 => z.ofLp 0))
+            (proj0.smulRight (rotR' α (rotMθ θ φ S))) x := by rw [← heq_form]; exact hcomp'
+        have hdiff : DifferentiableAt ℝ (fun y : E 3 => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x :=
+          differentiableAt_rotR_rotMθ S x
+        have heq_fderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x) (EuclideanSpace.single 0 1) =
+            (fderiv ℝ ((fun α' => rotR α' (rotMθ θ φ S)) ∘ (fun z : E 3 => z.ofLp 0)) x) (EuclideanSpace.single 0 1) := by
+          have hLHS : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x) (EuclideanSpace.single 0 1) =
+              rotR' α (rotMθ θ φ S) := by
+            rw [← hdiff.lineDeriv_eq_fderiv]
+            have hline : HasLineDerivAt ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S))
+                (rotR' α (rotMθ θ φ S)) x (EuclideanSpace.single 0 1) := by
+              unfold HasLineDerivAt
+              have hsimp : ∀ t, rotR ((x + t • EuclideanSpace.single 0 1).ofLp 0) (rotMθ ((x + t • EuclideanSpace.single 0 1).ofLp 1) ((x + t • EuclideanSpace.single 0 1).ofLp 2) S) =
+                  rotR (α + t) (rotMθ θ φ S) := by
+                intro t
+                have h0 : (x + t • EuclideanSpace.single 0 1).ofLp 0 = x.ofLp 0 + t := coord_e0_same x t
+                rw [h0, coord_e0_at1, coord_e0_at2]
+              simp_rw [hsimp]
+              have hrotR : HasDerivAt (fun a => rotR a (rotMθ θ φ S)) (rotR' α (rotMθ θ φ S)) α := HasDerivAt_rotR _ _
+              have hid : HasDerivAt (fun t : ℝ => α + t) 1 0 := by simpa using (hasDerivAt_id (0 : ℝ)).const_add α
+              have hrotR' : HasDerivAt (fun a => rotR a (rotMθ θ φ S)) (rotR' (α + 0) (rotMθ θ φ S)) (α + 0) := by simp only [add_zero]; exact hrotR
+              have hcomp' := hrotR'.scomp 0 hid
+              simp only [one_smul, add_zero] at hcomp'
+              have heq_fun : ((fun a ↦ rotR a (rotMθ θ φ S)) ∘ HAdd.hAdd α) = (fun t => rotR (α + t) (rotMθ θ φ S)) := by ext t; simp only [Function.comp_apply]
+              rw [heq_fun] at hcomp'; exact hcomp'
+            exact hline.lineDeriv
+          rw [hLHS, hcomp.fderiv]
+          simp only [ContinuousLinearMap.smulRight_apply, proj0, PiLp.proj_apply, EuclideanSpace.single_apply, ↓reduceIte, one_smul]
+        rw [heq_fderiv, hcomp.fderiv]
+        simp only [ContinuousLinearMap.smulRight_apply, proj0, PiLp.proj_apply,
+          EuclideanSpace.single_apply, ↓reduceIte, one_smul]
+      rw [hfderiv_rotR]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (0, 2): ∂²/∂α∂φ → rotR' α ∘L rotMφ θ φ
+    refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
+    · show nth_partial 0 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
+          ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1)) =
+          fun y => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotR_rotMφ S x)]
+      have hfderiv_rotR : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 0 1) = rotR' α (rotMφ θ φ S) :=
+        fderiv_rotR_any_M_in_e0 S x rotMφ (differentiableAt_rotR_rotMφ S x)
+      rw [hfderiv_rotR]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (1, 0): ∂²/∂θ∂α → rotR' α ∘L rotMθ θ φ (same as (0,1))
+    refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
+    · show nth_partial 1 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
+          ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1)) =
+          fun y => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotR'_rotM S x)]
+      have hfderiv : (fderiv ℝ (fun y => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 1 1) = rotR' α (rotMθ θ φ S) :=
+        fderiv_rotR'_rotM_in_e1 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)
+      rw [hfderiv]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (1, 1): ∂²/∂θ² → rotR α ∘L rotMθθ θ φ
+    refine ⟨rotR α ∘L rotMθθ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθθ_norm_le_one θ φ)
+    · show nth_partial 1 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθθ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
+          ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1)) =
+          fun y => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotR_rotMθ S x)]
+      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 1 1) = rotR α (rotMθθ θ φ S) := fderiv_rotR_rotMθ_in_e1 S x
+      rw [hfderiv]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (1, 2): ∂²/∂θ∂φ → rotR α ∘L rotMθφ θ φ
+    refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
+    · show nth_partial 1 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
+          ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1)) =
+          fun y => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotR_rotMφ S x)]
+      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 1 1) = rotR α (rotMθφ θ φ S) := fderiv_rotR_rotMφ_in_e1 S x
+      rw [hfderiv]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (2, 0): ∂²/∂φ∂α → rotR' α ∘L rotMφ θ φ (same as (0,2))
+    refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
+    · show nth_partial 2 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
+          ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1)) =
+          fun y => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 2 1) (differentiableAt_rotR'_rotM S x)]
+      have hfderiv : (fderiv ℝ (fun y => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 2 1) = rotR' α (rotMφ θ φ S) := by
+        have hf_diff : DifferentiableAt ℝ (fun y : E 3 => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S)) x :=
+          differentiableAt_rotR'_rotM S x
+        rw [← hf_diff.lineDeriv_eq_fderiv]
+        have hline : HasLineDerivAt ℝ (fun y : E 3 => rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S))
+            (rotR' α (rotMφ θ φ S)) x (EuclideanSpace.single 2 1) := by
+          unfold HasLineDerivAt
+          have hsimp : ∀ t, rotR' ((x + t • EuclideanSpace.single 2 1).ofLp 0)
+              (rotM ((x + t • EuclideanSpace.single 2 1).ofLp 1) ((x + t • EuclideanSpace.single 2 1).ofLp 2) S) =
+              rotR' α (rotM θ (φ + t) S) := by
+            intro t
+            have h2 : (x + t • EuclideanSpace.single 2 1).ofLp 2 = x.ofLp 2 + t := coord_e2_same x t
+            rw [coord_e2_at0, coord_e2_at1, h2]
+          simp_rw [hsimp]
+          have hrotM : HasDerivAt (fun φ' => rotM θ φ' S) (rotMφ θ φ S) φ := hasDerivAt_rotM_φ θ φ S
+          have hR : HasFDerivAt (fun v => rotR' α v) (rotR' α) (rotM θ φ S) := ContinuousLinearMap.hasFDerivAt (rotR' α)
+          have hrotM_fderiv : HasFDerivAt (fun φ' : ℝ => rotM θ φ' S)
+              (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ θ φ S)) φ := hrotM.hasFDerivAt
+          have hcomp_inner := hR.comp φ hrotM_fderiv
+          have heq_comp : (rotR' α).comp (ContinuousLinearMap.toSpanSingleton ℝ (rotMφ θ φ S)) =
+              ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMφ θ φ S)) := by
+            ext z; simp [ContinuousLinearMap.toSpanSingleton_apply]
+          rw [heq_comp] at hcomp_inner
+          have hcomp_deriv : HasDerivAt ((fun v => rotR' α v) ∘ (fun φ' => rotM θ φ' S)) (rotR' α (rotMφ θ φ S)) φ := by
+            have h := hcomp_inner.hasDerivAt (x := φ)
+            simp only [ContinuousLinearMap.toSpanSingleton_apply, one_smul] at h; exact h
+          have hid : HasDerivAt (fun t : ℝ => φ + t) 1 0 := by simpa using (hasDerivAt_id (0 : ℝ)).const_add φ
+          have hcomp_deriv' : HasDerivAt (fun φ' => rotR' α (rotM θ φ' S)) (rotR' α (rotMφ θ (φ + 0) S)) (φ + 0) := by
+            simp only [add_zero] at hcomp_deriv ⊢; exact hcomp_deriv
+          have hfinal := hcomp_deriv'.scomp 0 hid
+          simp only [one_smul, add_zero] at hfinal
+          have heq_fun : ((fun φ' => rotR' α (rotM θ φ' S)) ∘ HAdd.hAdd φ) =
+              (fun t => rotR' α (rotM θ (φ + t) S)) := by ext t; simp only [Function.comp_apply]
+          rw [heq_fun] at hfinal; exact hfinal
+        exact hline.lineDeriv
+      rw [hfderiv]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (2, 1): ∂²/∂φ∂θ → rotR α ∘L rotMθφ θ φ (same as (1,2))
+    refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
+    · show nth_partial 2 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
+          ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1)) =
+          fun y => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 2 1) (differentiableAt_rotR_rotMθ S x)]
+      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 2 1) = rotR α (rotMθφ θ φ S) := fderiv_rotR_rotMθ_in_e2 S x
+      rw [hfderiv]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (2, 2): ∂²/∂φ² → rotR α ∘L rotMφφ θ φ
+    refine ⟨rotR α ∘L rotMφφ θ φ, ?_, ?_⟩
+    · exact comp_norm_le_one' (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMφφ_norm_le_one θ φ)
+    · show nth_partial 2 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMφφ θ φ) S, w⟫
+      have heq_rotproj : rotproj_inner S w = fun y => ⟪rotR (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        ext y; simp [rotproj_inner, rotprojRM]
+      have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
+          ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
+      unfold nth_partial
+      have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1)) =
+          fun y => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
+      rw [congrArg (fderiv ℝ · x) hinner_eq]
+      rw [fderiv_inner_const _ w x (EuclideanSpace.single 2 1) (differentiableAt_rotR_rotMφ S x)]
+      have hfderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S)) x)
+          (EuclideanSpace.single 2 1) = rotR α (rotMφφ θ φ S) := fderiv_rotR_rotMφ_in_e2 S x
+      rw [hfderiv]
+      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+
+/-!
+## Main theorems
+-/
+
 /- [SY25] Lemma 19 (inner part) -/
 theorem second_partial_inner_rotM_inner (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 3) (y : ℝ³) :
     |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_inner_unit S w) z) (EuclideanSpace.single i 1)) y)
       (EuclideanSpace.single j 1)| ≤ 1 := by
-  sorry
+  by_cases hS : ‖S‖ = 0
+  · have hzero : rotproj_inner_unit S w = 0 := by ext y; simp [rotproj_inner_unit, hS]
+    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]
+    norm_num
+  · have S_pos : ‖S‖ > 0 := (norm_nonneg S).lt_of_ne' hS
+    have heq : rotproj_inner_unit S w = fun z => rotproj_inner S w z / ‖S‖ := by ext z; rfl
+    have hgoal : (fderiv ℝ (fun z => (fderiv ℝ (rotproj_inner_unit S w) z) (EuclideanSpace.single i 1)) y)
+        (EuclideanSpace.single j 1) = nth_partial j (nth_partial i (rotproj_inner_unit S w)) y := by
+      unfold nth_partial; rfl
+    rw [hgoal]
+    have hf_smooth : ContDiff ℝ 2 (rotproj_inner S w) := by
+      have heq_inner : rotproj_inner S w = ‖S‖ • rotproj_inner_unit S w := by
+        ext x; simp [rotproj_inner, rotproj_inner_unit, mul_div_cancel₀ _ (ne_of_gt S_pos)]
+      rw [heq_inner]
+      have h2 : ContDiff ℝ 2 (rotproj_inner_unit S w) := rotation_partials_exist S_pos
+      exact contDiff_const.smul h2
+    have hdiv : (fun z => rotproj_inner S w z / ‖S‖) = ‖S‖⁻¹ • (rotproj_inner S w) := by
+      ext z; simp [div_eq_inv_mul, smul_eq_mul]
+    have hpartial_smul : nth_partial i (‖S‖⁻¹ • rotproj_inner S w) =
+        ‖S‖⁻¹ • nth_partial i (rotproj_inner S w) := by
+      ext z
+      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
+      have h2ne : (2 : WithTop ℕ∞) ≠ 0 := by decide
+      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hf_smooth.differentiable h2ne z)]
+      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
+    have hg : ContDiff ℝ 1 (nth_partial i (rotproj_inner S w)) := by
+      unfold nth_partial
+      have h : (1 : WithTop ℕ∞) + 1 ≤ 2 := by decide
+      exact hf_smooth.fderiv_right h |>.clm_apply contDiff_const
+    have hg_diff : Differentiable ℝ (nth_partial i (rotproj_inner S w)) := by
+      have h1ne : (1 : WithTop ℕ∞) ≠ 0 := by decide
+      exact hg.differentiable h1ne
+    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i (rotproj_inner S w)) =
+        ‖S‖⁻¹ • nth_partial j (nth_partial i (rotproj_inner S w)) := by
+      ext z
+      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
+      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hg_diff z)]
+      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
+    have hscale : nth_partial j (nth_partial i (rotproj_inner_unit S w)) y =
+        nth_partial j (nth_partial i (rotproj_inner S w)) y / ‖S‖ := by
+      rw [heq, hdiv, hpartial_smul, hpartial_smul2]
+      simp only [Pi.smul_apply, smul_eq_mul, div_eq_inv_mul]
+    rw [hscale]
+    obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_inner_eq S w y j i
+    rw [hAeq]
+    exact inner_bound_helper' A S w w_unit hAnorm
 
 /- [SY25] Lemma 19 -/
 theorem rotation_partials_bounded (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_inner_unit S w) := by
-  sorry
+  intro x i j
+  have hgoal : (nth_partial i <| nth_partial j <| rotproj_inner_unit S w) x =
+      (fderiv ℝ (fun z => (fderiv ℝ (rotproj_inner_unit S w) z) (EuclideanSpace.single j 1)) x)
+        (EuclideanSpace.single i 1) := by
+    unfold nth_partial; rfl
+  rw [hgoal]
+  exact second_partial_inner_rotM_inner S w_unit j i x
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -161,9 +161,9 @@ theorem second_partial_inner_rotM_inner (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       contDiff_const).differentiable (by decide)
   have hscale : nth_partial j (nth_partial i (rotproj_inner_unit S w)) y =
       nth_partial j (nth_partial i (rotproj_inner S w)) y / ‖S‖ := by
-    rw [funext (rotproj_inner_unit_eq S w)]
-    rw [funext fun z => nth_partial_div_const i (rotproj_inner S w) ‖S‖ z (hf_diff z)]
-    simpa using nth_partial_div_const j (nth_partial i (rotproj_inner S w)) ‖S‖ y (hg_diff y)
+    simpa [rotproj_inner_unit_eq] using
+      nth_partial_nth_partial_div_const j i (rotproj_inner S w) ‖S‖ y
+        (Differentiable.rotproj_inner S w) hg_diff
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_inner_eq S w y j i
   simpa [hscale, hAeq] using inner_bound_helper A S w w_unit hAnorm
 

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -64,7 +64,6 @@ private lemma second_partial_col2 (S : ℝ³) (w : ℝ²) (x : E 3) (i : Fin 3) 
   rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
   exact fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x)
 
-set_option maxHeartbeats 400000 in
 private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i j : Fin 3) :
     ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
       nth_partial i (nth_partial j (rotproj_inner S w)) x = ⟪A S, w⟫ := by

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -79,67 +79,17 @@ private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i 
         ext y; simp [rotproj_inner, rotprojRM]
       have hfirst : ∀ y : E 3, (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
           ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-        intro y
-        set pbar : Pose := ⟨y.ofLp 1, 0, y.ofLp 2, 0, y.ofLp 0⟩ with hpbar_def
-        have hpbar : pbar.innerParams = y := by ext i; fin_cases i <;> rfl
-        rw [← hpbar, (HasFDerivAt.rotproj_inner pbar S w).fderiv, hpbar]
-        simp only [rotproj_inner', hpbar_def, Pose.rotR, Pose.rotM₁θ,
-          LinearMap.coe_toContinuousLinearMap']
-        have hbasis : EuclideanSpace.single 1 1 = (EuclideanSpace.basisFun (Fin 3) ℝ).toBasis 1 := by
-          ext i; simp only [OrthonormalBasis.coe_toBasis, EuclideanSpace.basisFun_apply, EuclideanSpace.single_apply]
-        rw [hbasis, Module.Basis.constr_basis]
-        simp only [Matrix.cons_val_one, Matrix.cons_val_zero]
+        intro y; rw [heq_rotproj]
+        have hf_diff := differentiableAt_rotR_rotM S y
+        rw [fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
       unfold nth_partial
       have hinner_eq : (fun y : E 3 => (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1)) =
           fun y => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := funext hfirst
       rw [congrArg (fderiv ℝ · x) hinner_eq]
       rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotR_rotMθ S x)]
       have hfderiv_rotR : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x)
-          (EuclideanSpace.single 0 1) = rotR' α (rotMθ θ φ S) := by
-        let proj0 : ℝ³ →L[ℝ] ℝ := PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 3 => ℝ) (0 : Fin 3)
-        have hproj0 : HasFDerivAt (fun z : ℝ³ => z.ofLp 0) proj0 x :=
-          (PiLp.hasStrictFDerivAt_apply 2 x 0).hasFDerivAt
-        have hderiv : HasDerivAt (fun α' => rotR α' (rotMθ θ φ S)) (rotR' α (rotMθ θ φ S)) α :=
-          HasDerivAt_rotR α (rotMθ θ φ S)
-        have hfderiv : HasFDerivAt (fun α' : ℝ => rotR α' (rotMθ θ φ S))
-            (ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S))) α := hderiv.hasFDerivAt
-        have hcomp' : HasFDerivAt ((fun α' => rotR α' (rotMθ θ φ S)) ∘ (fun z : E 3 => z.ofLp 0))
-            (ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S)) ∘L proj0) x :=
-          hfderiv.comp x hproj0
-        have heq_form : ContinuousLinearMap.toSpanSingleton ℝ (rotR' α (rotMθ θ φ S)) ∘L proj0 =
-            proj0.smulRight (rotR' α (rotMθ θ φ S)) := by
-          ext y; simp [ContinuousLinearMap.toSpanSingleton_apply, ContinuousLinearMap.smulRight_apply]
-        have hcomp : HasFDerivAt ((fun α' => rotR α' (rotMθ θ φ S)) ∘ (fun z : E 3 => z.ofLp 0))
-            (proj0.smulRight (rotR' α (rotMθ θ φ S))) x := by rw [← heq_form]; exact hcomp'
-        have hdiff : DifferentiableAt ℝ (fun y : E 3 => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x :=
-          differentiableAt_rotR_rotMθ S x
-        have heq_fderiv : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x) (EuclideanSpace.single 0 1) =
-            (fderiv ℝ ((fun α' => rotR α' (rotMθ θ φ S)) ∘ (fun z : E 3 => z.ofLp 0)) x) (EuclideanSpace.single 0 1) := by
-          have hLHS : (fderiv ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S)) x) (EuclideanSpace.single 0 1) =
-              rotR' α (rotMθ θ φ S) := by
-            rw [← hdiff.lineDeriv_eq_fderiv]
-            have hline : HasLineDerivAt ℝ (fun y => rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S))
-                (rotR' α (rotMθ θ φ S)) x (EuclideanSpace.single 0 1) := by
-              unfold HasLineDerivAt
-              have hsimp : ∀ t, rotR ((x + t • EuclideanSpace.single 0 1).ofLp 0) (rotMθ ((x + t • EuclideanSpace.single 0 1).ofLp 1) ((x + t • EuclideanSpace.single 0 1).ofLp 2) S) =
-                  rotR (α + t) (rotMθ θ φ S) := by
-                intro t
-                have h0 : (x + t • EuclideanSpace.single 0 1).ofLp 0 = x.ofLp 0 + t := coord_e0_same x t
-                rw [h0, coord_e0_at1, coord_e0_at2]
-              simp_rw [hsimp]
-              have hrotR : HasDerivAt (fun a => rotR a (rotMθ θ φ S)) (rotR' α (rotMθ θ φ S)) α := HasDerivAt_rotR _ _
-              have hid : HasDerivAt (fun t : ℝ => α + t) 1 0 := by simpa using (hasDerivAt_id (0 : ℝ)).const_add α
-              have hrotR' : HasDerivAt (fun a => rotR a (rotMθ θ φ S)) (rotR' (α + 0) (rotMθ θ φ S)) (α + 0) := by simp only [add_zero]; exact hrotR
-              have hcomp' := hrotR'.scomp 0 hid
-              simp only [one_smul, add_zero] at hcomp'
-              have heq_fun : ((fun a ↦ rotR a (rotMθ θ φ S)) ∘ HAdd.hAdd α) = (fun t => rotR (α + t) (rotMθ θ φ S)) := by ext t; simp only [Function.comp_apply]
-              rw [heq_fun] at hcomp'; exact hcomp'
-            exact hline.lineDeriv
-          rw [hLHS, hcomp.fderiv]
-          simp only [ContinuousLinearMap.smulRight_apply, proj0, PiLp.proj_apply, EuclideanSpace.single_apply, ↓reduceIte, one_smul]
-        rw [heq_fderiv, hcomp.fderiv]
-        simp only [ContinuousLinearMap.smulRight_apply, proj0, PiLp.proj_apply,
-          EuclideanSpace.single_apply, ↓reduceIte, one_smul]
+          (EuclideanSpace.single 0 1) = rotR' α (rotMθ θ φ S) :=
+        fderiv_rotR_any_M_in_e0 S x rotMθ (differentiableAt_rotR_rotMθ S x)
       rw [hfderiv_rotR]
       simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
   · -- (0, 2): ∂²/∂α∂φ → rotR' α ∘L rotMφ θ φ

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -154,8 +154,6 @@ theorem second_partial_inner_rotM_inner (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
     change ContDiff ℝ 2 (fun x : ℝ³ => ⟪rotprojRM (x 1) (x 2) (x 0) S, w⟫)
     simp [inner, rotprojRM, rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail]
     fun_prop
-  have hf_diff : Differentiable ℝ (rotproj_inner S w) :=
-    hf_smooth.differentiable (by decide)
   have hg_diff : Differentiable ℝ (nth_partial i (rotproj_inner S w)) :=
     (hf_smooth.fderiv_right (by decide : (1 : WithTop ℕ∞) + 1 ≤ 2) |>.clm_apply
       contDiff_const).differentiable (by decide)

--- a/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialInner.lean
@@ -43,85 +43,87 @@ The A[i,j] table:
 |  2  | rotR' α ∘L rotMφ θ φ    | rotR α ∘L rotMθφ θ φ  | rotR α ∘L rotMφφ θ φ  |
 -/
 
+private lemma second_partial_col0 (S : ℝ³) (w : ℝ²) (x : E 3) (i : Fin 3) :
+    nth_partial i (nth_partial 0 (rotproj_inner S w)) x =
+    ⟪(fderiv ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) x)
+      (EuclideanSpace.single i 1), w⟫ := by
+  rw [nth_partial_rotproj_inner_e0 S w]; unfold nth_partial
+  exact fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x)
+
+private lemma second_partial_col1 (S : ℝ³) (w : ℝ²) (x : E 3) (i : Fin 3) :
+    nth_partial i (nth_partial 1 (rotproj_inner S w)) x =
+    ⟪(fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) x)
+      (EuclideanSpace.single i 1), w⟫ := by
+  rw [nth_partial_rotproj_inner_e1 S w]; unfold nth_partial
+  exact fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x)
+
+private lemma second_partial_col2 (S : ℝ³) (w : ℝ²) (x : E 3) (i : Fin 3) :
+    nth_partial i (nth_partial 2 (rotproj_inner S w)) x =
+    ⟪(fderiv ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) x)
+      (EuclideanSpace.single i 1), w⟫ := by
+  rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
+  exact fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x)
+
 set_option maxHeartbeats 400000 in
 private lemma second_partial_rotM_inner_eq (S : ℝ³) (w : ℝ²) (x : E 3) (i j : Fin 3) :
     ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
       nth_partial i (nth_partial j (rotproj_inner S w)) x = ⟪A S, w⟫ := by
   let α := x.ofLp 0; let θ := x.ofLp 1; let φ := x.ofLp 2
   fin_cases i <;> fin_cases j
-  · -- (0, 0): ∂²/∂α² → -(rotR α ∘L rotM θ φ)
-    refine ⟨-(rotR α ∘L rotM θ φ), ?_, ?_⟩
-    · exact neg_comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (le_of_eq (Bounding.rotM_norm_one θ φ))
-    · show nth_partial 0 (nth_partial 0 (rotproj_inner S w)) x = ⟪(-(rotR α ∘L rotM θ φ)) S, w⟫
-      rw [nth_partial_rotproj_inner_e0 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
-        fderiv_rotR'_rotM_in_e0 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
-      simp only [ContinuousLinearMap.neg_apply, ContinuousLinearMap.coe_comp',
-        Function.comp_apply, inner_neg_left]
-  · -- (0, 1): ∂²/∂α∂θ → rotR' α ∘L rotMθ θ φ
-    refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
-    · show nth_partial 0 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e1 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
-        fderiv_rotR_any_M_in_e0 S x rotMθ (differentiableAt_rotR_rotMθ S x)]
-      rfl
-  · -- (0, 2): ∂²/∂α∂φ → rotR' α ∘L rotMφ θ φ
-    refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
-    · show nth_partial 0 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
-        fderiv_rotR_any_M_in_e0 S x rotMφ (differentiableAt_rotR_rotMφ S x)]
-      rfl
-  · -- (1, 0): ∂²/∂θ∂α → rotR' α ∘L rotMθ θ φ (same as (0,1))
-    refine ⟨rotR' α ∘L rotMθ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ)
-    · show nth_partial 1 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMθ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e0 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
-        fderiv_rotR'_rotM_in_e1 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
-  · -- (1, 1): ∂²/∂θ² → rotR α ∘L rotMθθ θ φ
-    refine ⟨rotR α ∘L rotMθθ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθθ_norm_le_one θ φ)
-    · show nth_partial 1 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθθ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e1 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
-        fderiv_rotR_rotMθ_in_e1 S x]
-      rfl
-  · -- (1, 2): ∂²/∂θ∂φ → rotR α ∘L rotMθφ θ φ
-    refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
-    · show nth_partial 1 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
-        fderiv_rotR_rotMφ_in_e1 S x]
-      rfl
-  · -- (2, 0): ∂²/∂φ∂α → rotR' α ∘L rotMφ θ φ (same as (0,2))
-    refine ⟨rotR' α ∘L rotMφ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ)
-    · show nth_partial 2 (nth_partial 0 (rotproj_inner S w)) x = ⟪(rotR' α ∘L rotMφ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e0 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR'_rotM S x),
-        fderiv_rotR'_rotM_in_e2 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
-      simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
-  · -- (2, 1): ∂²/∂φ∂θ → rotR α ∘L rotMθφ θ φ (same as (1,2))
-    refine ⟨rotR α ∘L rotMθφ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ)
-    · show nth_partial 2 (nth_partial 1 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMθφ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e1 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMθ S x),
-        fderiv_rotR_rotMθ_in_e2 S x]
-      rfl
-  · -- (2, 2): ∂²/∂φ² → rotR α ∘L rotMφφ θ φ
-    refine ⟨rotR α ∘L rotMφφ θ φ, ?_, ?_⟩
-    · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMφφ_norm_le_one θ φ)
-    · show nth_partial 2 (nth_partial 2 (rotproj_inner S w)) x = ⟪(rotR α ∘L rotMφφ θ φ) S, w⟫
-      rw [nth_partial_rotproj_inner_e2 S w]; unfold nth_partial
-      rw [fderiv_inner_const _ w x _ (differentiableAt_rotR_rotMφ S x),
-        fderiv_rotR_rotMφ_in_e2 S x]
-      rfl
+  · -- (0, 0): -(rotR α ∘L rotM θ φ)
+    refine ⟨-(rotR α ∘L rotM θ φ),
+      neg_comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (le_of_eq (Bounding.rotM_norm_one θ φ)), ?_⟩
+    show nth_partial 0 (nth_partial 0 _) x = _
+    rw [second_partial_col0 S w x,
+      fderiv_rotR'_rotM_in_e0 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
+    simp only [ContinuousLinearMap.neg_apply, ContinuousLinearMap.coe_comp',
+      Function.comp_apply, inner_neg_left]
+  · -- (0, 1): rotR' α ∘L rotMθ θ φ
+    refine ⟨rotR' α ∘L rotMθ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ), ?_⟩
+    show nth_partial 0 (nth_partial 1 _) x = _
+    rw [second_partial_col1 S w x,
+      fderiv_rotR_any_M_in_e0 S x rotMθ (differentiableAt_rotR_rotMθ S x)]; rfl
+  · -- (0, 2): rotR' α ∘L rotMφ θ φ
+    refine ⟨rotR' α ∘L rotMφ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ), ?_⟩
+    show nth_partial 0 (nth_partial 2 _) x = _
+    rw [second_partial_col2 S w x,
+      fderiv_rotR_any_M_in_e0 S x rotMφ (differentiableAt_rotR_rotMφ S x)]; rfl
+  · -- (1, 0): rotR' α ∘L rotMθ θ φ
+    refine ⟨rotR' α ∘L rotMθ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMθ_norm_le_one θ φ), ?_⟩
+    show nth_partial 1 (nth_partial 0 _) x = _
+    rw [second_partial_col0 S w x,
+      fderiv_rotR'_rotM_in_e1 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
+    simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (1, 1): rotR α ∘L rotMθθ θ φ
+    refine ⟨rotR α ∘L rotMθθ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθθ_norm_le_one θ φ), ?_⟩
+    show nth_partial 1 (nth_partial 1 _) x = _
+    rw [second_partial_col1 S w x, fderiv_rotR_rotMθ_in_e1 S x]; rfl
+  · -- (1, 2): rotR α ∘L rotMθφ θ φ
+    refine ⟨rotR α ∘L rotMθφ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ), ?_⟩
+    show nth_partial 1 (nth_partial 2 _) x = _
+    rw [second_partial_col2 S w x, fderiv_rotR_rotMφ_in_e1 S x]; rfl
+  · -- (2, 0): rotR' α ∘L rotMφ θ φ
+    refine ⟨rotR' α ∘L rotMφ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one α)) (Bounding.rotMφ_norm_le_one θ φ), ?_⟩
+    show nth_partial 2 (nth_partial 0 _) x = _
+    rw [second_partial_col0 S w x,
+      fderiv_rotR'_rotM_in_e2 S x α θ φ rfl rfl rfl (differentiableAt_rotR'_rotM S x)]
+    simp only [ContinuousLinearMap.coe_comp', Function.comp_apply]
+  · -- (2, 1): rotR α ∘L rotMθφ θ φ
+    refine ⟨rotR α ∘L rotMθφ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMθφ_norm_le_one θ φ), ?_⟩
+    show nth_partial 2 (nth_partial 1 _) x = _
+    rw [second_partial_col1 S w x, fderiv_rotR_rotMθ_in_e2 S x]; rfl
+  · -- (2, 2): rotR α ∘L rotMφφ θ φ
+    refine ⟨rotR α ∘L rotMφφ θ φ,
+      comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one α)) (Bounding.rotMφφ_norm_le_one θ φ), ?_⟩
+    show nth_partial 2 (nth_partial 2 _) x = _
+    rw [second_partial_col2 S w x, fderiv_rotR_rotMφ_in_e2 S x]; rfl
 
 /-!
 ## Main theorems
@@ -142,7 +144,7 @@ theorem second_partial_inner_rotM_inner (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
   have hscale : nth_partial j (nth_partial i (rotproj_inner_unit S w)) y =
       nth_partial j (nth_partial i (rotproj_inner S w)) y / ‖S‖ := by
     simpa [rotproj_inner_unit_eq] using
-      nth_partial_nth_partial_div_const' i j (rotproj_inner S w) ‖S‖ y
+      nth_partial_nth_partial_div_const i j (rotproj_inner S w) ‖S‖ y
         (Differentiable.rotproj_inner S w) hg_diff
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_inner_eq S w y j i
   simpa [hscale, hAeq] using inner_bound_helper A S w w_unit hAnorm

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -134,10 +134,9 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
     fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
   have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
       nth_partial j (nth_partial i f) y / ‖S‖ := by
-    rw [show rotproj_outer_unit S w = fun z => f z / ‖S‖ from rfl,
-      funext fun z => nth_partial_div_const i f ‖S‖ z (hf_smooth.differentiable WithTop.top_ne_zero z)]
-    exact nth_partial_div_const j _ ‖S‖ y
-      ((hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero y)
+    simpa using nth_partial_nth_partial_div_const j i f ‖S‖ y
+      (hf_smooth.differentiable WithTop.top_ne_zero)
+      ((hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero)
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
   simpa [hscale, f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -159,8 +159,7 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
     exact nth_partial_div_const j _ ‖S‖ y (hg_diff y)
   rw [hscale]
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-  rw [hAeq]
-  exact inner_bound_helper A S w w_unit hAnorm
+  simpa [f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -11,9 +11,12 @@ import Noperthedron.Global.SecondPartialHelpers
 # Second Partial Outer Lemmas
 
 This file contains:
-- `outer_second_partial_A` definition and norm bound
+- `outer_second_partial_A` definition
 - **`second_partial_inner_rotM_outer`** (4 cases: θθ, θφ, φθ, φφ)
 - **`rotation_partials_bounded_outer`**
+
+Helper lemmas `comp_norm_le_one`, `neg_comp_norm_le_one`, `inner_bound_helper` are imported
+from SecondPartialHelpers.
 -/
 
 open scoped RealInnerProductSpace
@@ -39,83 +42,196 @@ noncomputable def outer_second_partial_A (θ φ : ℝ) (i j : Fin 2) : ℝ³ →
   match i, j with
   | 0, 0 => rotMθθ θ φ
   | 0, 1 => rotMθφ θ φ
-  | 1, 0 => rotMθφ θ φ
+  | 1, 0 => rotMθφ θ φ  -- = A[0,1] by mixed partial symmetry
   | 1, 1 => rotMφφ θ φ
 
 /-- All A[i,j] have operator norm ≤ 1 for outer partials. -/
 lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
     ‖outer_second_partial_A θ φ i j‖ ≤ 1 := by
-  fin_cases i <;> fin_cases j <;>
-    simp [outer_second_partial_A, Bounding.rotMθθ_norm_le_one,
-      Bounding.rotMθφ_norm_le_one, Bounding.rotMφφ_norm_le_one]
-
-/-!
-## Helper lemmas: partials of ⟪rotM S, w⟫ in coordinate directions
--/
-
-private lemma outerPbar (x : E 2) : (⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ : Pose).outerParams = x := by
-  ext i; fin_cases i <;> simp [Pose.outerParams]
-
-private lemma fderiv_rotM_outer_eq (S : ℝ³) (x : E 2) :
-    fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) x = rotM' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
-  (outerPbar x ▸ HasFDerivAt.rotM_outer _ S).fderiv
-
-private lemma fderiv_rotMθ_outer_eq (S : ℝ³) (x : E 2) :
-    fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
-  (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv
-
-private lemma fderiv_rotMφ_outer_eq (S : ℝ³) (x : E 2) :
-    fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
-  (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv
-
-private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
-    (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-      (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y), fderiv_rotM_outer_eq S y]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
-
-private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
-    (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-      (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y), fderiv_rotM_outer_eq S y]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
-
-private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
-    (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-      (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x), fderiv_rotMθ_outer_eq S x]
-  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
-
-private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
-    (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-      (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x), fderiv_rotMθ_outer_eq S x]
-  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
-
-private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
-    (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-      (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x), fderiv_rotMφ_outer_eq S x]
-  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
-
-private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
-    (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-      (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x), fderiv_rotMφ_outer_eq S x]
-  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  fin_cases i <;> fin_cases j
+  · exact Bounding.rotMθθ_norm_le_one θ φ
+  · exact Bounding.rotMθφ_norm_le_one θ φ
+  · exact Bounding.rotMθφ_norm_le_one θ φ
+  · exact Bounding.rotMφφ_norm_le_one θ φ
 
 /-!
 ## Private lemma: second partials as inner products
+
+The second partial derivatives of ⟪rotM θ φ S, w⟫ equal ⟪A S, w⟫
+where A ∈ {rotMθθ, rotMθφ, rotMφφ} with ‖A‖ ≤ 1.
 -/
 
 private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i j : Fin 2) :
     ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
       nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
-  refine ⟨outer_second_partial_A (x.ofLp 0) (x.ofLp 1) i j,
-    outer_second_partial_A_norm_le _ _ _ _, ?_⟩
-  fin_cases i <;> fin_cases j <;> unfold nth_partial <;>
-    simp [outer_second_partial_A, fderiv_rotM_inner_e0, fderiv_rotM_inner_e1,
-      fderiv_rotMθ_inner_e0, fderiv_rotMθ_inner_e1, fderiv_rotMφ_inner_e0, fderiv_rotMφ_inner_e1]
+  -- Each pair (i, j) corresponds to a specific second derivative matrix
+  -- (0, 0) → rotMθθ, (0, 1) → rotMθφ, (1, 0) → rotMθφ, (1, 1) → rotMφφ
+  fin_cases i <;> fin_cases j
+  · -- (0, 0): uses rotMθθ
+    refine ⟨rotMθθ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθθ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    -- First partial in direction e₀ gives ⟪rotMθ S, w⟫
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMθ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
+      have h := HasFDerivAt.rotMθ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMθ]
+    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    rfl
+  · -- (0, 1): uses rotMθφ
+    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMφ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
+      have h := HasFDerivAt.rotMφ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMφ]
+    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    rfl
+  · -- (1, 0): uses rotMθφ
+    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMθ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
+      have h := HasFDerivAt.rotMθ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMθ]
+    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    rfl
+  · -- (1, 1): uses rotMφφ
+    refine ⟨rotMφφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMφφ_norm_le_one _ _, ?_⟩
+    let θ := x.ofLp 0; let φ := x.ofLp 1
+    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+      intro y
+      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
+      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+      rw [hfderiv_rotM]
+      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+      congr 1
+      ext i
+      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    unfold nth_partial
+    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫
+    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
+    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+        from congrArg (fderiv ℝ · x) hinner_eq]
+    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMφ_outer S x)]
+    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
+    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
+      have h := HasFDerivAt.rotMφ_outer pbar S
+      rw [hpbar] at h
+      exact h.fderiv
+    rw [hfderiv_rotMφ]
+    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
+    congr 1
+    ext i
+    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
+      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
+    rfl
 
 /-!
 ## Main theorems
@@ -125,24 +241,74 @@ private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i 
 theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 2) (y : ℝ²) :
     |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
       (EuclideanSpace.single j 1)| ≤ 1 := by
-  show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
-  let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hf_smooth : ContDiff ℝ ⊤ f := by
-    apply ContDiff.inner ℝ _ contDiff_const
-    rw [contDiff_piLp]; intro k
-    simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
-    fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
-  have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
-      nth_partial j (nth_partial i f) y / ‖S‖ := by
-    rw [show rotproj_outer_unit S w = fun z => f z / ‖S‖ from rfl,
-      funext fun z => nth_partial_div_const i f ‖S‖ z (hf_smooth.differentiable WithTop.top_ne_zero z)]
-    exact nth_partial_div_const j _ ‖S‖ y
-      ((hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero y)
-  obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-  simpa [hscale, f, hAeq] using inner_bound_helper A S w w_unit hAnorm
+  -- Handle the case when ‖S‖ = 0
+  by_cases hS : ‖S‖ = 0
+  · -- When ‖S‖ = 0, the function is constantly 0
+    have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
+    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]
+    norm_num
+  · -- When ‖S‖ ≠ 0, use the helper lemma
+    have S_pos : ‖S‖ > 0 := (norm_nonneg S).lt_of_ne' hS
+    -- The function is rotproj_outer_unit S w = (fun y => ⟪rotM (y 0) (y 1) S, w⟫) / ‖S‖
+    -- The second partial of f/c is (second partial of f) / c
+    have heq : rotproj_outer_unit S w = fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫ / ‖S‖ := by
+      ext z; rfl
+    -- Rewrite using nth_partial definition
+    have hgoal : (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
+        (EuclideanSpace.single j 1) = nth_partial j (nth_partial i (rotproj_outer_unit S w)) y := by
+      unfold nth_partial
+      rfl
+    rw [hgoal]
+    -- The second partial of f/‖S‖ is (second partial of f) / ‖S‖
+    let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
+    have hfun : rotproj_outer_unit S w = ‖S‖⁻¹ • f := by
+      ext z; simp [smul_eq_mul, div_eq_inv_mul, rotproj_outer_unit, f]
+    -- f is smooth
+    have hf_smooth : ContDiff ℝ ⊤ f := by
+      apply ContDiff.inner ℝ _ contDiff_const
+      rw [contDiff_piLp]; intro k
+      simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+      fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
+    have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
+    -- nth_partial of c⁻¹ • f = c⁻¹ • nth_partial f
+    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f := by
+      ext z
+      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
+      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hf_diff z)]
+      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
+    have hg : ContDiff ℝ ⊤ (nth_partial i f) := by
+      unfold nth_partial
+      exact hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const
+    have hg_diff : Differentiable ℝ (nth_partial i f) := hg.differentiable WithTop.top_ne_zero
+    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) := by
+      ext z
+      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
+      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hg_diff z)]
+      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
+    -- Combine scaling
+    have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
+        nth_partial j (nth_partial i f) y / ‖S‖ := by
+      rw [hfun, hpartial_smul, hpartial_smul2]
+      simp only [Pi.smul_apply, smul_eq_mul, div_eq_inv_mul]
+    rw [hscale]
+    -- Get the existence of A with norm bound
+    -- Note: swap indices to match nth_partial j (nth_partial i f)
+    obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
+    -- Now apply the bound
+    rw [hAeq]
+    exact inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
-    mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>
-  second_partial_inner_rotM_outer S w_unit j i x
+    mixed_partials_bounded (rotproj_outer_unit S w) := by
+  intro x i j
+  -- Rewrite the goal in terms of fderiv
+  have hgoal : (nth_partial i <| nth_partial j <| rotproj_outer_unit S w) x =
+      (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single j 1)) x)
+        (EuclideanSpace.single i 1) := by
+    unfold nth_partial
+    rfl
+  rw [hgoal]
+  -- Swap indices to match second_partial_inner_rotM_outer's convention
+  exact second_partial_inner_rotM_outer S w_unit j i x
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -62,7 +62,9 @@ private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
@@ -70,7 +72,9 @@ private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -78,7 +82,9 @@ private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -86,7 +92,9 @@ private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -94,7 +102,9 @@ private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -102,7 +112,9 @@ private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  congr 1
+  ext i
+  simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 /-!
 ## Private lemma: second partials as inner products

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -127,16 +127,17 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       (EuclideanSpace.single j 1)| ≤ 1 := by
   show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
   let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hf_smooth : ContDiff ℝ ⊤ f := by
+  have hf_smooth : ContDiff ℝ 2 f := by
     apply ContDiff.inner ℝ _ contDiff_const
     rw [contDiff_piLp]; intro k
     simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
     fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
   have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
       nth_partial j (nth_partial i f) y / ‖S‖ := by
-    simpa using nth_partial_nth_partial_div_const j i f ‖S‖ y
-      (hf_smooth.differentiable WithTop.top_ne_zero)
-      ((hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero)
+    simpa using nth_partial_nth_partial_div_const' i j f ‖S‖ y
+      (hf_smooth.differentiable (by decide))
+      ((hf_smooth.fderiv_right (by decide : (1 : WithTop ℕ∞) + 1 ≤ 2) |>.clm_apply
+        contDiff_const).differentiable (by decide))
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
   simpa [hscale, f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -42,7 +42,7 @@ noncomputable def outer_second_partial_A (θ φ : ℝ) (i j : Fin 2) : ℝ³ →
   match i, j with
   | 0, 0 => rotMθθ θ φ
   | 0, 1 => rotMθφ θ φ
-  | 1, 0 => rotMθφ θ φ  -- = A[0,1] by mixed partial symmetry
+  | 1, 0 => rotMθφ θ φ
   | 1, 1 => rotMφφ θ φ
 
 /-- All A[i,j] have operator norm ≤ 1 for outer partials. -/
@@ -55,183 +55,107 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
   · exact Bounding.rotMφφ_norm_le_one θ φ
 
 /-!
-## Private lemma: second partials as inner products
+## Helper lemmas: first partials of ⟪rotM S, w⟫ in coordinate directions
+-/
 
-The second partial derivatives of ⟪rotM θ φ S, w⟫ equal ⟪A S, w⟫
-where A ∈ {rotMθθ, rotMθφ, rotMφφ} with ‖A‖ ≤ 1.
+private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
+    (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+      (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
+  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+  rw [this]; congr 1; ext i
+  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (1 : Fin 2) ≠ 0 from by decide]
+  ring
+
+private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
+    (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+      (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
+  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
+  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
+  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
+    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
+  rw [this]; congr 1; ext i
+  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (0 : Fin 2) ≠ 1 from by decide]
+  ring
+
+/-!
+## Private lemma: second partials as inner products
 -/
 
 private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i j : Fin 2) :
     ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
       nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
-  -- Each pair (i, j) corresponds to a specific second derivative matrix
-  -- (0, 0) → rotMθθ, (0, 1) → rotMθφ, (1, 0) → rotMθφ, (1, 1) → rotMφφ
   fin_cases i <;> fin_cases j
-  · -- (0, 0): uses rotMθθ
+  · -- (0, 0): rotMθθ
     refine ⟨rotMθθ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθθ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    -- First partial in direction e₀ gives ⟪rotMθ S, w⟫
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMθ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
-      have h := HasFDerivAt.rotMθ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMθ]
-    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
-    rfl
-  · -- (0, 1): uses rotMθφ
+    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+    ring
+  · -- (0, 1): rotMθφ
     refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 0 1) (differentiableAt_rotMφ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
-      have h := HasFDerivAt.rotMφ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMφ]
-    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
-    rfl
-  · -- (1, 0): uses rotMθφ
+    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+    ring
+  · -- (1, 0): rotMθφ
     refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (1 : Fin 2) ≠ 0 from by decide, mul_zero, add_zero]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) = fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) = (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMθ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMθ : fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S := by
-      have h := HasFDerivAt.rotMθ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMθ]
-    simp only [rotMθ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
-    rfl
-  · -- (1, 1): uses rotMφφ
+    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+    ring
+  · -- (1, 1): rotMφφ
     refine ⟨rotMφφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMφφ_norm_le_one _ _, ?_⟩
     let θ := x.ofLp 0; let φ := x.ofLp 1
-    have hfirst : ∀ y : E 2, (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-      intro y
-      rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-      set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ with hpbar_def
-      have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-      have hfderiv_rotM : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-        (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-      rw [hfderiv_rotM]
-      simp only [rotM', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-      congr 1
-      ext i
-      simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-        EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-        show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
     unfold nth_partial
-    show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫
-    have hinner_eq : (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) = fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := funext hfirst
-    rw [show (fderiv ℝ (fun y : E 2 => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) = (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
-        from congrArg (fderiv ℝ · x) hinner_eq]
-    rw [fderiv_inner_const _ w x (EuclideanSpace.single 1 1) (differentiableAt_rotMφ_outer S x)]
+    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ θ φ S, w⟫
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
+    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
     set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
     have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    have hfderiv_rotMφ : fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S := by
-      have h := HasFDerivAt.rotMφ_outer pbar S
-      rw [hpbar] at h
-      exact h.fderiv
-    rw [hfderiv_rotMφ]
-    simp only [rotMφ', LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply, hpbar_def]
-    congr 1
-    ext i
-    simp only [Matrix.of_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
-      EuclideanSpace.single_apply, ↓reduceIte, mul_one,
-      show (0 : Fin 2) ≠ 1 from by decide, mul_zero, zero_add]
-    rfl
+    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+    congr 1; ext i
+    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+    ring
 
 /-!
 ## Main theorems
@@ -241,74 +165,38 @@ private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i 
 theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 2) (y : ℝ²) :
     |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
       (EuclideanSpace.single j 1)| ≤ 1 := by
-  -- Handle the case when ‖S‖ = 0
   by_cases hS : ‖S‖ = 0
-  · -- When ‖S‖ = 0, the function is constantly 0
-    have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
-    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]
-    norm_num
-  · -- When ‖S‖ ≠ 0, use the helper lemma
-    have S_pos : ‖S‖ > 0 := (norm_nonneg S).lt_of_ne' hS
-    -- The function is rotproj_outer_unit S w = (fun y => ⟪rotM (y 0) (y 1) S, w⟫) / ‖S‖
-    -- The second partial of f/c is (second partial of f) / c
-    have heq : rotproj_outer_unit S w = fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫ / ‖S‖ := by
-      ext z; rfl
-    -- Rewrite using nth_partial definition
-    have hgoal : (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
-        (EuclideanSpace.single j 1) = nth_partial j (nth_partial i (rotproj_outer_unit S w)) y := by
-      unfold nth_partial
-      rfl
-    rw [hgoal]
-    -- The second partial of f/‖S‖ is (second partial of f) / ‖S‖
+  · have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
+    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]; norm_num
+  · show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
     let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
     have hfun : rotproj_outer_unit S w = ‖S‖⁻¹ • f := by
       ext z; simp [smul_eq_mul, div_eq_inv_mul, rotproj_outer_unit, f]
-    -- f is smooth
     have hf_smooth : ContDiff ℝ ⊤ f := by
       apply ContDiff.inner ℝ _ contDiff_const
       rw [contDiff_piLp]; intro k
       simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
       fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
     have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
-    -- nth_partial of c⁻¹ • f = c⁻¹ • nth_partial f
-    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f := by
-      ext z
-      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
-      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hf_diff z)]
-      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
     have hg : ContDiff ℝ ⊤ (nth_partial i f) := by
       unfold nth_partial
       exact hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const
     have hg_diff : Differentiable ℝ (nth_partial i f) := hg.differentiable WithTop.top_ne_zero
-    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) := by
-      ext z
-      simp only [nth_partial, Pi.smul_apply, smul_eq_mul]
-      rw [fderiv_const_smul (c := ‖S‖⁻¹) (hg_diff z)]
-      simp only [ContinuousLinearMap.smul_apply, smul_eq_mul]
-    -- Combine scaling
+    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f :=
+      funext fun z => nth_partial_const_smul i _ _ z (hf_diff z)
+    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) :=
+      funext fun z => nth_partial_const_smul j _ _ z (hg_diff z)
     have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
         nth_partial j (nth_partial i f) y / ‖S‖ := by
       rw [hfun, hpartial_smul, hpartial_smul2]
       simp only [Pi.smul_apply, smul_eq_mul, div_eq_inv_mul]
     rw [hscale]
-    -- Get the existence of A with norm bound
-    -- Note: swap indices to match nth_partial j (nth_partial i f)
     obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-    -- Now apply the bound
     rw [hAeq]
     exact inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
-    mixed_partials_bounded (rotproj_outer_unit S w) := by
-  intro x i j
-  -- Rewrite the goal in terms of fderiv
-  have hgoal : (nth_partial i <| nth_partial j <| rotproj_outer_unit S w) x =
-      (fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single j 1)) x)
-        (EuclideanSpace.single i 1) := by
-    unfold nth_partial
-    rfl
-  rw [hgoal]
-  -- Swap indices to match second_partial_inner_rotM_outer's convention
-  exact second_partial_inner_rotM_outer S w_unit j i x
+    mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>
+  second_partial_inner_rotM_outer S w_unit j i x
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -11,12 +11,9 @@ import Noperthedron.Global.SecondPartialHelpers
 # Second Partial Outer Lemmas
 
 This file contains:
-- `outer_second_partial_A` definition
+- `outer_second_partial_A` definition and norm bound
 - **`second_partial_inner_rotM_outer`** (4 cases: θθ, θφ, φθ, φφ)
 - **`rotation_partials_bounded_outer`**
-
-Helper lemmas `comp_norm_le_one`, `neg_comp_norm_le_one`, `inner_bound_helper` are imported
-from SecondPartialHelpers.
 -/
 
 open scoped RealInnerProductSpace
@@ -85,77 +82,84 @@ private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
   ring
 
 /-!
+## Helper lemmas: second partials of ⟪rotMθ/rotMφ S, w⟫ via fderiv
+-/
+
+private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+  ring
+
+private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+  ring
+
+private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
+  ring
+
+private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
+    (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
+      (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
+  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
+  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
+  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
+    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  congr 1; ext i
+  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
+    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
+  ring
+
+/-!
 ## Private lemma: second partials as inner products
 -/
 
 private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i j : Fin 2) :
     ∃ A : ℝ³ →L[ℝ] ℝ², ‖A‖ ≤ 1 ∧
       nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
-  fin_cases i <;> fin_cases j
-  · -- (0, 0): rotMθθ
-    refine ⟨rotMθθ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθθ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+  refine ⟨outer_second_partial_A (x.ofLp 0) (x.ofLp 1) i j,
+    outer_second_partial_A_norm_le _ _ _ _, ?_⟩
+  let θ := x.ofLp 0; let φ := x.ofLp 1
+  fin_cases i <;> fin_cases j <;> unfold nth_partial
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-    ring
-  · -- (0, 1): rotMθφ
-    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e0]
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-    ring
-  · -- (1, 0): rotMθφ
-    refine ⟨rotMθφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMθφ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e0]
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-    ring
-  · -- (1, 1): rotMφφ
-    refine ⟨rotMφφ (x.ofLp 0) (x.ofLp 1), Bounding.rotMφφ_norm_le_one _ _, ?_⟩
-    let θ := x.ofLp 0; let φ := x.ofLp 1
-    unfold nth_partial
-    show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e1]
+  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
         (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w))]
-    rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-    set pbar : Pose := ⟨0, θ, 0, φ, 0⟩ with hpbar_def
-    have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-    rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-      (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
-    congr 1; ext i
-    simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-      show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-    ring
+    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e1]
 
 /-!
 ## Main theorems
@@ -165,35 +169,26 @@ private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i 
 theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) (i j : Fin 2) (y : ℝ²) :
     |(fderiv ℝ (fun z => (fderiv ℝ (rotproj_outer_unit S w) z) (EuclideanSpace.single i 1)) y)
       (EuclideanSpace.single j 1)| ≤ 1 := by
-  by_cases hS : ‖S‖ = 0
-  · have hzero : rotproj_outer_unit S w = 0 := by ext y; simp [rotproj_outer_unit, hS]
-    simp only [hzero, fderiv_zero, Pi.zero_apply, ContinuousLinearMap.zero_apply]; norm_num
-  · show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
-    let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-    have hfun : rotproj_outer_unit S w = ‖S‖⁻¹ • f := by
-      ext z; simp [smul_eq_mul, div_eq_inv_mul, rotproj_outer_unit, f]
-    have hf_smooth : ContDiff ℝ ⊤ f := by
-      apply ContDiff.inner ℝ _ contDiff_const
-      rw [contDiff_piLp]; intro k
-      simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
-      fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
-    have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
-    have hg : ContDiff ℝ ⊤ (nth_partial i f) := by
-      unfold nth_partial
-      exact hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const
-    have hg_diff : Differentiable ℝ (nth_partial i f) := hg.differentiable WithTop.top_ne_zero
-    have hpartial_smul : nth_partial i (‖S‖⁻¹ • f) = ‖S‖⁻¹ • nth_partial i f :=
-      funext fun z => nth_partial_const_smul i _ _ z (hf_diff z)
-    have hpartial_smul2 : nth_partial j (‖S‖⁻¹ • nth_partial i f) = ‖S‖⁻¹ • nth_partial j (nth_partial i f) :=
-      funext fun z => nth_partial_const_smul j _ _ z (hg_diff z)
-    have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
-        nth_partial j (nth_partial i f) y / ‖S‖ := by
-      rw [hfun, hpartial_smul, hpartial_smul2]
-      simp only [Pi.smul_apply, smul_eq_mul, div_eq_inv_mul]
-    rw [hscale]
-    obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-    rw [hAeq]
-    exact inner_bound_helper A S w w_unit hAnorm
+  show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
+  let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
+  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by
+    ext z; simp [rotproj_outer_unit, f]
+  have hf_smooth : ContDiff ℝ ⊤ f := by
+    apply ContDiff.inner ℝ _ contDiff_const
+    rw [contDiff_piLp]; intro k
+    simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
+    fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
+  have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
+  have hg_diff : Differentiable ℝ (nth_partial i f) :=
+    (hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero
+  have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
+      nth_partial j (nth_partial i f) y / ‖S‖ := by
+    rw [hfun, funext fun z => nth_partial_div_const i f ‖S‖ z (hf_diff z)]
+    exact nth_partial_div_const j _ ‖S‖ y (hg_diff y)
+  rw [hscale]
+  obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
+  rw [hAeq]
+  exact inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -50,90 +50,65 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
       Bounding.rotMθφ_norm_le_one, Bounding.rotMφφ_norm_le_one]
 
 /-!
-## Helper lemmas: first partials of ⟪rotM S, w⟫ in coordinate directions
+## Helper lemmas: partials of ⟪rotM S, w⟫ in coordinate directions
 -/
+
+private lemma outerPbar (x : E 2) : (⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ : Pose).outerParams = x := by
+  ext i; fin_cases i <;> rfl
 
 private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
-  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-  rw [this]; congr 1; ext i
-  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (1 : Fin 2) ≠ 0 from by decide]
-  ring
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
+    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
+      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
+  congr 1; ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y)]
-  set pbar : Pose := ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩
-  have hpbar : pbar.outerParams = y := by ext i; fin_cases i <;> rfl
-  have : fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' pbar S :=
-    (HasFDerivAt.rotM_outer pbar S).fderiv ▸ congrArg _ hpbar.symm
-  rw [this]; congr 1; ext i
-  simp only [rotM'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (0 : Fin 2) ≠ 1 from by decide]
-  ring
-
-/-!
-## Helper lemmas: second partials of ⟪rotMθ/rotMφ S, w⟫ via fderiv
--/
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
+    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
+      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
+  congr 1; ext i
+  simp [rotM'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
+    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-  ring
+  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMθ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
+    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMθ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-  ring
+  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
+    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (1 : Fin 2) ≠ 0 from by decide, hpbar_def]
-  ring
+  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x)]
-  set pbar : Pose := ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ with hpbar_def
-  have hpbar : pbar.outerParams = x := by ext i; fin_cases i <;> rfl
-  rw [show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' pbar S from
-    (hpbar ▸ HasFDerivAt.rotMφ_outer pbar S).fderiv]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
+    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
+      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
   congr 1; ext i
-  simp only [rotMφ'_apply, EuclideanSpace.single_apply, ↓reduceIte,
-    show (0 : Fin 2) ≠ 1 from by decide, hpbar_def]
-  ring
+  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
 
 /-!
 ## Private lemma: second partials as inner products

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -134,7 +134,7 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
     fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
   have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
       nth_partial j (nth_partial i f) y / ‖S‖ := by
-    simpa using nth_partial_nth_partial_div_const' i j f ‖S‖ y
+    simpa using nth_partial_nth_partial_div_const i j f ‖S‖ y
       (hf_smooth.differentiable (by decide))
       ((hf_smooth.fderiv_right (by decide : (1 : WithTop ℕ∞) + 1 ≤ 2) |>.clm_apply
         contDiff_const).differentiable (by decide))

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -54,7 +54,7 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
 -/
 
 private lemma outerPbar (x : E 2) : (⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ : Pose).outerParams = x := by
-  ext i; fin_cases i <;> rfl
+  ext i; fin_cases i <;> simp [Pose.outerParams]
 
 private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
@@ -139,19 +139,17 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       (EuclideanSpace.single j 1)| ≤ 1 := by
   show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
   let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := rfl
   have hf_smooth : ContDiff ℝ ⊤ f := by
     apply ContDiff.inner ℝ _ contDiff_const
     rw [contDiff_piLp]; intro k
     simp only [rotM, rotM_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toEuclideanLin_apply]
     fin_cases k <;> simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three] <;> fun_prop
-  have hf_diff : Differentiable ℝ f := hf_smooth.differentiable WithTop.top_ne_zero
-  have hg_diff : Differentiable ℝ (nth_partial i f) :=
-    (hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero
   have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
       nth_partial j (nth_partial i f) y / ‖S‖ := by
-    rw [hfun, funext fun z => nth_partial_div_const i f ‖S‖ z (hf_diff z)]
-    simpa using nth_partial_div_const j (nth_partial i f) ‖S‖ y (hg_diff y)
+    rw [show rotproj_outer_unit S w = fun z => f z / ‖S‖ from rfl,
+      funext fun z => nth_partial_div_const i f ‖S‖ z (hf_smooth.differentiable WithTop.top_ne_zero z)]
+    exact nth_partial_div_const j _ ‖S‖ y
+      ((hf_smooth.fderiv_right le_top |>.clm_apply contDiff_const).differentiable WithTop.top_ne_zero y)
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
   simpa [hscale, f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -56,65 +56,53 @@ lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
 private lemma outerPbar (x : E 2) : (⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ : Pose).outerParams = x := by
   ext i; fin_cases i <;> simp [Pose.outerParams]
 
+private lemma fderiv_rotM_outer_eq (S : ℝ³) (x : E 2) :
+    fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) x = rotM' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
+  (outerPbar x ▸ HasFDerivAt.rotM_outer _ S).fderiv
+
+private lemma fderiv_rotMθ_outer_eq (S : ℝ³) (x : E 2) :
+    fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
+  (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv
+
+private lemma fderiv_rotMφ_outer_eq (S : ℝ³) (x : E 2) :
+    fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S :=
+  (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv
+
 private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 0 1) = ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
-    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
-      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y), fderiv_rotM_outer_eq S y]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
       (EuclideanSpace.single 1 1) = ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
-    show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
-      (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y), fderiv_rotM_outer_eq S y]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθθ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
-    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x), fderiv_rotMθ_outer_eq S x]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
-    show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x), fderiv_rotMθ_outer_eq S x]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 0 1) = ⟪rotMθφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
-    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x), fderiv_rotMφ_outer_eq S x]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
       (EuclideanSpace.single 1 1) = ⟪rotMφφ (x.ofLp 0) (x.ofLp 1) S, w⟫ := by
-  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
-    show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
-      (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1
-  ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply]
+  rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x), fderiv_rotMφ_outer_eq S x]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 /-!
 ## Private lemma: second partials as inner products

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -62,8 +62,7 @@ private lemma fderiv_rotM_inner_e0 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
     (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
@@ -71,8 +70,7 @@ private lemma fderiv_rotM_inner_e1 (S : ℝ³) (w : ℝ²) (y : E 2) :
   rw [fderiv_inner_const _ w y _ (Differentiable.rotM_outer S y),
     show fderiv ℝ (fun z => rotM (z.ofLp 0) (z.ofLp 1) S) y = rotM' ⟨0, y.ofLp 0, 0, y.ofLp 1, 0⟩ S from
       (outerPbar y ▸ HasFDerivAt.rotM_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotM'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
+  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -80,8 +78,7 @@ private lemma fderiv_rotMθ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMθ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -89,8 +86,7 @@ private lemma fderiv_rotMθ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMθ_outer S x),
     show fderiv ℝ (fun y => rotMθ (y.ofLp 0) (y.ofLp 1) S) x = rotMθ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMθ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMθ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
+  congr 1; ext i; simp [rotMθ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -98,8 +94,7 @@ private lemma fderiv_rotMφ_inner_e0 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (1 : Fin 2) ≠ 0 from by decide]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
     (fderiv ℝ (fun y => ⟪rotMφ (y.ofLp 0) (y.ofLp 1) S, w⟫) x)
@@ -107,8 +102,7 @@ private lemma fderiv_rotMφ_inner_e1 (S : ℝ³) (w : ℝ²) (x : E 2) :
   rw [fderiv_inner_const _ w x _ (differentiableAt_rotMφ_outer S x),
     show fderiv ℝ (fun y => rotMφ (y.ofLp 0) (y.ofLp 1) S) x = rotMφ' ⟨0, x.ofLp 0, 0, x.ofLp 1, 0⟩ S from
       (outerPbar x ▸ HasFDerivAt.rotMφ_outer _ S).fderiv]
-  congr 1; ext i
-  simp [rotMφ'_apply, EuclideanSpace.single_apply, show (0 : Fin 2) ≠ 1 from by decide]
+  congr 1; ext i; simp [rotMφ'_apply, EuclideanSpace.single_apply]
 
 /-!
 ## Private lemma: second partials as inner products
@@ -119,20 +113,9 @@ private lemma second_partial_rotM_outer_eq (S : ℝ³) (w : ℝ²) (x : E 2) (i 
       nth_partial i (nth_partial j (fun y : E 2 => ⟪rotM (y.ofLp 0) (y.ofLp 1) S, w⟫)) x = ⟪A S, w⟫ := by
   refine ⟨outer_second_partial_A (x.ofLp 0) (x.ofLp 1) i j,
     outer_second_partial_A_norm_le _ _ _ _, ?_⟩
-  let θ := x.ofLp 0; let φ := x.ofLp 1
-  fin_cases i <;> fin_cases j <;> unfold nth_partial
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθθ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e0]
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 0 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e0]
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 0 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMθφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e0 S w)), fderiv_rotMθ_inner_e1]
-  · show (fderiv ℝ (fun y => (fderiv ℝ (fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫) y)
-        (EuclideanSpace.single 1 1)) x) (EuclideanSpace.single 1 1) = ⟪rotMφφ θ φ S, w⟫
-    rw [congrArg (fderiv ℝ · x) (funext (fderiv_rotM_inner_e1 S w)), fderiv_rotMφ_inner_e1]
+  fin_cases i <;> fin_cases j <;> unfold nth_partial <;>
+    simp [outer_second_partial_A, fderiv_rotM_inner_e0, fderiv_rotM_inner_e1,
+      fderiv_rotMθ_inner_e0, fderiv_rotMθ_inner_e1, fderiv_rotMφ_inner_e0, fderiv_rotMφ_inner_e1]
 
 /-!
 ## Main theorems
@@ -144,7 +127,7 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       (EuclideanSpace.single j 1)| ≤ 1 := by
   show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
   let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by ext; rfl
+  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := rfl
   have hf_smooth : ContDiff ℝ ⊤ f := by
     apply ContDiff.inner ℝ _ contDiff_const
     rw [contDiff_piLp]; intro k
@@ -156,10 +139,9 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
   have hscale : nth_partial j (nth_partial i (rotproj_outer_unit S w)) y =
       nth_partial j (nth_partial i f) y / ‖S‖ := by
     rw [hfun, funext fun z => nth_partial_div_const i f ‖S‖ z (hf_diff z)]
-    exact nth_partial_div_const j _ ‖S‖ y (hg_diff y)
-  rw [hscale]
+    simpa using nth_partial_div_const j (nth_partial i f) ‖S‖ y (hg_diff y)
   obtain ⟨A, hAnorm, hAeq⟩ := second_partial_rotM_outer_eq S w y j i
-  simpa [f, hAeq] using inner_bound_helper A S w w_unit hAnorm
+  simpa [hscale, f, hAeq] using inner_bound_helper A S w w_unit hAnorm
 
 theorem rotation_partials_bounded_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w‖ = 1) :
     mixed_partials_bounded (rotproj_outer_unit S w) := fun x i j =>

--- a/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
+++ b/Noperthedron/Global/RotationPartials/SecondPartialOuter.lean
@@ -45,11 +45,9 @@ noncomputable def outer_second_partial_A (θ φ : ℝ) (i j : Fin 2) : ℝ³ →
 /-- All A[i,j] have operator norm ≤ 1 for outer partials. -/
 lemma outer_second_partial_A_norm_le (θ φ : ℝ) (i j : Fin 2) :
     ‖outer_second_partial_A θ φ i j‖ ≤ 1 := by
-  fin_cases i <;> fin_cases j
-  · exact Bounding.rotMθθ_norm_le_one θ φ
-  · exact Bounding.rotMθφ_norm_le_one θ φ
-  · exact Bounding.rotMθφ_norm_le_one θ φ
-  · exact Bounding.rotMφφ_norm_le_one θ φ
+  fin_cases i <;> fin_cases j <;>
+    simp [outer_second_partial_A, Bounding.rotMθθ_norm_le_one,
+      Bounding.rotMθφ_norm_le_one, Bounding.rotMφφ_norm_le_one]
 
 /-!
 ## Helper lemmas: first partials of ⟪rotM S, w⟫ in coordinate directions
@@ -171,8 +169,7 @@ theorem second_partial_inner_rotM_outer (S : ℝ³) {w : ℝ²} (w_unit : ‖w�
       (EuclideanSpace.single j 1)| ≤ 1 := by
   show |nth_partial j (nth_partial i (rotproj_outer_unit S w)) y| ≤ 1
   let f : E 2 → ℝ := fun z => ⟪rotM (z.ofLp 0) (z.ofLp 1) S, w⟫
-  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by
-    ext z; simp [rotproj_outer_unit, f]
+  have hfun : rotproj_outer_unit S w = fun z => f z / ‖S‖ := by ext; rfl
   have hf_smooth : ContDiff ℝ ⊤ f := by
     apply ContDiff.inner ℝ _ contDiff_const
     rw [contDiff_piLp]; intro k


### PR DESCRIPTION
## Summary

Implements [SY25] Lemma 19 for the full 3-variable case (α, θ, φ).

## The A[i,j] table

| i\j | 0 | 1 | 2 |
|-----|---|---|---|
| 0 | -(rotR∘rotM) | rotR'∘rotMθ | rotR'∘rotMφ |
| 1 | rotR'∘rotMθ | rotR∘rotMθθ | rotR∘rotMθφ |
| 2 | rotR'∘rotMφ | rotR∘rotMθφ | rotR∘rotMφφ |

## Contents by file

- **Basic.lean**: `nth_partial_nth_partial_div_const` — second mixed partial of `f/c` equals `(mixed partial of f)/c`
- **FDerivHelpers.lean**: `nth_partial_rotproj_inner_e0/e1/e2` — function-level equalities for first partials of `rotproj_inner`
- **SecondPartialInner.lean**:
  - `second_partial_col0/col1/col2` — column helpers reducing second partials to inner products with fderivs
  - `second_partial_rotM_inner_eq` — existential helper (9 cases)
  - `second_partial_inner_rotM_inner` — direct bound on second partials
  - `rotation_partials_bounded` — the main theorem
- **SecondPartialOuter.lean**: `second_partial_inner_rotM_outer`, `rotation_partials_bounded_outer` (outer `hf_smooth` uses `ContDiff ℝ 2`)

Uses shared helpers from SecondPartialHelpers and FDerivHelpers.

## Depends on

- PR #20 (global-foundation)
- PR #21 (global-rotproj) — for `HasFDerivAt.rotproj_inner`
- PR #22 (global-rotm-outer)
- PR #23 (global-second-outer)

## Test plan

- [x] `lake build` passes (full build)
- [x] No sorries in rotation partial files