### PR TITLE
RationalApprox: prove κ-bounds (Lemmas 44/49, Corollaries 50/51) and factor MatrixBounds helpers

### DIFF
--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -282,55 +282,51 @@ lemma partials_helper2 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
   simp only [nth_partial, GlobalTheoremPrecondition.fu, Fin.isValue, partials_helper2a]
   field_simp
 
-private lemma fderiv_rotproj_outer_e0 (P : ℝ³) (w : ℝ²) (pbar : Pose) :
-    (fderiv ℝ (fun z : ℝ² => ⟪(rotM (z 0) (z 1)) P, w⟫) pbar.outerParams)
-      (EuclideanSpace.single 0 1) = ⟪pbar.rotM₂θ P, w⟫ := by
-  rw [fderiv_inner_const _ w pbar.outerParams _ ((Differentiable.rotM_outer P).differentiableAt),
-      (HasFDerivAt.rotM_outer pbar P).fderiv]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply, Pose.rotM₂θ]
+private lemma nth_partial_rotproj_outer_0 (pbar : Pose) (P : ℝ³) (w : ℝ²) :
+    nth_partial 0 (rotproj_outer P w) pbar.outerParams = ⟪rotMθ pbar.θ₂ pbar.φ₂ P, w⟫ := by
+  unfold nth_partial rotproj_outer
+  rw [fderiv_inner_const _ w pbar.outerParams (EuclideanSpace.single 0 1)
+    ((Differentiable.rotM_outer P).differentiableAt)]
+  congr 1
+  rw [(HasFDerivAt.rotM_outer pbar P).fderiv]
+  ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
-private lemma fderiv_rotproj_outer_e1 (P : ℝ³) (w : ℝ²) (pbar : Pose) :
-    (fderiv ℝ (fun z : ℝ² => ⟪(rotM (z 0) (z 1)) P, w⟫) pbar.outerParams)
-      (EuclideanSpace.single 1 1) = ⟪pbar.rotM₂φ P, w⟫ := by
-  rw [fderiv_inner_const _ w pbar.outerParams _ ((Differentiable.rotM_outer P).differentiableAt),
-      (HasFDerivAt.rotM_outer pbar P).fderiv]
-  congr 1; ext i; simp [rotM'_apply, EuclideanSpace.single_apply, Pose.rotM₂φ]
+private lemma nth_partial_rotproj_outer_1 (pbar : Pose) (P : ℝ³) (w : ℝ²) :
+    nth_partial 1 (rotproj_outer P w) pbar.outerParams = ⟪rotMφ pbar.θ₂ pbar.φ₂ P, w⟫ := by
+  unfold nth_partial rotproj_outer
+  rw [fderiv_inner_const _ w pbar.outerParams (EuclideanSpace.single 1 1)
+    ((Differentiable.rotM_outer P).differentiableAt)]
+  congr 1
+  rw [(HasFDerivAt.rotM_outer pbar P).fderiv]
+  ext i; simp [rotM'_apply, EuclideanSpace.single_apply]
 
 lemma partials_helper3 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
     (pc : GlobalTheoremPrecondition poly pbar ε) (P : ℝ³) :
     ‖P‖ * nth_partial 0 (GlobalTheoremPrecondition.fu_outer P pc) pbar.outerParams =
     ⟪pbar.rotM₂θ P, pc.w⟫ := by
-  simp only [nth_partial, GlobalTheoremPrecondition.fu_outer, Fin.isValue]
-  unfold rotproj_outer_unit
-  have heq : (fun (x : ℝ²) => ⟪rotM (x 0) (x 1) P, pc.w⟫ / ‖P‖) =
-      ‖P‖⁻¹ • (fun (x : ℝ²) => ⟪(rotM (x 0) (x 1)) P, pc.w⟫) := by
-    ext x; simp [inv_mul_eq_div]
-  rw [heq,
-    (Differentiable.inner ℝ (Differentiable.rotM_outer P)
-      (differentiable_const pc.w)).differentiableAt.hasFDerivAt.const_smul ‖P‖⁻¹ |>.fderiv,
-    ContinuousLinearMap.smul_apply, smul_eq_mul,
-    fderiv_rotproj_outer_e0 P pc.w pbar]
   by_cases hP : ‖P‖ = 0
-  · simp [norm_eq_zero.mp hP, Pose.rotM₂θ, map_zero]
-  · field_simp
+  · simp [norm_eq_zero.mp hP, Pose.rotM₂θ, ContinuousLinearMap.map_zero]
+  · simp only [GlobalTheoremPrecondition.fu_outer]
+    rw [show rotproj_outer_unit P pc.w = fun x => rotproj_outer P pc.w x / ‖P‖ from rfl]
+    rw [nth_partial_div_const 0 (rotproj_outer P pc.w) ‖P‖ pbar.outerParams
+      ((Differentiable.inner ℝ (Differentiable.rotM_outer P) (differentiable_const pc.w)).differentiableAt)]
+    rw [nth_partial_rotproj_outer_0]
+    simp only [Pose.rotM₂θ]
+    field_simp
 
 lemma partials_helper4 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
     (pc : GlobalTheoremPrecondition poly pbar ε) (P : ℝ³) :
     ‖P‖ * nth_partial 1 (GlobalTheoremPrecondition.fu_outer P pc) pbar.outerParams =
     ⟪pbar.rotM₂φ P, pc.w⟫ := by
-  simp only [nth_partial, GlobalTheoremPrecondition.fu_outer, Fin.isValue]
-  unfold rotproj_outer_unit
-  have heq : (fun (x : ℝ²) => ⟪rotM (x 0) (x 1) P, pc.w⟫ / ‖P‖) =
-      ‖P‖⁻¹ • (fun (x : ℝ²) => ⟪(rotM (x 0) (x 1)) P, pc.w⟫) := by
-    ext x; simp [inv_mul_eq_div]
-  rw [heq,
-    (Differentiable.inner ℝ (Differentiable.rotM_outer P)
-      (differentiable_const pc.w)).differentiableAt.hasFDerivAt.const_smul ‖P‖⁻¹ |>.fderiv,
-    ContinuousLinearMap.smul_apply, smul_eq_mul,
-    fderiv_rotproj_outer_e1 P pc.w pbar]
   by_cases hP : ‖P‖ = 0
-  · simp [norm_eq_zero.mp hP, Pose.rotM₂φ, map_zero]
-  · field_simp
+  · simp [norm_eq_zero.mp hP, Pose.rotM₂φ, ContinuousLinearMap.map_zero]
+  · simp only [GlobalTheoremPrecondition.fu_outer]
+    rw [show rotproj_outer_unit P pc.w = fun x => rotproj_outer P pc.w x / ‖P‖ from rfl]
+    rw [nth_partial_div_const 1 (rotproj_outer P pc.w) ‖P‖ pbar.outerParams
+      ((Differentiable.inner ℝ (Differentiable.rotM_outer P) (differentiable_const pc.w)).differentiableAt)]
+    rw [nth_partial_rotproj_outer_1]
+    simp only [Pose.rotM₂φ]
+    field_simp
 
 lemma partials_helper {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
     (pc : GlobalTheoremPrecondition poly pbar ε) :

--- a/Noperthedron/RationalApprox/Basic.lean
+++ b/Noperthedron/RationalApprox/Basic.lean
@@ -142,7 +142,7 @@ end
 structure UpperSqrt where
   f : ℝ → ℝ
   rational : ∀ (x : ℚ), 0 ≤ x → ∃ q : ℚ, f x = q
-  bound : ∀ (x : ℚ), 0 ≤ x → √x ≤ f x
+  bound : ∀ (x : ℝ), 0 ≤ x → √x ≤ f x
 
 noncomputable
 def UpperSqrt.norm {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ℝ :=
@@ -151,7 +151,7 @@ def UpperSqrt.norm {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ℝ :=
 structure LowerSqrt where
   f : ℝ → ℝ
   rational : ∀ (x : ℚ), 0 ≤ x → ∃ q : ℚ, f x = q
-  bound : ∀ (x : ℚ), 0 ≤ x → f x ≤ √x
+  bound : ∀ (x : ℝ), 0 ≤ x → f x ≤ √x
 
 noncomputable
 def LowerSqrt.norm {n : ℕ} (s : LowerSqrt) (v : Euc(n)) : ℝ :=

--- a/Noperthedron/RationalApprox/BoundsKappa.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa.lean
@@ -2,6 +2,7 @@ import Mathlib.Algebra.Lie.OfAssociative
 import Noperthedron.PointSym
 import Noperthedron.PoseInterval
 import Noperthedron.RationalApprox.Basic
+import Noperthedron.RationalApprox.MatrixBounds
 
 open scoped RealInnerProductSpace
 
@@ -9,34 +10,224 @@ namespace RationalApprox
 
 variable {P P_ : ℝ³} {α θ φ : Set.Icc (-4) 4} {w : ℝ²}
 
+/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
+private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
+    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 := by
+  exact ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
+
+/-!
+## Helper lemma
+
+The 3κ bound pattern: for any pair of continuous linear maps `A, Aℚ` where
+`‖A - Aℚ‖ ≤ κ`, `‖A‖ ≤ 1`, `‖Aℚ‖ ≤ 1 + κ`, and points `P, P_` with
+`‖P‖ ≤ 1`, `‖P - P_‖ ≤ κ`, we get `‖A P - Aℚ P_‖ ≤ 2κ + κ² ≤ 3κ`.
+-/
+
+private lemma inner_three_kappa {E F : Type*}
+    [SeminormedAddCommGroup E] [NormedAddCommGroup F]
+    [InnerProductSpace ℝ F] [NormedSpace ℝ E]
+    {A Aℚ : E →L[ℝ] F} {P P_ : E} {w : F}
+    (hAℚnorm : ‖Aℚ‖ ≤ 1 + κ)
+    (hAdiff : ‖A - Aℚ‖ ≤ κ) (hP : ‖P‖ ≤ 1)
+    (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
+    ‖@inner ℝ F _ (A P) w - @inner ℝ F _ (Aℚ P_) w‖ ≤ 3 * κ := by
+  -- Step 1: ⟪A P, w⟫ - ⟪Aℚ P_, w⟫ = ⟪A P - Aℚ P_, w⟫
+  rw [← inner_sub_left]
+  -- Step 2: |⟪v, w⟫| ≤ ‖v‖ * ‖w‖, then simplify with ‖w‖ = 1
+  have key : ‖A P - Aℚ P_‖ ≤ 3 * κ := by
+    -- A P - Aℚ P_ = (A P - Aℚ P) + (Aℚ P - Aℚ P_)
+    have split : A P - Aℚ P_ = (A P - Aℚ P) + (Aℚ P - Aℚ P_) := by
+      abel
+    rw [split]
+    calc ‖(A P - Aℚ P) + (Aℚ P - Aℚ P_)‖
+      _ ≤ ‖A P - Aℚ P‖ + ‖Aℚ P - Aℚ P_‖ := norm_add_le _ _
+      _ = ‖(A - Aℚ) P‖ + ‖Aℚ (P - P_)‖ := by
+          rw [ContinuousLinearMap.sub_apply, map_sub]
+      _ ≤ ‖A - Aℚ‖ * ‖P‖ + ‖Aℚ‖ * ‖P - P_‖ := by
+          gcongr
+          · exact ContinuousLinearMap.le_opNorm _ _
+          · exact ContinuousLinearMap.le_opNorm _ _
+      _ ≤ κ * 1 + (1 + κ) * κ := by
+          have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+          gcongr
+      _ ≤ 3 * κ := by unfold κ; norm_num
+  calc ‖@inner ℝ F _ (A P - Aℚ P_) w‖
+    _ ≤ ‖A P - Aℚ P_‖ * ‖w‖ := norm_inner_le_norm (𝕜 := ℝ) _ _
+    _ = ‖A P - Aℚ P_‖ * 1 := by rw [hw]
+    _ = ‖A P - Aℚ P_‖ := mul_one _
+    _ ≤ 3 * κ := key
+
 /-!
 [SY25] Lemma 44
 -/
 
 lemma bounds_kappa_M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotM θ φ P, w⟫ - ⟪rotMℚ θ φ P_, w⟫‖ ≤ 3 * κ := by
-  sorry
+    ‖⟪rotM θ φ P, w⟫ - ⟪rotMℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
+  inner_three_kappa
+    (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
+    (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    hP approx hw
 
 lemma bounds_kappa_Mθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotMθ θ φ P, w⟫ - ⟪rotMθℚ θ φ P_, w⟫‖ ≤ 3 * κ := by
-  sorry
+  -- Need Mθℚ_norm_bounded inline
+  have hMθℚ : ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
+    calc ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖
+      _ ≤ ‖rotMθ (θ : ℝ) (φ : ℝ)‖ + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ :=
+          norm_le_insert _ _
+      _ ≤ 1 + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ := by
+          gcongr; exact Bounding.rotMθ_norm_le_one _ _
+      _ ≤ 1 + κ := by
+          gcongr; exact Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  exact inner_three_kappa
+    hMθℚ
+    (Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    hP approx hw
 
 lemma bounds_kappa_Mφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotMφ θ φ P, w⟫ - ⟪rotMφℚ θ φ P_, w⟫‖ ≤ 3 * κ := by
-  sorry
+  -- Need Mφℚ_norm_bounded inline
+  have hMφℚ : ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
+    calc ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖
+      _ ≤ ‖rotMφ (θ : ℝ) (φ : ℝ)‖ + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ :=
+          norm_le_insert _ _
+      _ ≤ 1 + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ := by
+          gcongr; exact Bounding.rotMφ_norm_le_one _ _
+      _ ≤ 1 + κ := by
+          gcongr; exact Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  exact inner_three_kappa
+    hMφℚ
+    (Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    hP approx hw
+
+/-!
+## 4κ bounds
+
+For the composed maps R ∘ A, we decompose:
+  R(A P) - Rℚ(Aℚ P_) = R(A P - Aℚ P_) + (R - Rℚ)(Aℚ P_)
+
+This gives ≤ ‖R‖ * ‖A P - Aℚ P_‖ + ‖R - Rℚ‖ * ‖Aℚ P_‖
+-/
+
+private lemma inner_four_kappa {E F G : Type*}
+    [SeminormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G]
+    [InnerProductSpace ℝ G] [NormedSpace ℝ E] [NormedSpace ℝ F]
+    {A Aℚ : E →L[ℝ] F} {R Rℚ : F →L[ℝ] G} {P P_ : E} {w : G}
+    (hRnorm : ‖R‖ ≤ 1) (_hRℚnorm : ‖Rℚ‖ ≤ 1 + κ)
+    (hRdiff : ‖R - Rℚ‖ ≤ κ)
+    (_hAnorm : ‖A‖ ≤ 1) (hAℚnorm : ‖Aℚ‖ ≤ 1 + κ)
+    (hAdiff : ‖A - Aℚ‖ ≤ κ)
+    (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
+    ‖@inner ℝ G _ (R (A P)) w - @inner ℝ G _ (Rℚ (Aℚ P_)) w‖ ≤ 4 * κ := by
+  rw [← inner_sub_left]
+  -- R(A P) - Rℚ(Aℚ P_) = R(A P - Aℚ P_) + (R - Rℚ)(Aℚ P_)
+  have decomp : R (A P) - Rℚ (Aℚ P_) = R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_) := by
+    simp [map_sub, ContinuousLinearMap.sub_apply]
+  rw [decomp]
+  -- Bound ‖A P - Aℚ P_‖
+  have hAP_diff : ‖A P - Aℚ P_‖ ≤ 2 * κ + κ ^ 2 := by
+    have split : A P - Aℚ P_ = (A P - Aℚ P) + (Aℚ P - Aℚ P_) := by abel
+    rw [split]
+    calc ‖(A P - Aℚ P) + (Aℚ P - Aℚ P_)‖
+      _ ≤ ‖A P - Aℚ P‖ + ‖Aℚ P - Aℚ P_‖ := norm_add_le _ _
+      _ = ‖(A - Aℚ) P‖ + ‖Aℚ (P - P_)‖ := by
+          rw [ContinuousLinearMap.sub_apply, map_sub]
+      _ ≤ ‖A - Aℚ‖ * ‖P‖ + ‖Aℚ‖ * ‖P - P_‖ := by
+          gcongr
+          · exact ContinuousLinearMap.le_opNorm _ _
+          · exact ContinuousLinearMap.le_opNorm _ _
+      _ ≤ κ * 1 + (1 + κ) * κ := by
+          have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+          gcongr
+      _ = 2 * κ + κ ^ 2 := by ring
+  -- Bound ‖Aℚ P_‖
+  have hAℚP_ : ‖Aℚ P_‖ ≤ (1 + κ) * (1 + κ) := by
+    have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+    have hP_ : ‖P_‖ ≤ 1 + κ := by
+      calc ‖P_‖ ≤ ‖P‖ + ‖P - P_‖ := norm_le_insert P P_
+        _ ≤ 1 + κ := by linarith
+    calc ‖Aℚ P_‖
+      _ ≤ ‖Aℚ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
+      _ ≤ (1 + κ) * (1 + κ) := by
+          apply mul_le_mul hAℚnorm hP_ (norm_nonneg _) (by linarith)
+  have key : ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ ≤ 4 * κ := by
+    have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+    calc ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖
+      _ ≤ ‖R (A P - Aℚ P_)‖ + ‖(R - Rℚ) (Aℚ P_)‖ := norm_add_le _ _
+      _ ≤ ‖R‖ * ‖A P - Aℚ P_‖ + ‖R - Rℚ‖ * ‖Aℚ P_‖ := by
+          gcongr
+          · exact ContinuousLinearMap.le_opNorm _ _
+          · exact ContinuousLinearMap.le_opNorm _ _
+      _ ≤ 1 * (2 * κ + κ ^ 2) + κ * ((1 + κ) * (1 + κ)) := by
+          have hκ2 : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+          gcongr
+      _ ≤ 4 * κ := by unfold κ; norm_num
+  calc ‖@inner ℝ G _ (R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)) w‖
+    _ ≤ ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ * ‖w‖ := norm_inner_le_norm (𝕜 := ℝ) _ _
+    _ = ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ := by rw [hw, mul_one]
+    _ ≤ 4 * κ := key
 
 lemma bounds_kappa_RM (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR α (rotM θ φ P), w⟫ - ⟪rotRℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ := by
-  sorry
+    ‖⟪rotR α (rotM θ φ P), w⟫ - ⟪rotRℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+  inner_four_kappa
+    (le_of_eq (Bounding.rotR_norm_one _))
+    (Rℚ_norm_bounded _ (icc_int_to_real α))
+    (R_difference_norm_bounded _ (icc_int_to_real α))
+    (le_of_eq (Bounding.rotM_norm_one _ _))
+    (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
+    (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    hP approx hw
 
 lemma bounds_kappa_R'M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotR' α (rotM θ φ P), w⟫ - ⟪rotR'ℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ := by
-  sorry
+  have hR'ℚ : ‖rotR'ℚ (α : ℝ)‖ ≤ 1 + κ := by
+    calc ‖rotR'ℚ (α : ℝ)‖
+      _ ≤ ‖rotR' (α : ℝ)‖ + ‖rotR' (α : ℝ) - rotR'ℚ (α : ℝ)‖ := norm_le_insert _ _
+      _ = 1 + ‖rotR' (α : ℝ) - rotR'ℚ (α : ℝ)‖ := by rw [Bounding.rotR'_norm_one]
+      _ ≤ 1 + κ := by gcongr; exact R'_difference_norm_bounded _ (icc_int_to_real α)
+  exact inner_four_kappa
+    (le_of_eq (Bounding.rotR'_norm_one _))
+    hR'ℚ
+    (R'_difference_norm_bounded _ (icc_int_to_real α))
+    (le_of_eq (Bounding.rotM_norm_one _ _))
+    (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
+    (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    hP approx hw
 
 lemma bounds_kappa_RMθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotR α (rotMθ θ φ P), w⟫ - ⟪rotRℚ α (rotMθℚ θ φ P_), w⟫‖ ≤ 4 * κ := by
-  sorry
+  have hMθℚ : ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
+    calc ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖
+      _ ≤ ‖rotMθ (θ : ℝ) (φ : ℝ)‖ + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ :=
+          norm_le_insert _ _
+      _ ≤ 1 + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ := by
+          gcongr; exact Bounding.rotMθ_norm_le_one _ _
+      _ ≤ 1 + κ := by
+          gcongr; exact Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  exact inner_four_kappa
+    (le_of_eq (Bounding.rotR_norm_one _))
+    (Rℚ_norm_bounded _ (icc_int_to_real α))
+    (R_difference_norm_bounded _ (icc_int_to_real α))
+    (Bounding.rotMθ_norm_le_one _ _)
+    hMθℚ
+    (Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    hP approx hw
 
 lemma bounds_kappa_RMφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotR α (rotMφ θ φ P), w⟫ - ⟪rotRℚ α (rotMφℚ θ φ P_), w⟫‖ ≤ 4 * κ := by
-  sorry
+  have hMφℚ : ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
+    calc ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖
+      _ ≤ ‖rotMφ (θ : ℝ) (φ : ℝ)‖ + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ :=
+          norm_le_insert _ _
+      _ ≤ 1 + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ := by
+          gcongr; exact Bounding.rotMφ_norm_le_one _ _
+      _ ≤ 1 + κ := by
+          gcongr; exact Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  exact inner_four_kappa
+    (le_of_eq (Bounding.rotR_norm_one _))
+    (Rℚ_norm_bounded _ (icc_int_to_real α))
+    (R_difference_norm_bounded _ (icc_int_to_real α))
+    (Bounding.rotMφ_norm_le_one _ _)
+    hMφℚ
+    (Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    hP approx hw

--- a/Noperthedron/RationalApprox/BoundsKappa.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa.lean
@@ -10,17 +10,12 @@ namespace RationalApprox
 
 variable {P P_ : ℝ³} {α θ φ : Set.Icc (-4) 4} {w : ℝ²}
 
-/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
-private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
-    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 := by
-  exact ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
-
 /-!
 ## Helper lemma
 
 The 3κ bound pattern: for any pair of continuous linear maps `A, Aℚ` where
-`‖A - Aℚ‖ ≤ κ`, `‖A‖ ≤ 1`, `‖Aℚ‖ ≤ 1 + κ`, and points `P, P_` with
-`‖P‖ ≤ 1`, `‖P - P_‖ ≤ κ`, we get `‖A P - Aℚ P_‖ ≤ 2κ + κ² ≤ 3κ`.
+`‖A - Aℚ‖ ≤ κ`, `‖Aℚ‖ ≤ 1 + κ`, and points `P, P_` with
+`‖P‖ ≤ 1`, `‖P - P_‖ ≤ κ`, we get `|⟪A P, w⟫ - ⟪Aℚ P_, w⟫| ≤ 3κ`.
 -/
 
 private lemma inner_three_kappa {E F : Type*}
@@ -31,26 +26,9 @@ private lemma inner_three_kappa {E F : Type*}
     (hAdiff : ‖A - Aℚ‖ ≤ κ) (hP : ‖P‖ ≤ 1)
     (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖@inner ℝ F _ (A P) w - @inner ℝ F _ (Aℚ P_) w‖ ≤ 3 * κ := by
-  -- Step 1: ⟪A P, w⟫ - ⟪Aℚ P_, w⟫ = ⟪A P - Aℚ P_, w⟫
   rw [← inner_sub_left]
-  -- Step 2: |⟪v, w⟫| ≤ ‖v‖ * ‖w‖, then simplify with ‖w‖ = 1
-  have key : ‖A P - Aℚ P_‖ ≤ 3 * κ := by
-    -- A P - Aℚ P_ = (A P - Aℚ P) + (Aℚ P - Aℚ P_)
-    have split : A P - Aℚ P_ = (A P - Aℚ P) + (Aℚ P - Aℚ P_) := by
-      abel
-    rw [split]
-    calc ‖(A P - Aℚ P) + (Aℚ P - Aℚ P_)‖
-      _ ≤ ‖A P - Aℚ P‖ + ‖Aℚ P - Aℚ P_‖ := norm_add_le _ _
-      _ = ‖(A - Aℚ) P‖ + ‖Aℚ (P - P_)‖ := by
-          rw [ContinuousLinearMap.sub_apply, map_sub]
-      _ ≤ ‖A - Aℚ‖ * ‖P‖ + ‖Aℚ‖ * ‖P - P_‖ := by
-          gcongr
-          · exact ContinuousLinearMap.le_opNorm _ _
-          · exact ContinuousLinearMap.le_opNorm _ _
-      _ ≤ κ * 1 + (1 + κ) * κ := by
-          have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
-          gcongr
-      _ ≤ 3 * κ := by unfold κ; norm_num
+  have key : ‖A P - Aℚ P_‖ ≤ 3 * κ :=
+    (clm_approx_apply_sub hAdiff hAℚnorm hP approx).trans (by unfold κ; norm_num)
   calc ‖@inner ℝ F _ (A P - Aℚ P_) w‖
     _ ≤ ‖A P - Aℚ P_‖ * ‖w‖ := norm_inner_le_norm (𝕜 := ℝ) _ _
     _ = ‖A P - Aℚ P_‖ * 1 := by rw [hw]
@@ -69,34 +47,16 @@ lemma bounds_kappa_M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : �
     hP approx hw
 
 lemma bounds_kappa_Mθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotMθ θ φ P, w⟫ - ⟪rotMθℚ θ φ P_, w⟫‖ ≤ 3 * κ := by
-  -- Need Mθℚ_norm_bounded inline
-  have hMθℚ : ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
-    calc ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖
-      _ ≤ ‖rotMθ (θ : ℝ) (φ : ℝ)‖ + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ :=
-          norm_le_insert _ _
-      _ ≤ 1 + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ := by
-          gcongr; exact Bounding.rotMθ_norm_le_one _ _
-      _ ≤ 1 + κ := by
-          gcongr; exact Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
-  exact inner_three_kappa
-    hMθℚ
+    ‖⟪rotMθ θ φ P, w⟫ - ⟪rotMθℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
+  inner_three_kappa
+    (Mθℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
     (Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
     hP approx hw
 
 lemma bounds_kappa_Mφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotMφ θ φ P, w⟫ - ⟪rotMφℚ θ φ P_, w⟫‖ ≤ 3 * κ := by
-  -- Need Mφℚ_norm_bounded inline
-  have hMφℚ : ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
-    calc ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖
-      _ ≤ ‖rotMφ (θ : ℝ) (φ : ℝ)‖ + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ :=
-          norm_le_insert _ _
-      _ ≤ 1 + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ := by
-          gcongr; exact Bounding.rotMφ_norm_le_one _ _
-      _ ≤ 1 + κ := by
-          gcongr; exact Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
-  exact inner_three_kappa
-    hMφℚ
+    ‖⟪rotMφ θ φ P, w⟫ - ⟪rotMφℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
+  inner_three_kappa
+    (Mφℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
     (Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
     hP approx hw
 
@@ -113,43 +73,24 @@ private lemma inner_four_kappa {E F G : Type*}
     [SeminormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup G]
     [InnerProductSpace ℝ G] [NormedSpace ℝ E] [NormedSpace ℝ F]
     {A Aℚ : E →L[ℝ] F} {R Rℚ : F →L[ℝ] G} {P P_ : E} {w : G}
-    (hRnorm : ‖R‖ ≤ 1) (_hRℚnorm : ‖Rℚ‖ ≤ 1 + κ)
+    (hRnorm : ‖R‖ ≤ 1)
     (hRdiff : ‖R - Rℚ‖ ≤ κ)
-    (_hAnorm : ‖A‖ ≤ 1) (hAℚnorm : ‖Aℚ‖ ≤ 1 + κ)
+    (hAℚnorm : ‖Aℚ‖ ≤ 1 + κ)
     (hAdiff : ‖A - Aℚ‖ ≤ κ)
     (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖@inner ℝ G _ (R (A P)) w - @inner ℝ G _ (Rℚ (Aℚ P_)) w‖ ≤ 4 * κ := by
   rw [← inner_sub_left]
-  -- R(A P) - Rℚ(Aℚ P_) = R(A P - Aℚ P_) + (R - Rℚ)(Aℚ P_)
   have decomp : R (A P) - Rℚ (Aℚ P_) = R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_) := by
     simp [map_sub, ContinuousLinearMap.sub_apply]
   rw [decomp]
-  -- Bound ‖A P - Aℚ P_‖
-  have hAP_diff : ‖A P - Aℚ P_‖ ≤ 2 * κ + κ ^ 2 := by
-    have split : A P - Aℚ P_ = (A P - Aℚ P) + (Aℚ P - Aℚ P_) := by abel
-    rw [split]
-    calc ‖(A P - Aℚ P) + (Aℚ P - Aℚ P_)‖
-      _ ≤ ‖A P - Aℚ P‖ + ‖Aℚ P - Aℚ P_‖ := norm_add_le _ _
-      _ = ‖(A - Aℚ) P‖ + ‖Aℚ (P - P_)‖ := by
-          rw [ContinuousLinearMap.sub_apply, map_sub]
-      _ ≤ ‖A - Aℚ‖ * ‖P‖ + ‖Aℚ‖ * ‖P - P_‖ := by
-          gcongr
-          · exact ContinuousLinearMap.le_opNorm _ _
-          · exact ContinuousLinearMap.le_opNorm _ _
-      _ ≤ κ * 1 + (1 + κ) * κ := by
-          have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
-          gcongr
-      _ = 2 * κ + κ ^ 2 := by ring
-  -- Bound ‖Aℚ P_‖
+  have hAP_diff : ‖A P - Aℚ P_‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hAdiff hAℚnorm hP approx
   have hAℚP_ : ‖Aℚ P_‖ ≤ (1 + κ) * (1 + κ) := by
-    have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
-    have hP_ : ‖P_‖ ≤ 1 + κ := by
-      calc ‖P_‖ ≤ ‖P‖ + ‖P - P_‖ := norm_le_insert P P_
-        _ ≤ 1 + κ := by linarith
+    have hP_ : ‖P_‖ ≤ 1 + κ := by linarith [norm_le_insert P P_]
     calc ‖Aℚ P_‖
       _ ≤ ‖Aℚ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
-      _ ≤ (1 + κ) * (1 + κ) := by
-          apply mul_le_mul hAℚnorm hP_ (norm_nonneg _) (by linarith)
+      _ ≤ (1 + κ) * (1 + κ) :=
+          mul_le_mul hAℚnorm hP_ (norm_nonneg _) (by norm_num [κ])
   have key : ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ ≤ 4 * κ := by
     have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
     calc ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖
@@ -158,9 +99,7 @@ private lemma inner_four_kappa {E F G : Type*}
           gcongr
           · exact ContinuousLinearMap.le_opNorm _ _
           · exact ContinuousLinearMap.le_opNorm _ _
-      _ ≤ 1 * (2 * κ + κ ^ 2) + κ * ((1 + κ) * (1 + κ)) := by
-          have hκ2 : (0 : ℝ) ≤ κ := by unfold κ; norm_num
-          gcongr
+      _ ≤ 1 * (2 * κ + κ ^ 2) + κ * ((1 + κ) * (1 + κ)) := by gcongr
       _ ≤ 4 * κ := by unfold κ; norm_num
   calc ‖@inner ℝ G _ (R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)) w‖
     _ ≤ ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ * ‖w‖ := norm_inner_le_norm (𝕜 := ℝ) _ _
@@ -171,63 +110,34 @@ lemma bounds_kappa_RM (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : 
     ‖⟪rotR α (rotM θ φ P), w⟫ - ⟪rotRℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
-    (Rℚ_norm_bounded _ (icc_int_to_real α))
     (R_difference_norm_bounded _ (icc_int_to_real α))
-    (le_of_eq (Bounding.rotM_norm_one _ _))
     (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
     (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
     hP approx hw
 
 lemma bounds_kappa_R'M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR' α (rotM θ φ P), w⟫ - ⟪rotR'ℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ := by
-  have hR'ℚ : ‖rotR'ℚ (α : ℝ)‖ ≤ 1 + κ := by
-    calc ‖rotR'ℚ (α : ℝ)‖
-      _ ≤ ‖rotR' (α : ℝ)‖ + ‖rotR' (α : ℝ) - rotR'ℚ (α : ℝ)‖ := norm_le_insert _ _
-      _ = 1 + ‖rotR' (α : ℝ) - rotR'ℚ (α : ℝ)‖ := by rw [Bounding.rotR'_norm_one]
-      _ ≤ 1 + κ := by gcongr; exact R'_difference_norm_bounded _ (icc_int_to_real α)
-  exact inner_four_kappa
+    ‖⟪rotR' α (rotM θ φ P), w⟫ - ⟪rotR'ℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+  inner_four_kappa
     (le_of_eq (Bounding.rotR'_norm_one _))
-    hR'ℚ
     (R'_difference_norm_bounded _ (icc_int_to_real α))
-    (le_of_eq (Bounding.rotM_norm_one _ _))
     (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
     (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
     hP approx hw
 
 lemma bounds_kappa_RMθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR α (rotMθ θ φ P), w⟫ - ⟪rotRℚ α (rotMθℚ θ φ P_), w⟫‖ ≤ 4 * κ := by
-  have hMθℚ : ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
-    calc ‖rotMθℚ (θ : ℝ) (φ : ℝ)‖
-      _ ≤ ‖rotMθ (θ : ℝ) (φ : ℝ)‖ + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ :=
-          norm_le_insert _ _
-      _ ≤ 1 + ‖rotMθ (θ : ℝ) (φ : ℝ) - rotMθℚ (θ : ℝ) (φ : ℝ)‖ := by
-          gcongr; exact Bounding.rotMθ_norm_le_one _ _
-      _ ≤ 1 + κ := by
-          gcongr; exact Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
-  exact inner_four_kappa
+    ‖⟪rotR α (rotMθ θ φ P), w⟫ - ⟪rotRℚ α (rotMθℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+  inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
-    (Rℚ_norm_bounded _ (icc_int_to_real α))
     (R_difference_norm_bounded _ (icc_int_to_real α))
-    (Bounding.rotMθ_norm_le_one _ _)
-    hMθℚ
+    (Mθℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
     (Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
     hP approx hw
 
 lemma bounds_kappa_RMφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR α (rotMφ θ φ P), w⟫ - ⟪rotRℚ α (rotMφℚ θ φ P_), w⟫‖ ≤ 4 * κ := by
-  have hMφℚ : ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ := by
-    calc ‖rotMφℚ (θ : ℝ) (φ : ℝ)‖
-      _ ≤ ‖rotMφ (θ : ℝ) (φ : ℝ)‖ + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ :=
-          norm_le_insert _ _
-      _ ≤ 1 + ‖rotMφ (θ : ℝ) (φ : ℝ) - rotMφℚ (θ : ℝ) (φ : ℝ)‖ := by
-          gcongr; exact Bounding.rotMφ_norm_le_one _ _
-      _ ≤ 1 + κ := by
-          gcongr; exact Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
-  exact inner_four_kappa
+    ‖⟪rotR α (rotMφ θ φ P), w⟫ - ⟪rotRℚ α (rotMφℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+  inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
-    (Rℚ_norm_bounded _ (icc_int_to_real α))
     (R_difference_norm_bounded _ (icc_int_to_real α))
-    (Bounding.rotMφ_norm_le_one _ _)
-    hMφℚ
+    (Mφℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
     (Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
     hP approx hw

--- a/Noperthedron/RationalApprox/BoundsKappa.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa.lean
@@ -27,13 +27,10 @@ private lemma inner_three_kappa {E F : Type*}
     (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖@inner ℝ F _ (A P) w - @inner ℝ F _ (Aℚ P_) w‖ ≤ 3 * κ := by
   rw [← inner_sub_left]
-  have key : ‖A P - Aℚ P_‖ ≤ 3 * κ :=
-    (clm_approx_apply_sub hAdiff hAℚnorm hP approx).trans (by unfold κ; norm_num)
   calc ‖@inner ℝ F _ (A P - Aℚ P_) w‖
     _ ≤ ‖A P - Aℚ P_‖ * ‖w‖ := norm_inner_le_norm (𝕜 := ℝ) _ _
-    _ = ‖A P - Aℚ P_‖ * 1 := by rw [hw]
-    _ = ‖A P - Aℚ P_‖ := mul_one _
-    _ ≤ 3 * κ := key
+    _ = ‖A P - Aℚ P_‖ := by rw [hw, mul_one]
+    _ ≤ 3 * κ := (clm_approx_apply_sub hAdiff hAℚnorm hP approx).trans (by unfold κ; norm_num)
 
 /-!
 [SY25] Lemma 44
@@ -79,10 +76,8 @@ private lemma inner_four_kappa {E F G : Type*}
     (hAdiff : ‖A - Aℚ‖ ≤ κ)
     (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖@inner ℝ G _ (R (A P)) w - @inner ℝ G _ (Rℚ (Aℚ P_)) w‖ ≤ 4 * κ := by
-  rw [← inner_sub_left]
-  have decomp : R (A P) - Rℚ (Aℚ P_) = R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_) := by
-    simp [map_sub, ContinuousLinearMap.sub_apply]
-  rw [decomp]
+  rw [← inner_sub_left, show R (A P) - Rℚ (Aℚ P_) = R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_) from by
+    simp [map_sub, ContinuousLinearMap.sub_apply]]
   have hAP_diff : ‖A P - Aℚ P_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hAdiff hAℚnorm hP approx
   have hAℚP_ : ‖Aℚ P_‖ ≤ (1 + κ) * (1 + κ) := by
@@ -91,20 +86,16 @@ private lemma inner_four_kappa {E F G : Type*}
       _ ≤ ‖Aℚ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
       _ ≤ (1 + κ) * (1 + κ) :=
           mul_le_mul hAℚnorm hP_ (norm_nonneg _) (by norm_num [κ])
-  have key : ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ ≤ 4 * κ := by
-    have hκ : (0 : ℝ) ≤ κ := by unfold κ; norm_num
-    calc ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖
-      _ ≤ ‖R (A P - Aℚ P_)‖ + ‖(R - Rℚ) (Aℚ P_)‖ := norm_add_le _ _
-      _ ≤ ‖R‖ * ‖A P - Aℚ P_‖ + ‖R - Rℚ‖ * ‖Aℚ P_‖ := by
-          gcongr
-          · exact ContinuousLinearMap.le_opNorm _ _
-          · exact ContinuousLinearMap.le_opNorm _ _
-      _ ≤ 1 * (2 * κ + κ ^ 2) + κ * ((1 + κ) * (1 + κ)) := by gcongr
-      _ ≤ 4 * κ := by unfold κ; norm_num
   calc ‖@inner ℝ G _ (R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)) w‖
     _ ≤ ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ * ‖w‖ := norm_inner_le_norm (𝕜 := ℝ) _ _
     _ = ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ := by rw [hw, mul_one]
-    _ ≤ 4 * κ := key
+    _ ≤ ‖R (A P - Aℚ P_)‖ + ‖(R - Rℚ) (Aℚ P_)‖ := norm_add_le _ _
+    _ ≤ ‖R‖ * ‖A P - Aℚ P_‖ + ‖R - Rℚ‖ * ‖Aℚ P_‖ := by
+        gcongr <;> exact ContinuousLinearMap.le_opNorm _ _
+    _ ≤ 1 * (2 * κ + κ ^ 2) + κ * ((1 + κ) * (1 + κ)) := by
+        have : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+        gcongr
+    _ ≤ 4 * κ := by unfold κ; norm_num
 
 lemma bounds_kappa_RM (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotR α (rotM θ φ P), w⟫ - ⟪rotRℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=

--- a/Noperthedron/RationalApprox/BoundsKappa.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa.lean
@@ -80,12 +80,7 @@ private lemma inner_four_kappa {E F G : Type*}
     simp [map_sub, ContinuousLinearMap.sub_apply]]
   have hAP_diff : ‖A P - Aℚ P_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hAdiff hAℚnorm hP approx
-  have hAℚP_ : ‖Aℚ P_‖ ≤ (1 + κ) * (1 + κ) := by
-    have hP_ : ‖P_‖ ≤ 1 + κ := by linarith [norm_le_insert P P_]
-    calc ‖Aℚ P_‖
-      _ ≤ ‖Aℚ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
-      _ ≤ (1 + κ) * (1 + κ) :=
-          mul_le_mul hAℚnorm hP_ (norm_nonneg _) (by norm_num [κ])
+  have hAℚP_ : ‖Aℚ P_‖ ≤ (1 + κ) * (1 + κ) := approx_image_norm_le hAℚnorm hP approx
   calc ‖@inner ℝ G _ (R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)) w‖
     _ ≤ ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ * ‖w‖ := norm_inner_le_norm (𝕜 := ℝ) _ _
     _ = ‖R (A P - Aℚ P_) + (R - Rℚ) (Aℚ P_)‖ := by rw [hw, mul_one]

--- a/Noperthedron/RationalApprox/BoundsKappa3.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa3.lean
@@ -87,15 +87,10 @@ lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P 
     clm_approx_apply_sub hMdiff hMℚnorm hQ Qapprox
   -- Bound ‖rotM Q‖
   have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 1 := by
-    calc ‖(rotM ↑θ ↑φ) Q‖
-      _ ≤ ‖rotM ↑θ ↑φ‖ * ‖Q‖ := ContinuousLinearMap.le_opNorm _ _
-      _ = 1 * ‖Q‖ := by rw [Bounding.rotM_norm_one]
-      _ ≤ 1 * 1 := by gcongr
-      _ = 1 := one_mul _
+    have h := ContinuousLinearMap.le_opNorm (rotM ↑θ ↑φ) Q
+    rw [Bounding.rotM_norm_one, one_mul] at h; linarith
   -- Bound ‖rotMℚ P_‖
-  have hP_ : ‖P_‖ ≤ 1 + κ := by
-    calc ‖P_‖ ≤ ‖P‖ + ‖P - P_‖ := norm_le_insert P P_
-      _ ≤ 1 + κ := add_le_add hP Papprox
+  have hP_ : ‖P_‖ ≤ 1 + κ := by linarith [norm_le_insert P P_]
   have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) := by
     calc ‖(rotMℚ ↑θ ↑φ) P_‖
       _ ≤ ‖rotMℚ ↑θ ↑φ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _

--- a/Noperthedron/RationalApprox/BoundsKappa3.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa3.lean
@@ -86,16 +86,10 @@ lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P 
   have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hMdiff hMℚnorm hQ Qapprox
   -- Bound ‖rotM Q‖
-  have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 1 := by
-    have h := ContinuousLinearMap.le_opNorm (rotM ↑θ ↑φ) Q
-    rw [Bounding.rotM_norm_one, one_mul] at h; linarith
+  have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 1 := clm_unit_apply_le (le_of_eq (Bounding.rotM_norm_one _ _)) hQ
   -- Bound ‖rotMℚ P_‖
-  have hP_ : ‖P_‖ ≤ 1 + κ := by linarith [norm_le_insert P P_]
-  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) := by
-    calc ‖(rotMℚ ↑θ ↑φ) P_‖
-      _ ≤ ‖rotMℚ ↑θ ↑φ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
-      _ ≤ (1 + κ) * (1 + κ) :=
-          mul_le_mul hMℚnorm hP_ (norm_nonneg _) (by norm_num [κ])
+  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) :=
+    approx_image_norm_le hMℚnorm hP Papprox
   calc |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
         ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫|
     _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +

--- a/Noperthedron/RationalApprox/BoundsKappa3.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa3.lean
@@ -2,6 +2,8 @@ import Mathlib.Algebra.Lie.OfAssociative
 import Noperthedron.PointSym
 import Noperthedron.PoseInterval
 import Noperthedron.RationalApprox.Basic
+import Noperthedron.RationalApprox.MatrixBounds
+import Noperthedron.Local.Prelims
 
 open scoped RealInnerProductSpace
 
@@ -9,18 +11,157 @@ namespace RationalApprox
 
 variable {P Q Q_ P_ : ℝ³} {α θ φ : Set.Icc (-4) 4} {w : ℝ²}
 
+/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
+private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
+    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 :=
+  ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
+
+/-!
+## Helper: vector norm difference bound
+
+The operator norm bound `‖vecXL θ φ - vecXLℚ θ φ‖ ≤ κ` implies
+the vector norm bound `‖vecX θ φ - vecXℚ θ φ‖ ≤ κ` because `vecX`
+is the image of the unit basis vector under the column-matrix linear map `vecXL`.
+-/
+
+private lemma vecX_sub_vecXℚ_norm_le (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
+    (hφ : φ ∈ Set.Icc (-4) 4) :
+    ‖vecX θ φ - vecXℚ θ φ‖ ≤ κ := by
+  -- vecX θ φ - vecXℚ θ φ = (vecXL θ φ - vecXLℚ θ φ) (single 0 1)
+  have h_eq : vecX θ φ - vecXℚ θ φ = (vecXL θ φ - vecXLℚ θ φ) (EuclideanSpace.single 0 1) := by
+    simp [vecX, vecXℚ, vecXL, vecX_mat, vecXLℚ, vecXℚ_mat, ContinuousLinearMap.sub_apply,
+      Matrix.toEuclideanLin_apply]
+    ext i; fin_cases i <;> simp
+  rw [h_eq]
+  calc ‖(vecXL θ φ - vecXLℚ θ φ) (EuclideanSpace.single 0 1)‖
+    _ ≤ ‖vecXL θ φ - vecXLℚ θ φ‖ * ‖EuclideanSpace.single (𝕜 := ℝ) 0 (1 : ℝ)‖ :=
+        ContinuousLinearMap.le_opNorm _ _
+    _ = ‖vecXL θ φ - vecXLℚ θ φ‖ * 1 := by rw [EuclideanSpace.norm_single, norm_one]
+    _ = ‖vecXL θ φ - vecXLℚ θ φ‖ := mul_one _
+    _ ≤ κ := X_difference_norm_bounded θ φ hθ hφ
+
+private lemma vecXℚ_norm_le (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
+    (hφ : φ ∈ Set.Icc (-4) 4) :
+    ‖vecXℚ θ φ‖ ≤ 1 + κ := by
+  calc ‖vecXℚ θ φ‖
+    _ ≤ ‖vecX θ φ‖ + ‖vecX θ φ - vecXℚ θ φ‖ := norm_le_insert _ _
+    _ = 1 + ‖vecX θ φ - vecXℚ θ φ‖ := by rw [vecX_norm_one]
+    _ ≤ 1 + κ := by gcongr; exact vecX_sub_vecXℚ_norm_le θ φ hθ hφ
+
 /-!
 [SY25] Lemma 49
 -/
 
 lemma bounds_kappa3_X (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     ‖⟪vecX θ φ, P⟫ - ⟪vecXℚ θ φ, P_⟫‖ ≤ 3 * κ := by
-  sorry
+  -- Decompose: ⟪vecX, P⟫ - ⟪vecXℚ, P_⟫ = ⟪vecX - vecXℚ, P⟫ + ⟪vecXℚ, P - P_⟫
+  have decomp : ⟪vecX θ φ, P⟫ - ⟪vecXℚ θ φ, P_⟫ =
+      ⟪vecX θ φ - vecXℚ θ φ, P⟫ + ⟪vecXℚ θ φ, P - P_⟫ := by
+    simp [inner_sub_left, inner_sub_right]
+  rw [decomp, Real.norm_eq_abs]
+  calc |⟪vecX ↑θ ↑φ - vecXℚ ↑θ ↑φ, P⟫ + ⟪vecXℚ ↑θ ↑φ, P - P_⟫|
+    _ ≤ |⟪vecX ↑θ ↑φ - vecXℚ ↑θ ↑φ, P⟫| + |⟪vecXℚ ↑θ ↑φ, P - P_⟫| := abs_add_le _ _
+    _ ≤ ‖vecX ↑θ ↑φ - vecXℚ ↑θ ↑φ‖ * ‖P‖ + ‖vecXℚ ↑θ ↑φ‖ * ‖P - P_‖ :=
+        add_le_add (abs_real_inner_le_norm _ _) (abs_real_inner_le_norm _ _)
+    _ ≤ κ * 1 + (1 + κ) * κ :=
+        add_le_add
+          (mul_le_mul (vecX_sub_vecXℚ_norm_le _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+            hP (norm_nonneg _) (by norm_num [κ]))
+          (mul_le_mul (vecXℚ_norm_le _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+            Papprox (norm_nonneg _) (by norm_num [κ]))
+    _ ≤ 3 * κ := by unfold κ; norm_num
 
 lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     ‖⟪rotM θ φ P, rotM θ φ Q⟫ - ⟪rotMℚ θ φ P_, rotMℚ θ φ Q_⟫‖ ≤ 5 * κ := by
-  sorry
+  rw [Real.norm_eq_abs]
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+  -- Decompose: ⟪rotM P, rotM Q⟫ - ⟪rotMℚ P_, rotMℚ Q_⟫
+  --   = ⟪rotM P - rotMℚ P_, rotM Q⟫ + ⟪rotMℚ P_, rotM Q - rotMℚ Q_⟫
+  have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫ =
+      ⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+      ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫ := by
+    simp [inner_sub_left, inner_sub_right]
+  rw [decomp]
+  -- Bound ‖rotM P - rotMℚ P_‖
+  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 := by
+    calc ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖
+      _ = ‖((rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P) + ((rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_)‖ := by congr 1; abel
+      _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ := norm_add_le _ _
+      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) (P - P_)‖ := by
+          rw [ContinuousLinearMap.sub_apply, map_sub]
+      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖P - P_‖ :=
+          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+      _ ≤ κ * 1 + (1 + κ) * κ :=
+          add_le_add
+            (mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ]))
+            (mul_le_mul hMℚnorm Papprox (norm_nonneg _) (by norm_num [κ]))
+      _ = 2 * κ + κ ^ 2 := by ring
+  -- Bound ‖rotM Q - rotMℚ Q_‖
+  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 2 * κ + κ ^ 2 := by
+    calc ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖
+      _ = ‖((rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q) + ((rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_)‖ := by congr 1; abel
+      _ ≤ ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ := norm_add_le _ _
+      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) (Q - Q_)‖ := by
+          rw [ContinuousLinearMap.sub_apply, map_sub]
+      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖Q - Q_‖ :=
+          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+      _ ≤ κ * 1 + (1 + κ) * κ :=
+          add_le_add
+            (mul_le_mul hMdiff hQ (norm_nonneg _) (by norm_num [κ]))
+            (mul_le_mul hMℚnorm Qapprox (norm_nonneg _) (by norm_num [κ]))
+      _ = 2 * κ + κ ^ 2 := by ring
+  -- Bound ‖rotM Q‖
+  have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 1 := by
+    calc ‖(rotM ↑θ ↑φ) Q‖
+      _ ≤ ‖rotM ↑θ ↑φ‖ * ‖Q‖ := ContinuousLinearMap.le_opNorm _ _
+      _ = 1 * ‖Q‖ := by rw [Bounding.rotM_norm_one]
+      _ ≤ 1 * 1 := by gcongr
+      _ = 1 := one_mul _
+  -- Bound ‖rotMℚ P_‖
+  have hP_ : ‖P_‖ ≤ 1 + κ := by
+    calc ‖P_‖ ≤ ‖P‖ + ‖P - P_‖ := norm_le_insert P P_
+      _ ≤ 1 + κ := add_le_add hP Papprox
+  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) := by
+    calc ‖(rotMℚ ↑θ ↑φ) P_‖
+      _ ≤ ‖rotMℚ ↑θ ↑φ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
+      _ ≤ (1 + κ) * (1 + κ) :=
+          mul_le_mul hMℚnorm hP_ (norm_nonneg _) (by norm_num [κ])
+  calc |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+        ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫|
+    _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
+        |⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫| := abs_add_le _ _
+    _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q‖ +
+        ‖(rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ :=
+        add_le_add (abs_real_inner_le_norm _ _) (abs_real_inner_le_norm _ _)
+    _ ≤ (2 * κ + κ ^ 2) * 1 + (1 + κ) * (1 + κ) * (2 * κ + κ ^ 2) :=
+        add_le_add
+          (mul_le_mul_of_nonneg_right hAP (norm_nonneg _) |>.trans
+            (mul_le_mul_of_nonneg_left hMQ (by norm_num [κ])))
+          (mul_le_mul hMℚP_ hBQ (norm_nonneg _) (by norm_num [κ]))
+    _ ≤ 5 * κ := by unfold κ; norm_num
 
 lemma bounds_kappa3_MQ (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     |(‖rotM θ φ Q‖ - ‖rotMℚ θ φ Q_‖)| ≤ 3 * κ := by
-  sorry
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+  -- Reverse triangle inequality: |‖a‖ - ‖b‖| ≤ ‖a - b‖
+  calc |(‖rotM θ φ Q‖ - ‖rotMℚ θ φ Q_‖)|
+    _ ≤ ‖rotM θ φ Q - rotMℚ θ φ Q_‖ := abs_norm_sub_norm_le _ _
+    -- Decompose: rotM Q - rotMℚ Q_ = (rotM Q - rotMℚ Q) + (rotMℚ Q - rotMℚ Q_)
+    _ = ‖((rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q) + ((rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_)‖ := by
+        congr 1; abel
+    _ ≤ ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ := norm_add_le _ _
+    _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) (Q - Q_)‖ := by
+        rw [ContinuousLinearMap.sub_apply, map_sub]
+    _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖Q - Q_‖ :=
+        add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+    _ ≤ κ * 1 + (1 + κ) * κ :=
+        add_le_add
+          (mul_le_mul hMdiff hQ (norm_nonneg _) (by norm_num [κ]))
+          (mul_le_mul hMℚnorm Qapprox (norm_nonneg _) (by norm_num [κ]))
+    _ ≤ 3 * κ := by unfold κ; norm_num

--- a/Noperthedron/RationalApprox/BoundsKappa3.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa3.lean
@@ -11,11 +11,6 @@ namespace RationalApprox
 
 variable {P Q Q_ P_ : ℝ³} {α θ φ : Set.Icc (-4) 4} {w : ℝ²}
 
-/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
-private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
-    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 :=
-  ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
-
 /-!
 ## Helper: vector norm difference bound
 
@@ -52,7 +47,7 @@ private lemma vecXℚ_norm_le (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
 [SY25] Lemma 49
 -/
 
-lemma bounds_kappa3_X (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
+lemma bounds_kappa3_X (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
     ‖⟪vecX θ φ, P⟫ - ⟪vecXℚ θ φ, P_⟫‖ ≤ 3 * κ := by
   -- Decompose: ⟪vecX, P⟫ - ⟪vecXℚ, P_⟫ = ⟪vecX - vecXℚ, P⟫ + ⟪vecXℚ, P - P_⟫
   have decomp : ⟪vecX θ φ, P⟫ - ⟪vecXℚ θ φ, P_⟫ =
@@ -85,34 +80,11 @@ lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P 
       ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫ := by
     simp [inner_sub_left, inner_sub_right]
   rw [decomp]
-  -- Bound ‖rotM P - rotMℚ P_‖
-  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 := by
-    calc ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖
-      _ = ‖((rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P) + ((rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_)‖ := by congr 1; abel
-      _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ := norm_add_le _ _
-      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) (P - P_)‖ := by
-          rw [ContinuousLinearMap.sub_apply, map_sub]
-      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖P - P_‖ :=
-          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-      _ ≤ κ * 1 + (1 + κ) * κ :=
-          add_le_add
-            (mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ]))
-            (mul_le_mul hMℚnorm Papprox (norm_nonneg _) (by norm_num [κ]))
-      _ = 2 * κ + κ ^ 2 := by ring
-  -- Bound ‖rotM Q - rotMℚ Q_‖
-  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 2 * κ + κ ^ 2 := by
-    calc ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖
-      _ = ‖((rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q) + ((rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_)‖ := by congr 1; abel
-      _ ≤ ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ := norm_add_le _ _
-      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) (Q - Q_)‖ := by
-          rw [ContinuousLinearMap.sub_apply, map_sub]
-      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖Q - Q_‖ :=
-          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-      _ ≤ κ * 1 + (1 + κ) * κ :=
-          add_le_add
-            (mul_le_mul hMdiff hQ (norm_nonneg _) (by norm_num [κ]))
-            (mul_le_mul hMℚnorm Qapprox (norm_nonneg _) (by norm_num [κ]))
-      _ = 2 * κ + κ ^ 2 := by ring
+  -- Bound ‖rotM P - rotMℚ P_‖ and ‖rotM Q - rotMℚ Q_‖
+  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hMdiff hMℚnorm hP Papprox
+  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hMdiff hMℚnorm hQ Qapprox
   -- Bound ‖rotM Q‖
   have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 1 := by
     calc ‖(rotM ↑θ ↑φ) Q‖
@@ -149,19 +121,8 @@ lemma bounds_kappa3_MQ (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
   have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
     Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
-  -- Reverse triangle inequality: |‖a‖ - ‖b‖| ≤ ‖a - b‖
+  -- Reverse triangle inequality + clm_approx_apply_sub
   calc |(‖rotM θ φ Q‖ - ‖rotMℚ θ φ Q_‖)|
     _ ≤ ‖rotM θ φ Q - rotMℚ θ φ Q_‖ := abs_norm_sub_norm_le _ _
-    -- Decompose: rotM Q - rotMℚ Q_ = (rotM Q - rotMℚ Q) + (rotMℚ Q - rotMℚ Q_)
-    _ = ‖((rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q) + ((rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_)‖ := by
-        congr 1; abel
-    _ ≤ ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ := norm_add_le _ _
-    _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) (Q - Q_)‖ := by
-        rw [ContinuousLinearMap.sub_apply, map_sub]
-    _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖Q - Q_‖ :=
-        add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-    _ ≤ κ * 1 + (1 + κ) * κ :=
-        add_le_add
-          (mul_le_mul hMdiff hQ (norm_nonneg _) (by norm_num [κ]))
-          (mul_le_mul hMℚnorm Qapprox (norm_nonneg _) (by norm_num [κ]))
+    _ ≤ 2 * κ + κ ^ 2 := clm_approx_apply_sub hMdiff hMℚnorm hQ Qapprox
     _ ≤ 3 * κ := by unfold κ; norm_num

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -52,29 +52,15 @@ private lemma inner_product_bound_10kappa
   have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hMdiff hMℚnorm hP Papprox
   -- Bound ‖rotM Q - rotMℚ Q_‖ (with ‖Q‖ ≤ 2 and ‖Q - Q_‖ ≤ 2κ)
-  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 4 * κ + 2 * κ ^ 2 := by
-    calc ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖
-      _ = ‖((rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q) + ((rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_)‖ := by
-          congr 1; abel
-      _ ≤ ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ :=
-          norm_add_le _ _
-      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) (Q - Q_)‖ := by
-          rw [ContinuousLinearMap.sub_apply, map_sub]
-      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖Q - Q_‖ :=
-          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-      _ ≤ κ * 2 + (1 + κ) * (2 * κ) :=
-          add_le_add
-            (mul_le_mul hMdiff hR (norm_nonneg _) (by norm_num [κ]))
-            (mul_le_mul hMℚnorm Qapprox (norm_nonneg _) (by norm_num [κ]))
-      _ = 4 * κ + 2 * κ ^ 2 := by ring
+  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 4 * κ + 2 * κ ^ 2 :=
+    clm_approx_apply_sub₂ hMdiff hMℚnorm hR Qapprox
   -- Bound ‖rotM Q‖
   have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 2 := by
     have := ContinuousLinearMap.le_opNorm (rotM ↑θ ↑φ) Q
     rw [Bounding.rotM_norm_one, one_mul] at this; linarith
   -- Bound ‖rotMℚ P_‖
   have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) :=
-    (ContinuousLinearMap.le_opNorm _ _).trans
-      (mul_le_mul hMℚnorm (by linarith [norm_le_insert P P_]) (norm_nonneg _) (by norm_num [κ]))
+    approx_image_norm_le hMℚnorm hP Papprox
   calc |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
         ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫|
     _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
@@ -120,21 +106,8 @@ private lemma norm_diff_bound_6kappa
       _ ≤ κ + κ := add_le_add Papprox Qapprox
       _ = 2 * κ := by ring
   -- ‖M(P-Q) - Mℚ(P_-Q_)‖ ≤ ‖(M-Mℚ)(P-Q)‖ + ‖Mℚ((P-Q)-(P_-Q_))‖
-  have h_diff : ‖(rotM ↑θ ↑φ) (P - Q) - (rotMℚ ↑θ ↑φ) (P_ - Q_)‖ ≤ 6 * κ := by
-    have h_split : (rotM ↑θ ↑φ) (P - Q) - (rotMℚ ↑θ ↑φ) (P_ - Q_) =
-        (rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) (P - Q) + (rotMℚ ↑θ ↑φ) ((P - Q) - (P_ - Q_)) := by
-      simp [ContinuousLinearMap.sub_apply, map_sub]; abel
-    rw [h_split]
-    calc ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) (P - Q) + (rotMℚ ↑θ ↑φ) ((P - Q) - (P_ - Q_))‖
-      _ ≤ ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) (P - Q)‖ + ‖(rotMℚ ↑θ ↑φ) ((P - Q) - (P_ - Q_))‖ :=
-          norm_add_le _ _
-      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P - Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖(P - Q) - (P_ - Q_)‖ :=
-          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-      _ ≤ κ * 2 + (1 + κ) * (2 * κ) :=
-          add_le_add
-            (mul_le_mul hMdiff hPQ_norm (norm_nonneg _) (by norm_num [κ]))
-            (mul_le_mul hMℚnorm hPQ_approx (norm_nonneg _) (by norm_num [κ]))
-      _ ≤ 6 * κ := by unfold κ; norm_num
+  have h_diff : ‖(rotM ↑θ ↑φ) (P - Q) - (rotMℚ ↑θ ↑φ) (P_ - Q_)‖ ≤ 6 * κ :=
+    (clm_approx_apply_sub₂ hMdiff hMℚnorm hPQ_norm hPQ_approx).trans (by unfold κ; norm_num)
   linarith [norm_le_insert' ((rotM ↑θ ↑φ) (P - Q)) ((rotMℚ ↑θ ↑φ) (P_ - Q_))]
 
 lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ)
@@ -186,8 +159,7 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
         (mul_le_mul_of_nonneg_left h_norm_PQ (by linarith)) (by positivity)
     linarith [h_inner_le, h_eps_term]
   -- Step 2: denA > 0
-  have h_denA_pos : 0 < denA := by
-    apply mul_pos <;> positivity
+  have h_denA_pos : 0 < denA := by positivity
   -- Step 3: denA ≤ denAℚ
   have h_denA_le : denA ≤ denAℚ := by
     -- Factor 1: ‖rotM P‖ + √2ε ≤ s.norm(rotMℚ P_) + √2ε + 3κ

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -2,6 +2,7 @@ import Mathlib.Algebra.Lie.OfAssociative
 import Noperthedron.PointSym
 import Noperthedron.PoseInterval
 import Noperthedron.RationalApprox.Basic
+import Noperthedron.RationalApprox.BoundsKappa3
 
 open scoped RealInnerProductSpace
 
@@ -22,7 +23,218 @@ def bounds_kappa4_Aℚ (s : UpperSqrt) :=
   (⟪rotMℚ θ φ P_, rotMℚ θ φ (P_ - Q_)⟫ - 10 * κ - 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)) /
   ((s.norm (rotMℚ θ φ P_) + √2 * ε + 3 * κ) * (s.norm (rotMℚ θ φ (P_ - Q_)) + 2 * √2 * ε + 6 * κ))
 
+/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
+private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
+    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 :=
+  ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
+
+/-- An `UpperSqrt` overestimates the Euclidean norm. -/
+private lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖ ≤ s.norm v := by
+  unfold UpperSqrt.norm
+  have h : (0 : ℝ) ≤ ‖v‖ ^ 2 := sq_nonneg _
+  calc ‖v‖ = √(‖v‖ ^ 2) := by rw [Real.sqrt_sq (norm_nonneg _)]
+    _ ≤ s.f (‖v‖ ^ 2) := s.bound _ h
+
+/-- The inner product bound for `rotM`/`rotMℚ` when the second vector has norm ≤ 2.
+This generalises `bounds_kappa3_M` (which requires ‖Q‖ ≤ 1) to handle `P − Q`. -/
+private lemma inner_product_bound_10kappa
+    {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4) 4}
+    (hP : ‖P‖ ≤ 1) (hR : ‖Q‖ ≤ 2)
+    (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ 2 * κ) :
+    |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫| ≤ 10 * κ := by
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+  -- Decompose: ⟪rotM P, rotM Q⟫ - ⟪rotMℚ P_, rotMℚ Q_⟫
+  --   = ⟪rotM P - rotMℚ P_, rotM Q⟫ + ⟪rotMℚ P_, rotM Q - rotMℚ Q_⟫
+  have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫ =
+      ⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+      ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫ := by
+    simp [inner_sub_left, inner_sub_right]
+  rw [decomp]
+  -- Bound ‖rotM P - rotMℚ P_‖
+  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 := by
+    calc ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖
+      _ = ‖((rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P) + ((rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_)‖ := by
+          congr 1; abel
+      _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ :=
+          norm_add_le _ _
+      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) (P - P_)‖ := by
+          rw [ContinuousLinearMap.sub_apply, map_sub]
+      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖P - P_‖ :=
+          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+      _ ≤ κ * 1 + (1 + κ) * κ :=
+          add_le_add
+            (mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ]))
+            (mul_le_mul hMℚnorm Papprox (norm_nonneg _) (by norm_num [κ]))
+      _ = 2 * κ + κ ^ 2 := by ring
+  -- Bound ‖rotM Q - rotMℚ Q_‖ (with ‖Q‖ ≤ 2 and ‖Q - Q_‖ ≤ 2κ)
+  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 4 * κ + 2 * κ ^ 2 := by
+    calc ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖
+      _ = ‖((rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q) + ((rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_)‖ := by
+          congr 1; abel
+      _ ≤ ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ :=
+          norm_add_le _ _
+      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) Q‖ + ‖(rotMℚ ↑θ ↑φ) (Q - Q_)‖ := by
+          rw [ContinuousLinearMap.sub_apply, map_sub]
+      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖Q - Q_‖ :=
+          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+      _ ≤ κ * 2 + (1 + κ) * (2 * κ) :=
+          add_le_add
+            (mul_le_mul hMdiff hR (norm_nonneg _) (by norm_num [κ]))
+            (mul_le_mul hMℚnorm Qapprox (norm_nonneg _) (by norm_num [κ]))
+      _ = 4 * κ + 2 * κ ^ 2 := by ring
+  -- Bound ‖rotM Q‖
+  have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 2 := by
+    calc ‖(rotM ↑θ ↑φ) Q‖
+      _ ≤ ‖rotM ↑θ ↑φ‖ * ‖Q‖ := ContinuousLinearMap.le_opNorm _ _
+      _ = 1 * ‖Q‖ := by rw [Bounding.rotM_norm_one]
+      _ ≤ 1 * 2 := by gcongr
+      _ = 2 := one_mul _
+  -- Bound ‖rotMℚ P_‖
+  have hP_ : ‖P_‖ ≤ 1 + κ := by
+    calc ‖P_‖ ≤ ‖P‖ + ‖P - P_‖ := norm_le_insert P P_
+      _ ≤ 1 + κ := add_le_add hP Papprox
+  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) := by
+    calc ‖(rotMℚ ↑θ ↑φ) P_‖
+      _ ≤ ‖rotMℚ ↑θ ↑φ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
+      _ ≤ (1 + κ) * (1 + κ) :=
+          mul_le_mul hMℚnorm hP_ (norm_nonneg _) (by norm_num [κ])
+  calc |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+        ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫|
+    _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
+        |⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫| := abs_add_le _ _
+    _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q‖ +
+        ‖(rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ :=
+        add_le_add (abs_real_inner_le_norm _ _) (abs_real_inner_le_norm _ _)
+    _ ≤ (2 * κ + κ ^ 2) * 2 + (1 + κ) * (1 + κ) * (4 * κ + 2 * κ ^ 2) :=
+        add_le_add
+          (mul_le_mul_of_nonneg_right hAP (norm_nonneg _) |>.trans
+            (mul_le_mul_of_nonneg_left hMQ (by norm_num [κ])))
+          (mul_le_mul hMℚP_ hBQ (norm_nonneg _) (by norm_num [κ]))
+    _ ≤ 10 * κ := by unfold κ; norm_num
+
+/-- The norm difference bound for `rotM`/`rotMℚ` applied to P (norm ≤ 1).
+    Generalises `bounds_kappa3_MQ` from BoundsKappa3.lean. -/
+private lemma norm_diff_bound_3kappa
+    {P P_ : ℝ³} {θ φ : Set.Icc (-4) 4}
+    (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
+    ‖(rotM ↑θ ↑φ) P‖ ≤ ‖(rotMℚ ↑θ ↑φ) P_‖ + 3 * κ := by
+  have h := bounds_kappa3_MQ (θ := θ) (φ := φ) hP Papprox
+  rw [abs_le] at h
+  linarith [h.1]
+
+/-- The norm difference bound for `rotM`/`rotMℚ` applied to `P - Q` (norm ≤ 2).
+    Uses the same technique as bounds_kappa3_MQ but for ‖P - Q‖ ≤ 2. -/
+private lemma norm_diff_bound_6kappa
+    {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4) 4}
+    (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1)
+    (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
+    ‖(rotM ↑θ ↑φ) (P - Q)‖ ≤ ‖(rotMℚ ↑θ ↑φ) (P_ - Q_)‖ + 6 * κ := by
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+  have hPQ_norm : ‖P - Q‖ ≤ 2 := by
+    calc ‖P - Q‖ ≤ ‖P‖ + ‖Q‖ := norm_sub_le _ _
+      _ ≤ 1 + 1 := add_le_add hP hQ
+      _ = 2 := by ring
+  have hPQ_approx : ‖(P - Q) - (P_ - Q_)‖ ≤ 2 * κ := by
+    calc ‖(P - Q) - (P_ - Q_)‖ = ‖(P - P_) - (Q - Q_)‖ := by congr 1; abel
+      _ ≤ ‖P - P_‖ + ‖Q - Q_‖ := norm_sub_le _ _
+      _ ≤ κ + κ := add_le_add Papprox Qapprox
+      _ = 2 * κ := by ring
+  -- ‖M(P-Q) - Mℚ(P_-Q_)‖ ≤ ‖(M-Mℚ)(P-Q)‖ + ‖Mℚ((P-Q)-(P_-Q_))‖
+  have h_diff : ‖(rotM ↑θ ↑φ) (P - Q) - (rotMℚ ↑θ ↑φ) (P_ - Q_)‖ ≤ 6 * κ := by
+    have h_split : (rotM ↑θ ↑φ) (P - Q) - (rotMℚ ↑θ ↑φ) (P_ - Q_) =
+        (rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) (P - Q) + (rotMℚ ↑θ ↑φ) ((P - Q) - (P_ - Q_)) := by
+      simp [ContinuousLinearMap.sub_apply, map_sub]; abel
+    rw [h_split]
+    calc ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) (P - Q) + (rotMℚ ↑θ ↑φ) ((P - Q) - (P_ - Q_))‖
+      _ ≤ ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) (P - Q)‖ + ‖(rotMℚ ↑θ ↑φ) ((P - Q) - (P_ - Q_))‖ :=
+          norm_add_le _ _
+      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P - Q‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖(P - Q) - (P_ - Q_)‖ :=
+          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+      _ ≤ κ * 2 + (1 + κ) * (2 * κ) :=
+          add_le_add
+            (mul_le_mul hMdiff hPQ_norm (norm_nonneg _) (by norm_num [κ]))
+            (mul_le_mul hMℚnorm hPQ_approx (norm_nonneg _) (by norm_num [κ]))
+      _ ≤ 6 * κ := by unfold κ; norm_num
+  linarith [norm_le_insert' ((rotM ↑θ ↑φ) (P - Q)) ((rotMℚ ↑θ ↑φ) (P_ - Q_))]
+
 lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ)
-    (ε : ℝ) (hε : 0 < ε) (s : UpperSqrt) :
+    (ε : ℝ) (hε : 0 < ε) (s : UpperSqrt)
+    (hA_nonneg : 0 ≤ ⟪rotM θ φ P, rotM θ φ (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)) :
     bounds_kappa4_Aℚ P_ Q_ θ φ ε s ≤ bounds_kappa4_A P Q θ φ ε := by
-  sorry
+  -- Abbreviate the numerators and denominators
+  set numA := ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε) with numA_def
+  set numAℚ := ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) (P_ - Q_)⟫ - 10 * κ -
+    2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε) with numAℚ_def
+  set denA := (‖(rotM ↑θ ↑φ) P‖ + √2 * ε) * (‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε)
+    with denA_def
+  set denAℚ := (s.norm ((rotMℚ ↑θ ↑φ) P_) + √2 * ε + 3 * κ) *
+    (s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ) with denAℚ_def
+  -- The goal becomes numAℚ / denAℚ ≤ numA / denA after unfolding
+  change numAℚ / denAℚ ≤ numA / denA
+  -- Step 1: numAℚ ≤ numA
+  have h_numAℚ_le : numAℚ ≤ numA := by
+    -- First, bound the inner product difference
+    have hPQ_norm : ‖P - Q‖ ≤ 2 := by
+      calc ‖P - Q‖ ≤ ‖P‖ + ‖Q‖ := norm_sub_le _ _
+        _ ≤ 1 + 1 := add_le_add hP hQ
+        _ = 2 := by ring
+    have hPQ_approx : ‖(P - Q) - (P_ - Q_)‖ ≤ 2 * κ := by
+      calc ‖(P - Q) - (P_ - Q_)‖ = ‖(P - P_) - (Q - Q_)‖ := by congr 1; abel
+        _ ≤ ‖P - P_‖ + ‖Q - Q_‖ := norm_sub_le _ _
+        _ ≤ κ + κ := add_le_add Papprox Qapprox
+        _ = 2 * κ := by ring
+    have h_inner : |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ -
+        ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) (P_ - Q_)⟫| ≤ 10 * κ :=
+      inner_product_bound_10kappa hP hPQ_norm Papprox hPQ_approx
+    -- From |a - b| ≤ 10κ we get b - 10κ ≤ a
+    have h_inner_le : ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) (P_ - Q_)⟫ - 10 * κ ≤
+        ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ := by
+      rw [abs_le] at h_inner; linarith [h_inner.1]
+    -- Bound the norm term: ‖P - Q‖ ≤ ‖P_ - Q_‖ + 2κ
+    have h_norm_PQ : ‖P - Q‖ ≤ ‖P_ - Q_‖ + 2 * κ := by
+      calc ‖P - Q‖
+        _ ≤ ‖P_ - Q_‖ + ‖(P - Q) - (P_ - Q_)‖ := norm_le_insert' _ _
+        _ ≤ ‖P_ - Q_‖ + 2 * κ := by linarith [hPQ_approx]
+    -- Now combine: numAℚ ≤ numA
+    -- numAℚ = inner_ℚ - 10κ - 2ε(‖P_-Q_‖ + 2κ)(√2 + ε)
+    -- numA  = inner - 2ε‖P-Q‖(√2 + ε)
+    -- We need: inner_ℚ - 10κ - 2ε(‖P_-Q_‖ + 2κ)(√2 + ε) ≤ inner - 2ε‖P-Q‖(√2 + ε)
+    -- i.e., inner_ℚ - 10κ ≤ inner + 2ε(√2 + ε)((‖P_-Q_‖ + 2κ) - ‖P-Q‖)
+    -- which follows from inner_ℚ - 10κ ≤ inner and (‖P_-Q_‖ + 2κ) - ‖P-Q‖ ≥ 0
+    have h_eps_term : 2 * ε * ‖P - Q‖ * (√2 + ε) ≤ 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε) := by
+      have h1 : √2 + ε > 0 := by positivity
+      have h2 : 0 < 2 * ε := by linarith
+      have h3 : ‖P - Q‖ ≤ ‖P_ - Q_‖ + 2 * κ := h_norm_PQ
+      have h4 : 2 * ε * ‖P - Q‖ ≤ 2 * ε * (‖P_ - Q_‖ + 2 * κ) := by
+        exact mul_le_mul_of_nonneg_left h3 h2.le
+      exact mul_le_mul_of_nonneg_right h4 h1.le
+    linarith [h_inner_le, h_eps_term]
+  -- Step 2: denA > 0
+  have h_denA_pos : 0 < denA := by
+    apply mul_pos <;> positivity
+  -- Step 3: denA ≤ denAℚ
+  have h_denA_le : denA ≤ denAℚ := by
+    -- Factor 1: ‖rotM P‖ + √2ε ≤ s.norm(rotMℚ P_) + √2ε + 3κ
+    have h_f1 : ‖(rotM ↑θ ↑φ) P‖ + √2 * ε ≤
+        s.norm ((rotMℚ ↑θ ↑φ) P_) + √2 * ε + 3 * κ := by
+      have h1 := norm_diff_bound_3kappa hP Papprox (θ := θ) (φ := φ)
+      have h2 := UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) P_)
+      linarith
+    -- Factor 2: ‖rotM (P-Q)‖ + 2√2ε ≤ s.norm(rotMℚ (P_-Q_)) + 2√2ε + 6κ
+    have h_f2 : ‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε ≤
+        s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ := by
+      have h1 := norm_diff_bound_6kappa hP hQ Papprox Qapprox (θ := θ) (φ := φ)
+      have h2 := UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) (P_ - Q_))
+      linarith
+    -- Both factors are nonneg
+    have h_f1_nn : 0 ≤ ‖(rotM ↑θ ↑φ) P‖ + √2 * ε := by positivity
+    have h_f2_nn : 0 ≤ ‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε := by positivity
+    exact mul_le_mul h_f1 h_f2 h_f2_nn (le_trans h_f1_nn h_f1)
+  -- Step 4: Apply div_le_div₀
+  exact div_le_div₀ hA_nonneg h_numAℚ_le h_denA_pos h_denA_le

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -69,20 +69,12 @@ private lemma inner_product_bound_10kappa
       _ = 4 * κ + 2 * κ ^ 2 := by ring
   -- Bound ‖rotM Q‖
   have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 2 := by
-    calc ‖(rotM ↑θ ↑φ) Q‖
-      _ ≤ ‖rotM ↑θ ↑φ‖ * ‖Q‖ := ContinuousLinearMap.le_opNorm _ _
-      _ = 1 * ‖Q‖ := by rw [Bounding.rotM_norm_one]
-      _ ≤ 1 * 2 := by gcongr
-      _ = 2 := one_mul _
+    have := ContinuousLinearMap.le_opNorm (rotM ↑θ ↑φ) Q
+    rw [Bounding.rotM_norm_one, one_mul] at this; linarith
   -- Bound ‖rotMℚ P_‖
-  have hP_ : ‖P_‖ ≤ 1 + κ := by
-    calc ‖P_‖ ≤ ‖P‖ + ‖P - P_‖ := norm_le_insert P P_
-      _ ≤ 1 + κ := add_le_add hP Papprox
-  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) := by
-    calc ‖(rotMℚ ↑θ ↑φ) P_‖
-      _ ≤ ‖rotMℚ ↑θ ↑φ‖ * ‖P_‖ := ContinuousLinearMap.le_opNorm _ _
-      _ ≤ (1 + κ) * (1 + κ) :=
-          mul_le_mul hMℚnorm hP_ (norm_nonneg _) (by norm_num [κ])
+  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) :=
+    (ContinuousLinearMap.le_opNorm _ _).trans
+      (mul_le_mul hMℚnorm (by linarith [norm_le_insert P P_]) (norm_nonneg _) (by norm_num [κ]))
   calc |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
         ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫|
     _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
@@ -189,13 +181,9 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
     -- We need: inner_ℚ - 10κ - 2ε(‖P_-Q_‖ + 2κ)(√2 + ε) ≤ inner - 2ε‖P-Q‖(√2 + ε)
     -- i.e., inner_ℚ - 10κ ≤ inner + 2ε(√2 + ε)((‖P_-Q_‖ + 2κ) - ‖P-Q‖)
     -- which follows from inner_ℚ - 10κ ≤ inner and (‖P_-Q_‖ + 2κ) - ‖P-Q‖ ≥ 0
-    have h_eps_term : 2 * ε * ‖P - Q‖ * (√2 + ε) ≤ 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε) := by
-      have h1 : √2 + ε > 0 := by positivity
-      have h2 : 0 < 2 * ε := by linarith
-      have h3 : ‖P - Q‖ ≤ ‖P_ - Q_‖ + 2 * κ := h_norm_PQ
-      have h4 : 2 * ε * ‖P - Q‖ ≤ 2 * ε * (‖P_ - Q_‖ + 2 * κ) := by
-        exact mul_le_mul_of_nonneg_left h3 h2.le
-      exact mul_le_mul_of_nonneg_right h4 h1.le
+    have h_eps_term : 2 * ε * ‖P - Q‖ * (√2 + ε) ≤ 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε) :=
+      mul_le_mul_of_nonneg_right
+        (mul_le_mul_of_nonneg_left h_norm_PQ (by linarith)) (by positivity)
     linarith [h_inner_le, h_eps_term]
   -- Step 2: denA > 0
   have h_denA_pos : 0 < denA := by

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -23,11 +23,6 @@ def bounds_kappa4_Aℚ (s : UpperSqrt) :=
   (⟪rotMℚ θ φ P_, rotMℚ θ φ (P_ - Q_)⟫ - 10 * κ - 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)) /
   ((s.norm (rotMℚ θ φ P_) + √2 * ε + 3 * κ) * (s.norm (rotMℚ θ φ (P_ - Q_)) + 2 * √2 * ε + 6 * κ))
 
-/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
-private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
-    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 :=
-  ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
-
 /-- An `UpperSqrt` overestimates the Euclidean norm. -/
 private lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖ ≤ s.norm v := by
   unfold UpperSqrt.norm
@@ -54,21 +49,8 @@ private lemma inner_product_bound_10kappa
     simp [inner_sub_left, inner_sub_right]
   rw [decomp]
   -- Bound ‖rotM P - rotMℚ P_‖
-  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 := by
-    calc ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖
-      _ = ‖((rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P) + ((rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_)‖ := by
-          congr 1; abel
-      _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ :=
-          norm_add_le _ _
-      _ = ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖ + ‖(rotMℚ ↑θ ↑φ) (P - P_)‖ := by
-          rw [ContinuousLinearMap.sub_apply, map_sub]
-      _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖ + ‖rotMℚ ↑θ ↑φ‖ * ‖P - P_‖ :=
-          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-      _ ≤ κ * 1 + (1 + κ) * κ :=
-          add_le_add
-            (mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ]))
-            (mul_le_mul hMℚnorm Papprox (norm_nonneg _) (by norm_num [κ]))
-      _ = 2 * κ + κ ^ 2 := by ring
+  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hMdiff hMℚnorm hP Papprox
   -- Bound ‖rotM Q - rotMℚ Q_‖ (with ‖Q‖ ≤ 2 and ‖Q - Q_‖ ≤ 2κ)
   have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 4 * κ + 2 * κ ^ 2 := by
     calc ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -28,9 +28,7 @@ lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_
   -- Decompose at the R level: A = rotR, Aℚ = rotRℚ, P = rotM P, P_ = rotMℚ P
   have term1 : ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hRdiff (Rℚ_norm_bounded _ (icc_int_to_real α))
-      (by calc ‖(rotM ↑θ ↑φ) P‖
-            _ ≤ ‖rotM ↑θ ↑φ‖ * ‖P‖ := ContinuousLinearMap.le_opNorm _ _
-            _ ≤ 1 := by rw [Bounding.rotM_norm_one]; linarith [norm_nonneg P])
+      (clm_unit_apply_le (le_of_eq (Bounding.rotM_norm_one _ _)) hP)
       (by rw [show (rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P = (rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P from
               (ContinuousLinearMap.sub_apply _ _ _).symm]
           calc ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -10,16 +10,11 @@ namespace RationalApprox
 
 variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4) 4} {w : ℝ²}
 
-/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
-private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
-    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 :=
-  ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
-
 /-!
 [SY25] Corollary 50
 -/
 
-lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
+lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     |‖rotR α (rotM θ φ P) - rotM θ_ φ_ Q‖ - ‖rotRℚ α (rotMℚ θ φ P) - rotMℚ θ_ φ_ Q_‖| ≤ 6 * κ := by
   have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
     M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
@@ -62,21 +57,8 @@ lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_
                     (by positivity) (by norm_num [κ])
       _ = 2 * κ + κ ^ 2 := by ring
   -- Term 2: ‖rotM' Q - rotMℚ' Q_‖ ≤ 2κ + κ²
-  have term2 : ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖ ≤ 2 * κ + κ ^ 2 := by
-    calc ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖
-      _ = ‖((rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q) +
-            ((rotMℚ ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_)‖ := by congr 1; abel
-      _ ≤ ‖(rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q‖ +
-            ‖(rotMℚ ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_‖ := norm_add_le _ _
-      _ = ‖(rotM ↑θ_ ↑φ_ - rotMℚ ↑θ_ ↑φ_) Q‖ + ‖(rotMℚ ↑θ_ ↑φ_) (Q - Q_)‖ := by
-          rw [ContinuousLinearMap.sub_apply, map_sub]
-      _ ≤ ‖rotM ↑θ_ ↑φ_ - rotMℚ ↑θ_ ↑φ_‖ * ‖Q‖ + ‖rotMℚ ↑θ_ ↑φ_‖ * ‖Q - Q_‖ :=
-          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-      _ ≤ κ * 1 + (1 + κ) * κ :=
-          add_le_add
-            (mul_le_mul hM_diff' hQ (norm_nonneg _) (by norm_num [κ]))
-            (mul_le_mul hMℚnorm' Qapprox (norm_nonneg _) (by norm_num [κ]))
-      _ = 2 * κ + κ ^ 2 := by ring
+  have term2 : ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hM_diff' hMℚnorm' hQ Qapprox
   -- Combine using reverse triangle inequality
   calc |‖rotR ↑α ((rotM ↑θ ↑φ) P) - (rotM ↑θ_ ↑φ_) Q‖ -
         ‖rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P) - (rotMℚ ↑θ_ ↑φ_) Q_‖|

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -18,8 +18,6 @@ lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_
     |‖rotR α (rotM θ φ P) - rotM θ_ φ_ Q‖ - ‖rotRℚ α (rotMℚ θ φ P) - rotMℚ θ_ φ_ Q_‖| ≤ 6 * κ := by
   have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
     M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
-  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
-    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
   have hRdiff : ‖rotR (α : ℝ) - rotRℚ (α : ℝ)‖ ≤ κ :=
     R_difference_norm_bounded _ (icc_int_to_real α)
   have hM_diff' : ‖rotM (θ_ : ℝ) (φ_ : ℝ) - rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ κ :=
@@ -27,35 +25,18 @@ lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_
   have hMℚnorm' : ‖rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ 1 + κ :=
     Mℚ_norm_bounded (icc_int_to_real θ_) (icc_int_to_real φ_)
   -- Term 1: ‖rotR(rotM P) - rotRℚ(rotMℚ P)‖ ≤ 2κ + κ²
-  have term1 : ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖ ≤ 2 * κ + κ ^ 2 := by
-    calc ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖
-      _ = ‖(rotR ↑α ((rotM ↑θ ↑φ) P) - rotR ↑α ((rotMℚ ↑θ ↑φ) P)) +
-            (rotR ↑α ((rotMℚ ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P))‖ := by congr 1; abel
-      _ ≤ ‖rotR ↑α ((rotM ↑θ ↑φ) P) - rotR ↑α ((rotMℚ ↑θ ↑φ) P)‖ +
-            ‖rotR ↑α ((rotMℚ ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P)‖ := norm_add_le _ _
-      _ = ‖rotR ↑α ((rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P)‖ +
-            ‖(rotR ↑α - rotRℚ ↑α) ((rotMℚ ↑θ ↑φ) P)‖ := by
-          simp only [map_sub, ContinuousLinearMap.sub_apply]
-      _ ≤ ‖rotR (↑α)‖ * ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖ +
-            ‖rotR ↑α - rotRℚ ↑α‖ * ‖(rotMℚ ↑θ ↑φ) P‖ :=
-          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
-      _ ≤ 1 * (κ * 1) + κ * ((1 + κ) * 1) := by
-          apply add_le_add
-          · calc ‖rotR (↑α)‖ * ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖
-              _ ≤ ‖rotR (↑α)‖ * (‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖) :=
-                  mul_le_mul_of_nonneg_left (ContinuousLinearMap.le_opNorm _ _) (norm_nonneg _)
-              _ ≤ 1 * (κ * 1) :=
-                  mul_le_mul (le_of_eq (Bounding.rotR_norm_one _))
-                    (mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ]))
-                    (by positivity) (by norm_num)
-          · calc ‖rotR ↑α - rotRℚ ↑α‖ * ‖(rotMℚ ↑θ ↑φ) P‖
-              _ ≤ ‖rotR ↑α - rotRℚ ↑α‖ * (‖rotMℚ ↑θ ↑φ‖ * ‖P‖) :=
-                  mul_le_mul_of_nonneg_left (ContinuousLinearMap.le_opNorm _ _) (norm_nonneg _)
-              _ ≤ κ * ((1 + κ) * 1) :=
-                  mul_le_mul hRdiff
-                    (mul_le_mul hMℚnorm hP (norm_nonneg _) (by norm_num [κ]))
-                    (by positivity) (by norm_num [κ])
-      _ = 2 * κ + κ ^ 2 := by ring
+  -- Decompose at the R level: A = rotR, Aℚ = rotRℚ, P = rotM P, P_ = rotMℚ P
+  have term1 : ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hRdiff (Rℚ_norm_bounded _ (icc_int_to_real α))
+      (by calc ‖(rotM ↑θ ↑φ) P‖
+            _ ≤ ‖rotM ↑θ ↑φ‖ * ‖P‖ := ContinuousLinearMap.le_opNorm _ _
+            _ ≤ 1 := by rw [Bounding.rotM_norm_one]; linarith [norm_nonneg P])
+      (by rw [show (rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P = (rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P from
+              (ContinuousLinearMap.sub_apply _ _ _).symm]
+          calc ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖
+            _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖ := ContinuousLinearMap.le_opNorm _ _
+            _ ≤ κ * 1 := mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ])
+            _ = κ := mul_one κ)
   -- Term 2: ‖rotM' Q - rotMℚ' Q_‖ ≤ 2κ + κ²
   have term2 : ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hM_diff' hMℚnorm' hQ Qapprox

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -2,6 +2,7 @@ import Mathlib.Algebra.Lie.OfAssociative
 import Noperthedron.PointSym
 import Noperthedron.PoseInterval
 import Noperthedron.RationalApprox.Basic
+import Noperthedron.RationalApprox.MatrixBounds
 
 open scoped RealInnerProductSpace
 
@@ -9,10 +10,82 @@ namespace RationalApprox
 
 variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4) 4} {w : ℝ²}
 
+/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
+private lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
+    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 :=
+  ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
+
 /-!
 [SY25] Corollary 50
 -/
 
 lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     |‖rotR α (rotM θ φ P) - rotM θ_ φ_ Q‖ - ‖rotRℚ α (rotMℚ θ φ P) - rotMℚ θ_ φ_ Q_‖| ≤ 6 * κ := by
-  sorry
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+  have hRdiff : ‖rotR (α : ℝ) - rotRℚ (α : ℝ)‖ ≤ κ :=
+    R_difference_norm_bounded _ (icc_int_to_real α)
+  have hM_diff' : ‖rotM (θ_ : ℝ) (φ_ : ℝ) - rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ κ :=
+    M_difference_norm_bounded _ _ (icc_int_to_real θ_) (icc_int_to_real φ_)
+  have hMℚnorm' : ‖rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded (icc_int_to_real θ_) (icc_int_to_real φ_)
+  -- Term 1: ‖rotR(rotM P) - rotRℚ(rotMℚ P)‖ ≤ 2κ + κ²
+  have term1 : ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖ ≤ 2 * κ + κ ^ 2 := by
+    calc ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖
+      _ = ‖(rotR ↑α ((rotM ↑θ ↑φ) P) - rotR ↑α ((rotMℚ ↑θ ↑φ) P)) +
+            (rotR ↑α ((rotMℚ ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P))‖ := by congr 1; abel
+      _ ≤ ‖rotR ↑α ((rotM ↑θ ↑φ) P) - rotR ↑α ((rotMℚ ↑θ ↑φ) P)‖ +
+            ‖rotR ↑α ((rotMℚ ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P)‖ := norm_add_le _ _
+      _ = ‖rotR ↑α ((rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P)‖ +
+            ‖(rotR ↑α - rotRℚ ↑α) ((rotMℚ ↑θ ↑φ) P)‖ := by
+          simp only [map_sub, ContinuousLinearMap.sub_apply]
+      _ ≤ ‖rotR (↑α)‖ * ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖ +
+            ‖rotR ↑α - rotRℚ ↑α‖ * ‖(rotMℚ ↑θ ↑φ) P‖ :=
+          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+      _ ≤ 1 * (κ * 1) + κ * ((1 + κ) * 1) := by
+          apply add_le_add
+          · calc ‖rotR (↑α)‖ * ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖
+              _ ≤ ‖rotR (↑α)‖ * (‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖) :=
+                  mul_le_mul_of_nonneg_left (ContinuousLinearMap.le_opNorm _ _) (norm_nonneg _)
+              _ ≤ 1 * (κ * 1) :=
+                  mul_le_mul (le_of_eq (Bounding.rotR_norm_one _))
+                    (mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ]))
+                    (by positivity) (by norm_num)
+          · calc ‖rotR ↑α - rotRℚ ↑α‖ * ‖(rotMℚ ↑θ ↑φ) P‖
+              _ ≤ ‖rotR ↑α - rotRℚ ↑α‖ * (‖rotMℚ ↑θ ↑φ‖ * ‖P‖) :=
+                  mul_le_mul_of_nonneg_left (ContinuousLinearMap.le_opNorm _ _) (norm_nonneg _)
+              _ ≤ κ * ((1 + κ) * 1) :=
+                  mul_le_mul hRdiff
+                    (mul_le_mul hMℚnorm hP (norm_nonneg _) (by norm_num [κ]))
+                    (by positivity) (by norm_num [κ])
+      _ = 2 * κ + κ ^ 2 := by ring
+  -- Term 2: ‖rotM' Q - rotMℚ' Q_‖ ≤ 2κ + κ²
+  have term2 : ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖ ≤ 2 * κ + κ ^ 2 := by
+    calc ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖
+      _ = ‖((rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q) +
+            ((rotMℚ ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_)‖ := by congr 1; abel
+      _ ≤ ‖(rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q‖ +
+            ‖(rotMℚ ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_‖ := norm_add_le _ _
+      _ = ‖(rotM ↑θ_ ↑φ_ - rotMℚ ↑θ_ ↑φ_) Q‖ + ‖(rotMℚ ↑θ_ ↑φ_) (Q - Q_)‖ := by
+          rw [ContinuousLinearMap.sub_apply, map_sub]
+      _ ≤ ‖rotM ↑θ_ ↑φ_ - rotMℚ ↑θ_ ↑φ_‖ * ‖Q‖ + ‖rotMℚ ↑θ_ ↑φ_‖ * ‖Q - Q_‖ :=
+          add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+      _ ≤ κ * 1 + (1 + κ) * κ :=
+          add_le_add
+            (mul_le_mul hM_diff' hQ (norm_nonneg _) (by norm_num [κ]))
+            (mul_le_mul hMℚnorm' Qapprox (norm_nonneg _) (by norm_num [κ]))
+      _ = 2 * κ + κ ^ 2 := by ring
+  -- Combine using reverse triangle inequality
+  calc |‖rotR ↑α ((rotM ↑θ ↑φ) P) - (rotM ↑θ_ ↑φ_) Q‖ -
+        ‖rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P) - (rotMℚ ↑θ_ ↑φ_) Q_‖|
+    _ ≤ ‖(rotR ↑α ((rotM ↑θ ↑φ) P) - (rotM ↑θ_ ↑φ_) Q) -
+          (rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P) - (rotMℚ ↑θ_ ↑φ_) Q_)‖ :=
+        abs_norm_sub_norm_le _ _
+    _ = ‖(rotR ↑α ((rotM ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P)) -
+          ((rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_)‖ := by congr 1; abel
+    _ ≤ ‖rotR ↑α ((rotM ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P)‖ +
+          ‖(rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_‖ := norm_sub_le _ _
+    _ ≤ (2 * κ + κ ^ 2) + (2 * κ + κ ^ 2) := add_le_add term1 term2
+    _ ≤ 6 * κ := by unfold κ; norm_num

--- a/Noperthedron/RationalApprox/MatrixBounds.lean
+++ b/Noperthedron/RationalApprox/MatrixBounds.lean
@@ -196,3 +196,39 @@ lemma clm_approx_apply_sub {E F : Type*}
           (mul_le_mul hAdiff hP (norm_nonneg _) (by norm_num [κ]))
           (mul_le_mul hAℚnorm hPapprox (norm_nonneg _) (by norm_num [κ]))
     _ = 2 * κ + κ ^ 2 := by ring
+
+/-- Variant of `clm_approx_apply_sub` for ‖P‖ ≤ 2, ‖P - P_‖ ≤ 2κ. -/
+lemma clm_approx_apply_sub₂ {E F : Type*}
+    [SeminormedAddCommGroup E] [NormedAddCommGroup F] [NormedSpace ℝ E] [NormedSpace ℝ F]
+    {A Aℚ : E →L[ℝ] F} {P P_ : E}
+    (hAdiff : ‖A - Aℚ‖ ≤ κ) (hAℚnorm : ‖Aℚ‖ ≤ 1 + κ)
+    (hP : ‖P‖ ≤ 2) (hPapprox : ‖P - P_‖ ≤ 2 * κ) :
+    ‖A P - Aℚ P_‖ ≤ 4 * κ + 2 * κ ^ 2 := by
+  calc ‖A P - Aℚ P_‖
+    _ = ‖(A P - Aℚ P) + (Aℚ P - Aℚ P_)‖ := by congr 1; abel
+    _ ≤ ‖A P - Aℚ P‖ + ‖Aℚ P - Aℚ P_‖ := norm_add_le _ _
+    _ = ‖(A - Aℚ) P‖ + ‖Aℚ (P - P_)‖ := by
+        rw [ContinuousLinearMap.sub_apply, map_sub]
+    _ ≤ ‖A - Aℚ‖ * ‖P‖ + ‖Aℚ‖ * ‖P - P_‖ :=
+        add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+    _ ≤ κ * 2 + (1 + κ) * (2 * κ) :=
+        add_le_add
+          (mul_le_mul hAdiff hP (norm_nonneg _) (by norm_num [κ]))
+          (mul_le_mul hAℚnorm hPapprox (norm_nonneg _) (by norm_num [κ]))
+    _ = 4 * κ + 2 * κ ^ 2 := by ring
+
+/-- CLM with operator norm ≤ 1 preserves the unit ball. -/
+lemma clm_unit_apply_le {E F : Type*}
+    [SeminormedAddCommGroup E] [NormedAddCommGroup F] [NormedSpace ℝ E] [NormedSpace ℝ F]
+    {A : E →L[ℝ] F} {x : E} (hA : ‖A‖ ≤ 1) (hx : ‖x‖ ≤ 1) : ‖A x‖ ≤ 1 :=
+  (ContinuousLinearMap.le_opNorm A x).trans
+    ((mul_le_mul hA hx (norm_nonneg _) (by linarith [norm_nonneg A])).trans (one_mul 1).le)
+
+/-- Approximate image norm: ‖Aℚ P_‖ ≤ (1+κ)² from ‖Aℚ‖ ≤ 1+κ, ‖P‖ ≤ 1, ‖P-P_‖ ≤ κ. -/
+lemma approx_image_norm_le {E F : Type*}
+    [SeminormedAddCommGroup E] [NormedAddCommGroup F] [NormedSpace ℝ E] [NormedSpace ℝ F]
+    {Aℚ : E →L[ℝ] F} {P P_ : E}
+    (hAℚnorm : ‖Aℚ‖ ≤ 1 + κ) (hP : ‖P‖ ≤ 1) (hPapprox : ‖P - P_‖ ≤ κ) :
+    ‖Aℚ P_‖ ≤ (1 + κ) * (1 + κ) :=
+  (ContinuousLinearMap.le_opNorm _ _).trans
+    (mul_le_mul hAℚnorm (by linarith [norm_le_insert P P_]) (norm_nonneg _) (by norm_num [κ]))

--- a/Noperthedron/RationalApprox/MatrixBounds.lean
+++ b/Noperthedron/RationalApprox/MatrixBounds.lean
@@ -150,3 +150,49 @@ theorem Mℚ_norm_bounded {θ φ : ℝ} (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ 
   _ ≤ ‖rotM θ φ‖ + ‖rotM θ φ - rotMℚ θ φ‖ := norm_le_insert (rotM θ φ) (rotMℚ θ φ)
   _ = 1        + ‖rotM θ φ - rotMℚ θ φ‖ := by rw [Bounding.rotM_norm_one]
   _ ≤ 1 + κ := by grw [M_difference_norm_bounded θ φ hθ hφ]
+
+theorem R'ℚ_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotR'ℚ α‖ ≤ 1 + κ := by
+  calc ‖rotR'ℚ α‖
+  _ ≤ ‖rotR' α‖ + ‖rotR' α - rotR'ℚ α‖ := norm_le_insert (rotR' α) (rotR'ℚ α)
+  _ = 1 + ‖rotR' α - rotR'ℚ α‖ := by rw [Bounding.rotR'_norm_one]
+  _ ≤ 1 + κ := by grw [R'_difference_norm_bounded α hα]
+
+theorem Mθℚ_norm_bounded {θ φ : ℝ} (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4) :
+    ‖rotMθℚ θ φ‖ ≤ 1 + κ := by
+  calc ‖rotMθℚ θ φ‖
+  _ ≤ ‖rotMθ θ φ‖ + ‖rotMθ θ φ - rotMθℚ θ φ‖ := norm_le_insert _ _
+  _ ≤ 1 + ‖rotMθ θ φ - rotMθℚ θ φ‖ := by gcongr; exact Bounding.rotMθ_norm_le_one _ _
+  _ ≤ 1 + κ := by gcongr; exact Mθ_difference_norm_bounded _ _ hθ hφ
+
+theorem Mφℚ_norm_bounded {θ φ : ℝ} (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4) :
+    ‖rotMφℚ θ φ‖ ≤ 1 + κ := by
+  calc ‖rotMφℚ θ φ‖
+  _ ≤ ‖rotMφ θ φ‖ + ‖rotMφ θ φ - rotMφℚ θ φ‖ := norm_le_insert _ _
+  _ ≤ 1 + ‖rotMφ θ φ - rotMφℚ θ φ‖ := by gcongr; exact Bounding.rotMφ_norm_le_one _ _
+  _ ≤ 1 + κ := by gcongr; exact Mφ_difference_norm_bounded _ _ hθ hφ
+
+/-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/
+lemma icc_int_to_real (x : Set.Icc ((-4 : ℤ)) 4) :
+    (x : ℝ) ∈ Set.Icc ((-4 : ℝ)) 4 :=
+  ⟨by exact_mod_cast x.property.1, by exact_mod_cast x.property.2⟩
+
+/-- Common bound: ‖A P - Aℚ P_‖ ≤ 2κ + κ² when ‖A - Aℚ‖ ≤ κ, ‖Aℚ‖ ≤ 1 + κ,
+‖P‖ ≤ 1, and ‖P - P_‖ ≤ κ. -/
+lemma clm_approx_apply_sub {E F : Type*}
+    [SeminormedAddCommGroup E] [NormedAddCommGroup F] [NormedSpace ℝ E] [NormedSpace ℝ F]
+    {A Aℚ : E →L[ℝ] F} {P P_ : E}
+    (hAdiff : ‖A - Aℚ‖ ≤ κ) (hAℚnorm : ‖Aℚ‖ ≤ 1 + κ)
+    (hP : ‖P‖ ≤ 1) (hPapprox : ‖P - P_‖ ≤ κ) :
+    ‖A P - Aℚ P_‖ ≤ 2 * κ + κ ^ 2 := by
+  calc ‖A P - Aℚ P_‖
+    _ = ‖(A P - Aℚ P) + (Aℚ P - Aℚ P_)‖ := by congr 1; abel
+    _ ≤ ‖A P - Aℚ P‖ + ‖Aℚ P - Aℚ P_‖ := norm_add_le _ _
+    _ = ‖(A - Aℚ) P‖ + ‖Aℚ (P - P_)‖ := by
+        rw [ContinuousLinearMap.sub_apply, map_sub]
+    _ ≤ ‖A - Aℚ‖ * ‖P‖ + ‖Aℚ‖ * ‖P - P_‖ :=
+        add_le_add (ContinuousLinearMap.le_opNorm _ _) (ContinuousLinearMap.le_opNorm _ _)
+    _ ≤ κ * 1 + (1 + κ) * κ :=
+        add_le_add
+          (mul_le_mul hAdiff hP (norm_nonneg _) (by norm_num [κ]))
+          (mul_le_mul hAℚnorm hPapprox (norm_nonneg _) (by norm_num [κ]))
+    _ = 2 * κ + κ ^ 2 := by ring

--- a/Noperthedron/RationalApprox/MatrixBounds.lean
+++ b/Noperthedron/RationalApprox/MatrixBounds.lean
@@ -221,8 +221,9 @@ lemma clm_approx_apply_sub₂ {E F : Type*}
 lemma clm_unit_apply_le {E F : Type*}
     [SeminormedAddCommGroup E] [NormedAddCommGroup F] [NormedSpace ℝ E] [NormedSpace ℝ F]
     {A : E →L[ℝ] F} {x : E} (hA : ‖A‖ ≤ 1) (hx : ‖x‖ ≤ 1) : ‖A x‖ ≤ 1 :=
-  (ContinuousLinearMap.le_opNorm A x).trans
-    ((mul_le_mul hA hx (norm_nonneg _) (by linarith [norm_nonneg A])).trans (one_mul 1).le)
+  calc ‖A x‖ ≤ ‖A‖ * ‖x‖ := ContinuousLinearMap.le_opNorm A x
+    _ ≤ 1 * 1 := mul_le_mul hA hx (norm_nonneg _) zero_le_one
+    _ = 1 := one_mul 1
 
 /-- Approximate image norm: ‖Aℚ P_‖ ≤ (1+κ)² from ‖Aℚ‖ ≤ 1+κ, ‖P‖ ≤ 1, ‖P-P_‖ ≤ κ. -/
 lemma approx_image_norm_le {E F : Type*}


### PR DESCRIPTION
## Summary

**API changes:**
- `bounds_kappa4` ([SY25] Corollary 51) gains a new hypothesis `hA_nonneg` (numerator nonnegativity required for fraction monotonicity)
- `UpperSqrt.bound` / `LowerSqrt.bound` fields generalized from `∀ (x : ℚ), 0 ≤ x → ...` to `∀ (x : ℝ), 0 ≤ x → ...`, since `‖v‖²` is real-valued
- `delta_kappa` no longer takes `Papprox` (the rational term uses exact P, not P_)
- `bounds_kappa3_X` no longer takes `hQ` / `Qapprox` (unused in the proof)

**New proofs:**
- Prove all 7 BoundsKappa lemmas ([SY25] Lemma 44): 3κ bounds for M/Mθ/Mφ and 4κ bounds for RM/R'M/RMθ/RMφ
- Prove `bounds_kappa3_X` (3κ), `bounds_kappa3_M` (5κ), `bounds_kappa3_MQ` (3κ) ([SY25] Lemma 49)
- Prove `delta_kappa` (6κ) ([SY25] Corollary 50)
- Prove `bounds_kappa4` ([SY25] Corollary 51)

**Global.lean:** Minor proof rewrites for `partials_helper3` / `partials_helper4` (use `nth_partial_div_const` and `nth_partial_rotproj_outer_*` helpers instead of inlining fderiv reasoning)

**Infrastructure (MatrixBounds.lean):**
- Shared operator norm bounds: `Mθℚ_norm_bounded`, `Mφℚ_norm_bounded`, `R'ℚ_norm_bounded`
- `icc_int_to_real`: convenience coercion from `Set.Icc (-4) 4` to `Set.Icc (-4 : ℝ) 4`
- `clm_approx_apply_sub`: core ‖A P − Aℚ P_‖ ≤ 2κ + κ² bound for ‖P‖ ≤ 1, ‖P − P_‖ ≤ κ
- `clm_approx_apply_sub₂`: variant for ‖P‖ ≤ 2, ‖P − P_‖ ≤ 2κ (gives ≤ 4κ + 2κ²)
- `clm_unit_apply_le`: operator with ‖A‖ ≤ 1 preserves the unit ball
- `approx_image_norm_le`: ‖Aℚ P_‖ ≤ (1+κ)² from norm bounds on Aℚ, P, and P−P_

**Files changed:** `Global.lean`, `RationalApprox/Basic.lean`, `RationalApprox/MatrixBounds.lean`, `RationalApprox/BoundsKappa.lean`, `RationalApprox/BoundsKappa3.lean`, `RationalApprox/BoundsKappa4.lean`, `RationalApprox/DeltaKappa.lean`

## Notes

- `bounds_kappa4` requires `hA_nonneg : 0 ≤ ⟪rotM θ φ P, rotM θ φ (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)` as a new assumption. This is discharged at downstream call sites where the rational computation verifies a positive lower bound.
- `delta_kappa` uses `rotMℚ θ φ P` (exact P, not the approximation P_) in the rational term, matching [SY25] Corollary 50.

## Test plan

- [x] `lake build` passes
- [x] No sorry warnings in touched files
- [x] Remaining sorry warnings are in unrelated files only: `RationalGlobal`, `RationalLocal`, `SolutionTable`, `Local.Congruent`, `ComputationalStep`