### PR TITLE
Prove rational_local and rational_global (Theorems 48 & 43)

### DIFF
--- a/Noperthedron/RationalApprox/BoundsKappa.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa.lean
@@ -8,7 +8,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable {P P_ : ℝ³} {α θ φ : Set.Icc (-4) 4} {w : ℝ²}
+variable {P P_ : ℝ³} {α θ φ : Set.Icc (-4 : ℝ) 4} {w : ℝ²}
 
 /-!
 ## Helper lemma
@@ -39,22 +39,22 @@ private lemma inner_three_kappa {E F : Type*}
 lemma bounds_kappa_M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotM θ φ P, w⟫ - ⟪rotMℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
   inner_three_kappa
-    (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
-    (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    (Mℚ_norm_bounded (θ.property) (φ.property))
+    (M_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 lemma bounds_kappa_Mθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotMθ θ φ P, w⟫ - ⟪rotMθℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
   inner_three_kappa
-    (Mθℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
-    (Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    (Mθℚ_norm_bounded (θ.property) (φ.property))
+    (Mθ_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 lemma bounds_kappa_Mφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotMφ θ φ P, w⟫ - ⟪rotMφℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
   inner_three_kappa
-    (Mφℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
-    (Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    (Mφℚ_norm_bounded (θ.property) (φ.property))
+    (Mφ_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 /-!
@@ -96,34 +96,34 @@ lemma bounds_kappa_RM (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : 
     ‖⟪rotR α (rotM θ φ P), w⟫ - ⟪rotRℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
-    (R_difference_norm_bounded _ (icc_int_to_real α))
-    (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
-    (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    (R_difference_norm_bounded _ (α.property))
+    (Mℚ_norm_bounded (θ.property) (φ.property))
+    (M_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 lemma bounds_kappa_R'M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotR' α (rotM θ φ P), w⟫ - ⟪rotR'ℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR'_norm_one _))
-    (R'_difference_norm_bounded _ (icc_int_to_real α))
-    (Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
-    (M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    (R'_difference_norm_bounded _ (α.property))
+    (Mℚ_norm_bounded (θ.property) (φ.property))
+    (M_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 lemma bounds_kappa_RMθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotR α (rotMθ θ φ P), w⟫ - ⟪rotRℚ α (rotMθℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
-    (R_difference_norm_bounded _ (icc_int_to_real α))
-    (Mθℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
-    (Mθ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    (R_difference_norm_bounded _ (α.property))
+    (Mθℚ_norm_bounded (θ.property) (φ.property))
+    (Mθ_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 lemma bounds_kappa_RMφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
     ‖⟪rotR α (rotMφ θ φ P), w⟫ - ⟪rotRℚ α (rotMφℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
-    (R_difference_norm_bounded _ (icc_int_to_real α))
-    (Mφℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ))
-    (Mφ_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+    (R_difference_norm_bounded _ (α.property))
+    (Mφℚ_norm_bounded (θ.property) (φ.property))
+    (Mφ_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw

--- a/Noperthedron/RationalApprox/BoundsKappa3.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa3.lean
@@ -9,7 +9,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable {P Q Q_ P_ : ℝ³} {α θ φ : Set.Icc (-4 : ℝ) 4} {w : ℝ²}
+variable {P Q Q_ P_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
 
 /-!
 ## Helper: vector norm difference bound

--- a/Noperthedron/RationalApprox/BoundsKappa3.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa3.lean
@@ -9,7 +9,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable {P Q Q_ P_ : ℝ³} {α θ φ : Set.Icc (-4) 4} {w : ℝ²}
+variable {P Q Q_ P_ : ℝ³} {α θ φ : Set.Icc (-4 : ℝ) 4} {w : ℝ²}
 
 /-!
 ## Helper: vector norm difference bound
@@ -60,9 +60,9 @@ lemma bounds_kappa3_X (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
         add_le_add (abs_real_inner_le_norm _ _) (abs_real_inner_le_norm _ _)
     _ ≤ κ * 1 + (1 + κ) * κ :=
         add_le_add
-          (mul_le_mul (vecX_sub_vecXℚ_norm_le _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+          (mul_le_mul (vecX_sub_vecXℚ_norm_le _ _ (θ.property) (φ.property))
             hP (norm_nonneg _) (by norm_num [κ]))
-          (mul_le_mul (vecXℚ_norm_le _ _ (icc_int_to_real θ) (icc_int_to_real φ))
+          (mul_le_mul (vecXℚ_norm_le _ _ (θ.property) (φ.property))
             Papprox (norm_nonneg _) (by norm_num [κ]))
     _ ≤ 3 * κ := by unfold κ; norm_num
 
@@ -70,9 +70,9 @@ lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P 
     ‖⟪rotM θ φ P, rotM θ φ Q⟫ - ⟪rotMℚ θ φ P_, rotMℚ θ φ Q_⟫‖ ≤ 5 * κ := by
   rw [Real.norm_eq_abs]
   have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
-    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+    M_difference_norm_bounded _ _ (θ.property) (φ.property)
   have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
-    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+    Mℚ_norm_bounded (θ.property) (φ.property)
   -- Decompose: ⟪rotM P, rotM Q⟫ - ⟪rotMℚ P_, rotMℚ Q_⟫
   --   = ⟪rotM P - rotMℚ P_, rotM Q⟫ + ⟪rotMℚ P_, rotM Q - rotMℚ Q_⟫
   have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫ =
@@ -107,9 +107,9 @@ lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P 
 lemma bounds_kappa3_MQ (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     |(‖rotM θ φ Q‖ - ‖rotMℚ θ φ Q_‖)| ≤ 3 * κ := by
   have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
-    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+    M_difference_norm_bounded _ _ (θ.property) (φ.property)
   have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
-    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+    Mℚ_norm_bounded (θ.property) (φ.property)
   -- Reverse triangle inequality + clm_approx_apply_sub
   calc |(‖rotM θ φ Q‖ - ‖rotMℚ θ φ Q_‖)|
     _ ≤ ‖rotM θ φ Q - rotMℚ θ φ Q_‖ := abs_norm_sub_norm_le _ _

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -8,7 +8,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable (P Q P_ Q_ : ℝ³) (α θ φ : Set.Icc (-4 : ℝ) 4) (ε : ℝ)
+variable (P Q P_ Q_ : ℝ³) (θ φ : Set.Icc (-4 : ℝ) 4) (ε : ℝ)
 
 /-!
 [SY25] Corollary 51

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -165,15 +165,13 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
     -- Factor 1: ‖rotM P‖ + √2ε ≤ s.norm(rotMℚ P_) + √2ε + 3κ
     have h_f1 : ‖(rotM ↑θ ↑φ) P‖ + √2 * ε ≤
         s.norm ((rotMℚ ↑θ ↑φ) P_) + √2 * ε + 3 * κ := by
-      have h1 := norm_diff_bound_3kappa hP Papprox (θ := θ) (φ := φ)
-      have h2 := UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) P_)
-      linarith
+      linarith [norm_diff_bound_3kappa hP Papprox (θ := θ) (φ := φ),
+        UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) P_)]
     -- Factor 2: ‖rotM (P-Q)‖ + 2√2ε ≤ s.norm(rotMℚ (P_-Q_)) + 2√2ε + 6κ
     have h_f2 : ‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε ≤
         s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ := by
-      have h1 := norm_diff_bound_6kappa hP hQ Papprox Qapprox (θ := θ) (φ := φ)
-      have h2 := UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) (P_ - Q_))
-      linarith
+      linarith [norm_diff_bound_6kappa hP hQ Papprox Qapprox (θ := θ) (φ := φ),
+        UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) (P_ - Q_))]
     -- Both factors are nonneg
     have h_f1_nn : 0 ≤ ‖(rotM ↑θ ↑φ) P‖ + √2 * ε := by positivity
     have h_f2_nn : 0 ≤ ‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε := by positivity

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -8,7 +8,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable (P Q P_ Q_ : ℝ³) (α θ φ : Set.Icc (-4) 4) (ε : ℝ)
+variable (P Q P_ Q_ : ℝ³) (α θ φ : Set.Icc (-4 : ℝ) 4) (ε : ℝ)
 
 /-!
 [SY25] Corollary 51
@@ -33,14 +33,14 @@ private lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖
 /-- The inner product bound for `rotM`/`rotMℚ` when the second vector has norm ≤ 2.
 This generalises `bounds_kappa3_M` (which requires ‖Q‖ ≤ 1) to handle `P − Q`. -/
 private lemma inner_product_bound_10kappa
-    {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4) 4}
+    {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (hR : ‖Q‖ ≤ 2)
     (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ 2 * κ) :
     |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫| ≤ 10 * κ := by
   have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
-    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+    M_difference_norm_bounded _ _ (θ.property) (φ.property)
   have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
-    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+    Mℚ_norm_bounded (θ.property) (φ.property)
   -- Decompose: ⟪rotM P, rotM Q⟫ - ⟪rotMℚ P_, rotMℚ Q_⟫
   --   = ⟪rotM P - rotMℚ P_, rotM Q⟫ + ⟪rotMℚ P_, rotM Q - rotMℚ Q_⟫
   have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫ =
@@ -78,7 +78,7 @@ private lemma inner_product_bound_10kappa
 /-- The norm difference bound for `rotM`/`rotMℚ` applied to P (norm ≤ 1).
     Generalises `bounds_kappa3_MQ` from BoundsKappa3.lean. -/
 private lemma norm_diff_bound_3kappa
-    {P P_ : ℝ³} {θ φ : Set.Icc (-4) 4}
+    {P P_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
     ‖(rotM ↑θ ↑φ) P‖ ≤ ‖(rotMℚ ↑θ ↑φ) P_‖ + 3 * κ := by
   have h := bounds_kappa3_MQ (θ := θ) (φ := φ) hP Papprox
@@ -88,14 +88,14 @@ private lemma norm_diff_bound_3kappa
 /-- The norm difference bound for `rotM`/`rotMℚ` applied to `P - Q` (norm ≤ 2).
     Uses the same technique as bounds_kappa3_MQ but for ‖P - Q‖ ≤ 2. -/
 private lemma norm_diff_bound_6kappa
-    {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4) 4}
+    {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1)
     (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     ‖(rotM ↑θ ↑φ) (P - Q)‖ ≤ ‖(rotMℚ ↑θ ↑φ) (P_ - Q_)‖ + 6 * κ := by
   have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
-    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+    M_difference_norm_bounded _ _ (θ.property) (φ.property)
   have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
-    Mℚ_norm_bounded (icc_int_to_real θ) (icc_int_to_real φ)
+    Mℚ_norm_bounded (θ.property) (φ.property)
   have hPQ_norm : ‖P - Q‖ ≤ 2 := by
     calc ‖P - Q‖ ≤ ‖P‖ + ‖Q‖ := norm_sub_le _ _
       _ ≤ 1 + 1 := add_le_add hP hQ

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -115,13 +115,12 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
     (hA_nonneg : 0 ≤ ⟪rotM θ φ P, rotM θ φ (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)) :
     bounds_kappa4_Aℚ P_ Q_ θ φ ε s ≤ bounds_kappa4_A P Q θ φ ε := by
   -- Abbreviate the numerators and denominators
-  set numA := ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε) with numA_def
+  set numA := ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)
   set numAℚ := ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) (P_ - Q_)⟫ - 10 * κ -
-    2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε) with numAℚ_def
+    2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)
   set denA := (‖(rotM ↑θ ↑φ) P‖ + √2 * ε) * (‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε)
-    with denA_def
   set denAℚ := (s.norm ((rotMℚ ↑θ ↑φ) P_) + √2 * ε + 3 * κ) *
-    (s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ) with denAℚ_def
+    (s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ)
   -- The goal becomes numAℚ / denAℚ ≤ numA / denA after unfolding
   change numAℚ / denAℚ ≤ numA / denA
   -- Step 1: numAℚ ≤ numA
@@ -158,9 +157,7 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
       mul_le_mul_of_nonneg_right
         (mul_le_mul_of_nonneg_left h_norm_PQ (by linarith)) (by positivity)
     linarith [h_inner_le, h_eps_term]
-  -- Step 2: denA > 0
-  have h_denA_pos : 0 < denA := by positivity
-  -- Step 3: denA ≤ denAℚ
+  -- Step 2: denA ≤ denAℚ
   have h_denA_le : denA ≤ denAℚ := by
     -- Factor 1: ‖rotM P‖ + √2ε ≤ s.norm(rotMℚ P_) + √2ε + 3κ
     have h_f1 : ‖(rotM ↑θ ↑φ) P‖ + √2 * ε ≤
@@ -172,9 +169,6 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
         s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ := by
       linarith [norm_diff_bound_6kappa hP hQ Papprox Qapprox (θ := θ) (φ := φ),
         UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) (P_ - Q_))]
-    -- Both factors are nonneg
-    have h_f1_nn : 0 ≤ ‖(rotM ↑θ ↑φ) P‖ + √2 * ε := by positivity
-    have h_f2_nn : 0 ≤ ‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε := by positivity
-    exact mul_le_mul h_f1 h_f2 h_f2_nn (le_trans h_f1_nn h_f1)
-  -- Step 4: Apply div_le_div₀
-  exact div_le_div₀ hA_nonneg h_numAℚ_le h_denA_pos h_denA_le
+    exact mul_le_mul h_f1 h_f2 (by positivity) (le_trans (by positivity) h_f1)
+  -- Step 3: Apply div_le_div₀
+  exact div_le_div₀ hA_nonneg h_numAℚ_le (by positivity) h_denA_le

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -24,7 +24,7 @@ def bounds_kappa4_Aℚ (s : UpperSqrt) :=
   ((s.norm (rotMℚ θ φ P_) + √2 * ε + 3 * κ) * (s.norm (rotMℚ θ φ (P_ - Q_)) + 2 * √2 * ε + 6 * κ))
 
 /-- An `UpperSqrt` overestimates the Euclidean norm. -/
-private lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖ ≤ s.norm v := by
+lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖ ≤ s.norm v := by
   unfold UpperSqrt.norm
   have h : (0 : ℝ) ≤ ‖v‖ ^ 2 := sq_nonneg _
   calc ‖v‖ = √(‖v‖ ^ 2) := by rw [Real.sqrt_sq (norm_nonneg _)]
@@ -32,7 +32,7 @@ private lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖
 
 /-- The inner product bound for `rotM`/`rotMℚ` when the second vector has norm ≤ 2.
 This generalises `bounds_kappa3_M` (which requires ‖Q‖ ≤ 1) to handle `P − Q`. -/
-private lemma inner_product_bound_10kappa
+lemma inner_product_bound_10kappa
     {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (hR : ‖Q‖ ≤ 2)
     (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ 2 * κ) :
@@ -77,7 +77,7 @@ private lemma inner_product_bound_10kappa
 
 /-- The norm difference bound for `rotM`/`rotMℚ` applied to P (norm ≤ 1).
     Generalises `bounds_kappa3_MQ` from BoundsKappa3.lean. -/
-private lemma norm_diff_bound_3kappa
+lemma norm_diff_bound_3kappa
     {P P_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
     ‖(rotM ↑θ ↑φ) P‖ ≤ ‖(rotMℚ ↑θ ↑φ) P_‖ + 3 * κ := by
@@ -87,7 +87,7 @@ private lemma norm_diff_bound_3kappa
 
 /-- The norm difference bound for `rotM`/`rotMℚ` applied to `P - Q` (norm ≤ 2).
     Uses the same technique as bounds_kappa3_MQ but for ‖P - Q‖ ≤ 2. -/
-private lemma norm_diff_bound_6kappa
+lemma norm_diff_bound_6kappa
     {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1)
     (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -8,7 +8,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4 : ℝ) 4} {w : ℝ²}
+variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4 : ℝ) 4}
 
 /-!
 [SY25] Corollary 50

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -8,7 +8,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4) 4} {w : ℝ²}
+variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4 : ℝ) 4} {w : ℝ²}
 
 /-!
 [SY25] Corollary 50
@@ -17,17 +17,17 @@ variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4) 4} {w : 
 lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_‖ ≤ κ) :
     |‖rotR α (rotM θ φ P) - rotM θ_ φ_ Q‖ - ‖rotRℚ α (rotMℚ θ φ P) - rotMℚ θ_ φ_ Q_‖| ≤ 6 * κ := by
   have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
-    M_difference_norm_bounded _ _ (icc_int_to_real θ) (icc_int_to_real φ)
+    M_difference_norm_bounded _ _ (θ.property) (φ.property)
   have hRdiff : ‖rotR (α : ℝ) - rotRℚ (α : ℝ)‖ ≤ κ :=
-    R_difference_norm_bounded _ (icc_int_to_real α)
+    R_difference_norm_bounded _ (α.property)
   have hM_diff' : ‖rotM (θ_ : ℝ) (φ_ : ℝ) - rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ κ :=
-    M_difference_norm_bounded _ _ (icc_int_to_real θ_) (icc_int_to_real φ_)
+    M_difference_norm_bounded _ _ (θ_.property) (φ_.property)
   have hMℚnorm' : ‖rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ 1 + κ :=
-    Mℚ_norm_bounded (icc_int_to_real θ_) (icc_int_to_real φ_)
+    Mℚ_norm_bounded (θ_.property) (φ_.property)
   -- Term 1: ‖rotR(rotM P) - rotRℚ(rotMℚ P)‖ ≤ 2κ + κ²
   -- Decompose at the R level: A = rotR, Aℚ = rotRℚ, P = rotM P, P_ = rotMℚ P
   have term1 : ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖ ≤ 2 * κ + κ ^ 2 :=
-    clm_approx_apply_sub hRdiff (Rℚ_norm_bounded _ (icc_int_to_real α))
+    clm_approx_apply_sub hRdiff (Rℚ_norm_bounded _ (α.property))
       (clm_unit_apply_le (le_of_eq (Bounding.rotM_norm_one _ _)) hP)
       (by rw [show (rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P = (rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P from
               (ContinuousLinearMap.sub_apply _ _ _).symm]

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -20,10 +20,6 @@ lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_
     M_difference_norm_bounded _ _ (θ.property) (φ.property)
   have hRdiff : ‖rotR (α : ℝ) - rotRℚ (α : ℝ)‖ ≤ κ :=
     R_difference_norm_bounded _ (α.property)
-  have hM_diff' : ‖rotM (θ_ : ℝ) (φ_ : ℝ) - rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ κ :=
-    M_difference_norm_bounded _ _ (θ_.property) (φ_.property)
-  have hMℚnorm' : ‖rotMℚ (θ_ : ℝ) (φ_ : ℝ)‖ ≤ 1 + κ :=
-    Mℚ_norm_bounded (θ_.property) (φ_.property)
   -- Term 1: ‖rotR(rotM P) - rotRℚ(rotMℚ P)‖ ≤ 2κ + κ²
   -- Decompose at the R level: A = rotR, Aℚ = rotRℚ, P = rotM P, P_ = rotMℚ P
   have term1 : ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖ ≤ 2 * κ + κ ^ 2 :=
@@ -37,7 +33,8 @@ lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_
             _ = κ := mul_one κ)
   -- Term 2: ‖rotM' Q - rotMℚ' Q_‖ ≤ 2κ + κ²
   have term2 : ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖ ≤ 2 * κ + κ ^ 2 :=
-    clm_approx_apply_sub hM_diff' hMℚnorm' hQ Qapprox
+    clm_approx_apply_sub (M_difference_norm_bounded _ _ (θ_.property) (φ_.property))
+      (Mℚ_norm_bounded (θ_.property) (φ_.property)) hQ Qapprox
   -- Combine using reverse triangle inequality
   calc |‖rotR ↑α ((rotM ↑θ ↑φ) P) - (rotM ↑θ_ ↑φ_) Q‖ -
         ‖rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P) - (rotMℚ ↑θ_ ↑φ_) Q_‖|

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -8,7 +8,7 @@ open scoped RealInnerProductSpace
 
 namespace RationalApprox
 
-variable {P P_ : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4 : ℝ) 4}
+variable {P : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4 : ℝ) 4}
 
 /-!
 [SY25] Corollary 50

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -48,6 +48,9 @@ structure RationalGlobalTheoremPrecondition (poly poly_ : GoodPoly)
   w_unit : ‖w‖ = 1
   exceeds : G p ε S w > maxH p poly_ ε w
 
+private lemma abs_le_abs_add_of_norm_sub_le {a b C : ℝ} (h : ‖a - b‖ ≤ C) : |a| ≤ |b| + C := by
+  linarith [abs_sub_abs_le_abs_sub a b, (Real.norm_eq_abs _).symm ▸ h]
+
 private lemma G_rational_le_G_real {pbar : Pose} {ε : ℝ} (hε : ε > 0)
     {S S_ : ℝ³} {w : ℝ²}
     (hS : ‖S‖ ≤ 1) (hS_approx : ‖S - S_‖ ≤ κ) (hw : ‖w‖ = 1)
@@ -91,18 +94,9 @@ private lemma G_rational_le_G_real {pbar : Pose} {ε : ℝ} (hε : ε > 0)
   have hi_le : ⟪pbar.rotRℚ (pbar.rotM₁ℚ S_), w⟫ ≤ ⟪pbar.rotR (pbar.rotM₁ S), w⟫ + 4 * κ := by
     have := (Real.norm_eq_abs _).symm ▸ h_inner; rw [abs_le] at this; linarith [this.1]
   -- |abs_real| ≤ |abs_rational| + 4κ for the three ε-coefficient terms
-  have hR'_abs : |⟪pbar.rotR' (pbar.rotM₁ S), w⟫| ≤ |⟪pbar.rotR'ℚ (pbar.rotM₁ℚ S_), w⟫| + 4 * κ := by
-    have h2 : |⟪pbar.rotR' (pbar.rotM₁ S), w⟫ - ⟪pbar.rotR'ℚ (pbar.rotM₁ℚ S_), w⟫| ≤ 4 * κ :=
-      (Real.norm_eq_abs _).symm ▸ h_R'M
-    linarith [abs_sub_abs_le_abs_sub (⟪pbar.rotR' (pbar.rotM₁ S), w⟫) (⟪pbar.rotR'ℚ (pbar.rotM₁ℚ S_), w⟫)]
-  have hRθ_abs : |⟪pbar.rotR (pbar.rotM₁θ S), w⟫| ≤ |⟪pbar.rotRℚ (pbar.rotM₁θℚ S_), w⟫| + 4 * κ := by
-    have h2 : |⟪pbar.rotR (pbar.rotM₁θ S), w⟫ - ⟪pbar.rotRℚ (pbar.rotM₁θℚ S_), w⟫| ≤ 4 * κ :=
-      (Real.norm_eq_abs _).symm ▸ h_RMθ
-    linarith [abs_sub_abs_le_abs_sub (⟪pbar.rotR (pbar.rotM₁θ S), w⟫) (⟪pbar.rotRℚ (pbar.rotM₁θℚ S_), w⟫)]
-  have hRφ_abs : |⟪pbar.rotR (pbar.rotM₁φ S), w⟫| ≤ |⟪pbar.rotRℚ (pbar.rotM₁φℚ S_), w⟫| + 4 * κ := by
-    have h2 : |⟪pbar.rotR (pbar.rotM₁φ S), w⟫ - ⟪pbar.rotRℚ (pbar.rotM₁φℚ S_), w⟫| ≤ 4 * κ :=
-      (Real.norm_eq_abs _).symm ▸ h_RMφ
-    linarith [abs_sub_abs_le_abs_sub (⟪pbar.rotR (pbar.rotM₁φ S), w⟫) (⟪pbar.rotRℚ (pbar.rotM₁φℚ S_), w⟫)]
+  have hR'_abs := abs_le_abs_add_of_norm_sub_le h_R'M
+  have hRθ_abs := abs_le_abs_add_of_norm_sub_le h_RMθ
+  have hRφ_abs := abs_le_abs_add_of_norm_sub_le h_RMφ
   nlinarith
 
 private lemma H_real_le_H_rational {pbar : Pose} {ε : ℝ} (hε : ε > 0)
@@ -130,15 +124,8 @@ private lemma H_real_le_H_rational {pbar : Pose} {ε : ℝ} (hε : ε > 0)
   have hm_le : ⟪pbar.rotM₂ P, w⟫ ≤ ⟪pbar.rotM₂ℚ P_, w⟫ + 3 * κ := by
     have := (Real.norm_eq_abs _).symm ▸ h_M; rw [abs_le] at this; linarith [this.2]
   -- Absolute value bounds: |real| ≤ |rational| + 3κ
-  have hθ_abs : |⟪pbar.rotM₂θ P, w⟫| ≤ |⟪pbar.rotM₂θℚ P_, w⟫| + 3 * κ := by
-    have h1 := abs_abs_sub_abs_le ⟪pbar.rotM₂θ P, w⟫ ⟪pbar.rotM₂θℚ P_, w⟫
-    have h2 : |⟪pbar.rotM₂θ P, w⟫ - ⟪pbar.rotM₂θℚ P_, w⟫| ≤ 3 * κ :=
-      (Real.norm_eq_abs _).symm ▸ h_Mθ
-    linarith [abs_sub_abs_le_abs_sub (⟪pbar.rotM₂θ P, w⟫) (⟪pbar.rotM₂θℚ P_, w⟫)]
-  have hφ_abs : |⟪pbar.rotM₂φ P, w⟫| ≤ |⟪pbar.rotM₂φℚ P_, w⟫| + 3 * κ := by
-    have h2 : |⟪pbar.rotM₂φ P, w⟫ - ⟪pbar.rotM₂φℚ P_, w⟫| ≤ 3 * κ :=
-      (Real.norm_eq_abs _).symm ▸ h_Mφ
-    linarith [abs_sub_abs_le_abs_sub (⟪pbar.rotM₂φ P, w⟫) (⟪pbar.rotM₂φℚ P_, w⟫)]
+  have hθ_abs := abs_le_abs_add_of_norm_sub_le h_Mθ
+  have hφ_abs := abs_le_abs_add_of_norm_sub_le h_Mφ
   nlinarith
 
 /--

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -13,7 +13,7 @@ A measure of how far an inner-shadow vertex S can "stick out"
 noncomputable
 def G (p : Pose) (ε : ℝ) (S : ℝ³) (w : ℝ²) : ℝ :=
   ⟪p.innerℚ S, w⟫ - (ε * (|⟪p.rotR'ℚ (p.rotM₁ℚ S), w⟫| + |⟪p.rotRℚ (p.rotM₁θℚ S), w⟫| + |⟪p.rotRℚ (p.rotM₁φℚ S), w⟫|)
-  - 9 * ε^2 / 2 - 4 * κ * (1 + 3 * ε))
+  + 9 * ε^2 / 2 + 4 * κ * (1 + 3 * ε))
 
 /--
 A measure of how far an outer-shadow vertex P can "reach" along w.

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -150,7 +150,7 @@ theorem rational_global (pbar : Pose) (ε : ℝ) (hε : ε > 0)
     -- Map P to P_
     let P_ := happrox.bijection ⟨P, hP_mem⟩
     have hP_norm : ‖P‖ ≤ 1 := poly.vertex_radius_le_one P hP_mem
-    have hP_approx : ‖P - (P_ : ℝ³)‖ ≤ κ := happrox.approx ⟨P, hP_mem⟩
+    have hP_approx : ‖P - (P_ : ℝ³)‖ ≤ κ := by simpa [P_] using happrox.approx ⟨P, hP_mem⟩
     have hH_le := H_le_Hℚ hε hP_norm hP_approx pc.w_unit pc.p_in_4
     calc GlobalTheorem.H pbar ε pc.w P
       _ ≤ Hℚ pbar ε pc.w P_ := hH_le

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -68,7 +68,7 @@ private lemma G_rational_le_G_real {pbar : Pose} {ε : ℝ} (hε : ε > 0)
     exact bounds_kappa_RM hS hS_approx hw
   -- The inner is ⟪pbar.inner S, w⟫ = ⟪pbar.rotR (pbar.rotM₁ S), w⟫
   have h_inner_eq : ⟪(pbar.inner S : ℝ²), w⟫ = ⟪pbar.rotR (pbar.rotM₁ S), w⟫ := by
-    congr 1; have := Pose.inner_eq_RM pbar; rw [this]; rfl
+    simp [Pose.inner_eq_RM pbar]
   -- innerℚ = rotRℚ ∘ rotM₁ℚ
   have h_innerQ_eq : ⟪pbar.innerℚ S_, w⟫ = ⟪pbar.rotRℚ (pbar.rotM₁ℚ S_), w⟫ := by
     simp [Pose.innerℚ, ContinuousLinearMap.comp_apply]
@@ -141,9 +141,7 @@ theorem rational_global (pbar : Pose) (ε : ℝ) (hε : ε > 0)
   let S_real := happrox.bijection.symm ⟨pc.S, pc.S_in_poly⟩
   have hS_in : (S_real : ℝ³) ∈ poly.vertices := S_real.property
   have hS_approx : ‖(S_real : ℝ³) - pc.S‖ ≤ κ := by
-    have h := happrox.approx S_real
-    simp only [S_real, Equiv.apply_symm_apply] at h
-    exact h
+    simpa [S_real, Equiv.apply_symm_apply] using happrox.approx S_real
   have hS_norm : ‖(S_real : ℝ³)‖ ≤ 1 := poly.vertex_radius_le_one _ hS_in
   -- Step 2: Build GlobalTheoremPrecondition
   have h_G_le := G_rational_le_G_real hε hS_norm hS_approx pc.w_unit pc.p_in_4
@@ -151,9 +149,8 @@ theorem rational_global (pbar : Pose) (ε : ℝ) (hε : ε > 0)
   have h_maxH_le : _root_.GlobalTheorem.maxH pbar poly ε pc.w ≤ maxH pbar poly_ ε pc.w := by
     unfold _root_.GlobalTheorem.maxH maxH
     apply Finset.max'_le
-    intro h_real hh_real
-    simp only [Finset.mem_image] at hh_real
-    obtain ⟨P, hP_mem, rfl⟩ := hh_real
+    intro _ hh_real
+    rcases Finset.mem_image.mp hh_real with ⟨P, hP_mem, rfl⟩
     -- Map P to P_
     let P_ := happrox.bijection ⟨P, hP_mem⟩
     have hP_norm : ‖P‖ ≤ 1 := poly.vertex_radius_le_one P hP_mem

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -139,9 +139,7 @@ theorem rational_global (pbar : Pose) (ε : ℝ) (hε : ε > 0)
   have hS_approx : ‖(S_real : ℝ³) - pc.S‖ ≤ κ := by
     simpa [S_real, Equiv.apply_symm_apply] using happrox.approx S_real
   have hS_norm : ‖(S_real : ℝ³)‖ ≤ 1 := poly.vertex_radius_le_one _ hS_in
-  -- Step 2: Build GlobalTheoremPrecondition
-  have h_G_le := Gℚ_le_G hε hS_norm hS_approx pc.w_unit pc.p_in_4
-  -- Step 3: Show maxH_real ≤ maxHℚ
+  -- Step 2: Show maxH_real ≤ maxHℚ
   have h_maxH_le : GlobalTheorem.maxH pbar poly ε pc.w ≤ maxHℚ pbar poly_ ε pc.w := by
     unfold GlobalTheorem.maxH maxHℚ
     apply Finset.max'_le
@@ -151,9 +149,8 @@ theorem rational_global (pbar : Pose) (ε : ℝ) (hε : ε > 0)
     let P_ := happrox.bijection ⟨P, hP_mem⟩
     have hP_norm : ‖P‖ ≤ 1 := poly.vertex_radius_le_one P hP_mem
     have hP_approx : ‖P - (P_ : ℝ³)‖ ≤ κ := by simpa [P_] using happrox.approx ⟨P, hP_mem⟩
-    have hH_le := H_le_Hℚ hε hP_norm hP_approx pc.w_unit pc.p_in_4
     calc GlobalTheorem.H pbar ε pc.w P
-      _ ≤ Hℚ pbar ε pc.w P_ := hH_le
+      _ ≤ Hℚ pbar ε pc.w P_ := H_le_Hℚ hε hP_norm hP_approx pc.w_unit pc.p_in_4
       _ ≤ (poly_.vertices.image (Hℚ pbar ε pc.w)).max' _ := by
           apply Finset.le_max'
           exact Finset.mem_image_of_mem _ P_.property
@@ -163,5 +160,5 @@ theorem rational_global (pbar : Pose) (ε : ℝ) (hε : ε > 0)
     S_in_poly := hS_in
     w := pc.w
     w_unit := pc.w_unit
-    exceeds := by linarith [pc.exceeds]
+    exceeds := by linarith [pc.exceeds, Gℚ_le_G hε hS_norm hS_approx pc.w_unit pc.p_in_4]
   }

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -4,9 +4,34 @@ import Noperthedron.RationalApprox.EpsKapSpanning
 import Noperthedron.RationalApprox.BoundsKappa3
 import Noperthedron.RationalApprox.BoundsKappa4
 
-namespace RationalApprox.LocalTheorem
 open Local (Triangle)
 open scoped RealInnerProductSpace Real
+
+open RationalApprox (κ UpperSqrt)
+
+namespace Local.Triangle
+
+/--
+Condition A_ε^ℚ from [SY25] Theorem 48
+-/
+def Aεℚ (X : ℝ³) (P_ : Triangle) (ε : ℝ) : Prop :=
+  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪X, P_ i⟫ > √2 * ε + 3 * κ
+
+noncomputable
+def Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose) (ε : ℝ) (su : UpperSqrt) : ℝ :=
+   (⟪p.rotM₂ℚ v₁, p.rotM₂ℚ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (su.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
+   / ((su.norm (p.rotM₂ℚ v₁) + √2 * ε + 3 * κ) * (su.norm (p.rotM₂ℚ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
+
+/--
+Condition B_ε^ℚ from [SY25] Theorem 48
+-/
+def Bεℚ (Q : Triangle) (poly : Finset Euc(3)) (p : Pose) (ε δ r : ℝ) (su : UpperSqrt) : Prop :=
+  ∀ i : Fin 3, ∀ v ∈ poly, v ≠ Q i →
+    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q i) v p ε su
+
+end Local.Triangle
+
+namespace RationalApprox.LocalTheorem
 
 /--
 If we have a triangle `P` in `poly`, yield the corresponding
@@ -16,24 +41,6 @@ def transportTri {poly poly_ : GoodPoly} {P : Triangle}
     (hP : ∀ i, P i ∈ poly.vertices)
     (hpoly : κApproxPoly poly.vertices poly_.vertices) : Triangle :=
   fun i => hpoly.bijection ⟨P i, hP i⟩
-
-/--
-Condition A_ε^ℚ from [SY25] Theorem 48
--/
-def _root_.Local.Triangle.Aεℚ (X : ℝ³) (P_ : Triangle) (ε : ℝ) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪X, P_ i⟫ > √2 * ε + 3 * κ
-
-noncomputable
-def _root_.Local.Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose) (ε : ℝ) (su : UpperSqrt) : ℝ :=
-   (⟪p.rotM₂ℚ v₁, p.rotM₂ℚ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (su.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
-   / ((su.norm (p.rotM₂ℚ v₁) + √2 * ε + 3 * κ) * (su.norm (p.rotM₂ℚ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
-
-/--
-Condition B_ε^ℚ from [SY25] Theorem 48
--/
-def _root_.Local.Triangle.Bεℚ (Q : Triangle) (poly : Finset Euc(3)) (p : Pose) (ε δ r : ℝ) (su : UpperSqrt) : Prop :=
-  ∀ i : Fin 3, ∀ v ∈ poly, v ≠ Q i →
-    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q i) v p ε su
 
 /-- The condition on δ -/
 def BoundDeltaℚ (δ : ℝ) (p : Pose) (P Q : Triangle) (su : UpperSqrt) : Prop :=

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -29,13 +29,13 @@ def _root_.Local.Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose) (ε : ℝ) 
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
 -/
-def _root_.Local.Triangle.Bεℚ (Q : Triangle) (poly : Finset Euc(3)) (p : Pose) (ε δ r : ℝ) : Prop :=
+def _root_.Local.Triangle.Bεℚ (Q : Triangle) (poly : Finset Euc(3)) (p : Pose) (ε δ r : ℝ) (su : UpperSqrt) : Prop :=
   ∀ i : Fin 3, ∀ v ∈ poly, v ≠ Q i →
-    (δ + √5 * ε) / r < Triangle.Bε.lhs (Q i) v p ε
+    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q i) v p ε su
 
 /-- The condition on δ -/
 def BoundDeltaℚ (δ : ℝ) (p : Pose) (P Q : Triangle) (su : UpperSqrt) : Prop :=
-  ∀ i : Fin 3, δ ≥ su.norm (p.rotR (p.rotM₁ℚ (P i)) - p.rotM₂ℚ (Q i))/2
+  ∀ i : Fin 3, δ ≥ su.norm (p.rotR (p.rotM₁ℚ (P i)) - p.rotM₂ℚ (Q i))/2 + 3 * κ
 
 /-- The condition on r -/
 def BoundRℚ (r ε : ℝ) (p : Pose) (Q : Triangle) (sl : LowerSqrt) : Prop :=
@@ -57,6 +57,6 @@ theorem rational_local (poly poly_ : GoodPoly)
     (ae₁ : (transportTri hP hpoly).Aεℚ p_.vecX₁ℚ ε) (ae₂ : (transportTri hQ hpoly).Aεℚ p_.vecX₂ℚ ε)
     (span₁ : (transportTri hP hpoly).κSpanning p_.θ₁ p_.φ₁ ε)
     (span₂ : (transportTri hQ hpoly).κSpanning p_.θ₂ p_.φ₂ ε)
-    (be : (transportTri hQ hpoly).Bεℚ poly_.vertices p_ ε δ r)
+    (be : (transportTri hQ hpoly).Bεℚ poly_.vertices p_ ε δ r su)
     : ¬∃ p ∈ p_.closed_ball ε, RupertPose p poly.hull := by
   sorry

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -1,6 +1,8 @@
 import Noperthedron.Local
 import Noperthedron.RationalApprox.Basic
 import Noperthedron.RationalApprox.EpsKapSpanning
+import Noperthedron.RationalApprox.BoundsKappa3
+import Noperthedron.RationalApprox.BoundsKappa4
 
 namespace RationalApprox.LocalTheorem
 open Local (Triangle)
@@ -59,4 +61,217 @@ theorem rational_local (poly poly_ : GoodPoly)
     (span₂ : (transportTri hQ hpoly).κSpanning p_.θ₂ p_.φ₂ ε)
     (be : (transportTri hQ hpoly).Bεℚ poly_.vertices p_ ε δ r su)
     : ¬∃ p ∈ p_.closed_ball ε, RupertPose p poly.hull := by
-  sorry
+  -- Abbreviations for transported triangles
+  set P_ := transportTri hP hpoly
+  set Q_ := transportTri hQ hpoly
+  -- Angle subtypes
+  set θ₁ : Set.Icc (-4 : ℝ) 4 := ⟨p_.θ₁, hp.1⟩
+  set φ₁ : Set.Icc (-4 : ℝ) 4 := ⟨p_.φ₁, hp.2.2.1⟩
+  set θ₂ : Set.Icc (-4 : ℝ) 4 := ⟨p_.θ₂, hp.2.1⟩
+  set φ₂ : Set.Icc (-4 : ℝ) 4 := ⟨p_.φ₂, hp.2.2.2.1⟩
+  -- Vertex norm bounds
+  have hPnorm (i : Fin 3) : ‖P i‖ ≤ 1 := poly.vertex_radius_le_one _ (hP i)
+  have hQnorm (i : Fin 3) : ‖Q i‖ ≤ 1 := poly.vertex_radius_le_one _ (hQ i)
+  -- Approximation bounds
+  have hPapprox (i : Fin 3) : ‖P i - P_ i‖ ≤ κ := hpoly.approx ⟨P i, hP i⟩
+  have hQapprox (i : Fin 3) : ‖Q i - Q_ i‖ ≤ κ := hpoly.approx ⟨Q i, hQ i⟩
+  -- Bridge: κSpanning → Spanning
+  have span₁' : P.Spanning p_.θ₁ p_.φ₁ ε :=
+    ek_spanning_imp_e_spanning P P_ (fun i => hPapprox i) hPnorm hp.1 hp.2.2.1 span₁
+  have span₂' : Q.Spanning p_.θ₂ p_.φ₂ ε :=
+    ek_spanning_imp_e_spanning Q Q_ (fun i => hQapprox i) hQnorm hp.2.1 hp.2.2.2.1 span₂
+  -- Bridge: Aεℚ → Aε
+  have ae₁' : P.Aε p_.vecX₁ ε := by
+    obtain ⟨σ, hσ₁, hσ₂⟩ := ae₁
+    refine ⟨σ, hσ₁, fun i => ?_⟩
+    have hX : ‖⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫‖ ≤ 3 * κ :=
+      bounds_kappa3_X (θ := θ₁) (φ := φ₁) (hPnorm i) (hPapprox i)
+    change (-1) ^ σ * ⟪vecX ↑θ₁ ↑φ₁, P i⟫ > √2 * ε
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
+    rw [Real.norm_eq_abs] at hX
+    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
+    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
+      rw [abs_mul, habs, one_mul]; exact hX
+    rw [abs_le] at hdiff
+    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₁ ↑φ₁, P i⟫ ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫]
+  have ae₂' : Q.Aε p_.vecX₂ ε := by
+    obtain ⟨σ, hσ₁, hσ₂⟩ := ae₂
+    refine ⟨σ, hσ₁, fun i => ?_⟩
+    have hX : ‖⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫‖ ≤ 3 * κ :=
+      bounds_kappa3_X (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
+    change (-1) ^ σ * ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ > √2 * ε
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
+    rw [Real.norm_eq_abs] at hX
+    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
+    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by
+      rw [abs_mul, habs, one_mul]; exact hX
+    rw [abs_le] at hdiff
+    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫]
+  -- Bridge: BoundRℚ → BoundR
+  have hr₁' : Local.BoundR r ε p_ Q := by
+    intro i
+    have hsl : sl.norm ((rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) ≤ ‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
+      show sl.f _ ≤ _; calc sl.f (‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2)
+        _ ≤ √(‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2) := sl.bound _ (sq_nonneg _)
+        _ = ‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := Real.sqrt_sq (norm_nonneg _)
+    have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ - ‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖)| ≤ 3 * κ :=
+      bounds_kappa3_MQ (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
+    show ‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ > r + √2 * ε
+    have hr₁i : sl.norm ((rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) > r + √2 * ε + 3 * κ := hr₁ i
+    rw [abs_le] at hMQ
+    linarith [hMQ.1]
+  -- Bridge: BoundDeltaℚ → BoundDelta
+  have hδ' : Local.BoundDelta δ p_ P Q := by
+    intro i
+    have := hδ i
+    -- su.norm ≥ ‖·‖
+    have hsu : ‖p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i)‖ ≤
+        su.norm (p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i)) := by
+      exact UpperSqrt_norm_le su _
+    -- ‖real - rational‖ ≤ 6κ
+    have hM₁diff : ‖rotM (↑θ₁ : ℝ) ↑φ₁ - rotMℚ ↑θ₁ ↑φ₁‖ ≤ κ :=
+      M_difference_norm_bounded _ _ θ₁.property φ₁.property
+    have hM₁ℚnorm : ‖rotMℚ (↑θ₁ : ℝ) ↑φ₁‖ ≤ 1 + κ :=
+      Mℚ_norm_bounded θ₁.property φ₁.property
+    have hM₂diff : ‖rotM (↑θ₂ : ℝ) ↑φ₂ - rotMℚ ↑θ₂ ↑φ₂‖ ≤ κ :=
+      M_difference_norm_bounded _ _ θ₂.property φ₂.property
+    have hM₂ℚnorm : ‖rotMℚ (↑θ₂ : ℝ) ↑φ₂‖ ≤ 1 + κ :=
+      Mℚ_norm_bounded θ₂.property φ₂.property
+    have h₁ : ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)‖ ≤ 2 * κ + κ ^ 2 :=
+      clm_approx_apply_sub hM₁diff hM₁ℚnorm (hPnorm i) (hPapprox i)
+    have h₂ : ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ ≤ 2 * κ + κ ^ 2 :=
+      clm_approx_apply_sub hM₂diff hM₂ℚnorm (hQnorm i) (hQapprox i)
+    have hdiff : ‖(p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)) -
+        (p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i))‖ ≤ 4 * κ + 2 * κ ^ 2 := by
+      show ‖(rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i)) -
+            (rotR p_.α ((rotMℚ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i))‖ ≤ _
+      have hrw : rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i) -
+            (rotR p_.α ((rotMℚ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) =
+            rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)) -
+            ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) := by
+        simp [map_sub]; abel
+      rw [hrw]
+      calc ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)) -
+              ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i))‖
+        _ ≤ ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i))‖ +
+            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := norm_sub_le _ _
+        _ = ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)‖ +
+            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
+          rw [Bounding.rotR_preserves_norm]
+        _ ≤ (2 * κ + κ ^ 2) + (2 * κ + κ ^ 2) := add_le_add h₁ h₂
+        _ = 4 * κ + 2 * κ ^ 2 := by ring
+    show δ ≥ ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ / 2
+    have hnorm_le : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
+        ‖p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i)‖ + (4 * κ + 2 * κ ^ 2) := by
+      linarith [norm_le_insert' (p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i))
+        (p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i))]
+    have h6k : 4 * κ + 2 * κ ^ 2 ≤ 6 * κ := by unfold κ; norm_num
+    linarith [hsu]
+  -- Bridge: Bεℚ → Bε
+  have be' : Q.Bε poly.vertices p_ ε δ r := by
+    intro i v hv hne
+    -- Map v to v_ in poly_
+    let bij_v := hpoly.bijection ⟨v, hv⟩
+    have hv_ : (bij_v : ℝ³) ∈ poly_.vertices := bij_v.property
+    have hne_ : (bij_v : ℝ³) ≠ Q_ i := by
+      intro h; apply hne
+      have h1 : bij_v = hpoly.bijection ⟨Q i, hQ i⟩ := Subtype.coe_injective h
+      exact congr_arg Subtype.val (hpoly.bijection.injective h1)
+    have hvapprox : ‖v - (bij_v : ℝ³)‖ ≤ κ := hpoly.approx ⟨v, hv⟩
+    have hvnorm : ‖v‖ ≤ 1 := poly.vertex_radius_le_one v hv
+    set v_ : ℝ³ := (bij_v : ℝ³)
+    -- Get the Bεℚ hypothesis
+    have hbe := be i v_ hv_ hne_
+    show (δ + √5 * ε) / r < Local.Triangle.Bε.lhs (Q i) v p_ ε
+    -- Helper facts
+    have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
+    have hsu_ge : su.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le su _
+    -- Denominator positivity (su.norm ≥ ‖·‖ ≥ 0, and √2*ε + 3κ > 0)
+    have hden_pos : 0 < (su.norm (p_.rotM₂ℚ (Q_ i)) + √2 * ε + 3 * κ) *
+        (su.norm (p_.rotM₂ℚ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ) := by
+      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚ (Q_ i))) (UpperSqrt_norm_le su _)
+      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚ (Q_ i - v_))) (UpperSqrt_norm_le su _)
+      have h_sε : 0 < √2 * ε := mul_pos (Real.sqrt_pos.mpr (by norm_num : (0:ℝ) < 2)) hε
+      apply mul_pos <;> linarith
+    -- Extract positivity of Bεℚ numerator
+    have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+        2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+      have hδ_pos : 0 < δ := by
+        have := hδ 0
+        linarith [le_trans (norm_nonneg _)
+          (UpperSqrt_norm_le su (p_.rotR (p_.rotM₁ℚ (P_ 0)) - p_.rotM₂ℚ (Q_ 0)))]
+      have h0 : 0 < (δ + √5 * ε) / r :=
+        div_pos (by nlinarith [Real.sqrt_pos.mpr (show (0:ℝ) < 5 by norm_num)]) hr
+      exact (div_pos_iff_of_pos_right hden_pos).mp (h0.trans hbe)
+    -- su.norm ≥ ‖·‖ means numBεℚ ≤ numAℚ (subtracted term is bigger with su.norm)
+    have hAℚ_num_pos : 0 < ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ -
+        2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
+      show 0 < ⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+          2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)
+      have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
+          2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+        apply mul_le_mul_of_nonneg_right
+        · exact mul_le_mul_of_nonneg_left (by linarith [hsu_ge]) (by linarith)
+        · positivity
+      linarith [hBεℚ_num_pos]
+    -- From inner_product_bound_10kappa: |innerA - innerAℚ| ≤ 10κ
+    have hQv_norm : ‖Q i - v‖ ≤ 2 := calc
+      ‖Q i - v‖ ≤ ‖Q i‖ + ‖v‖ := norm_sub_le _ _
+      _ ≤ 1 + 1 := add_le_add (hQnorm i) hvnorm
+      _ = 2 := by ring
+    have hQv_approx : ‖(Q i - v) - (Q_ i - v_)‖ ≤ 2 * κ := calc
+      ‖(Q i - v) - (Q_ i - v_)‖ = ‖(Q i - Q_ i) - (v - v_)‖ := by congr 1; abel
+      _ ≤ ‖Q i - Q_ i‖ + ‖v - v_‖ := norm_sub_le _ _
+      _ ≤ κ + κ := add_le_add (hQapprox i) hvapprox
+      _ = 2 * κ := by ring
+    have h_inner_10 : |⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - v)⟫ -
+        ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫| ≤ 10 * κ :=
+      inner_product_bound_10kappa (θ := θ₂) (φ := φ₂) (hQnorm i) hQv_norm (hQapprox i) hQv_approx
+    have h_norm_QR : ‖Q i - v‖ ≤ ‖Q_ i - v_‖ + 2 * κ :=
+      calc ‖Q i - v‖
+        _ ≤ ‖Q_ i - v_‖ + ‖(Q i - v) - (Q_ i - v_)‖ := norm_le_insert' _ _
+        _ ≤ ‖Q_ i - v_‖ + 2 * κ := by linarith [hQv_approx]
+    have hA_nonneg : 0 ≤ ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - v)⟫ -
+        2 * ε * ‖Q i - v‖ * (√2 + ε) := by
+      have h_inner_le : ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ ≤
+          ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - v)⟫ := by
+        rw [abs_le] at h_inner_10; linarith [h_inner_10.1]
+      have h_eps_term : 2 * ε * ‖Q i - v‖ * (√2 + ε) ≤
+          2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
+        apply mul_le_mul_of_nonneg_right
+        · exact mul_le_mul_of_nonneg_left h_norm_QR (by linarith)
+        · positivity
+      linarith [hAℚ_num_pos]
+    -- Apply bounds_kappa4 (note: P Q P_ Q_ θ φ are explicit in bounds_kappa4)
+    have hbk4 : bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su ≤
+        bounds_kappa4_A (Q i) v θ₂ φ₂ ε :=
+      bounds_kappa4 (Q i) v (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hε su hA_nonneg
+    -- Bεℚ.lhs ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ in numerator, denominators def. equal)
+    have hBεℚ_le : Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε su ≤
+        bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su := by
+      -- Express both sides using p_.rotM₂ℚ (which is def. equal to rotMℚ ↑θ₂ ↑φ₂)
+      show (⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+            2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε)) /
+          ((su.norm (p_.rotM₂ℚ (Q_ i)) + √2 * ε + 3 * κ) *
+            (su.norm (p_.rotM₂ℚ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ)) ≤
+          (⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+            2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)) /
+          ((su.norm (p_.rotM₂ℚ (Q_ i)) + √2 * ε + 3 * κ) *
+            (su.norm (p_.rotM₂ℚ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
+      apply div_le_div_of_nonneg_right _ (le_of_lt hden_pos)
+      have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
+          2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+        apply mul_le_mul_of_nonneg_right
+        · exact mul_le_mul_of_nonneg_left (by linarith [hsu_ge]) (by linarith)
+        · positivity
+      linarith [h_sub_le]
+    -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
+    have hA_eq : bounds_kappa4_A (Q i) v θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) v p_ ε := rfl
+    -- Combine
+    calc (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε su := hbe
+      _ ≤ bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su := hBεℚ_le
+      _ ≤ bounds_kappa4_A (Q i) v θ₂ φ₂ ε := hbk4
+      _ = Local.Triangle.Bε.lhs (Q i) v p_ ε := hA_eq
+  -- Apply local_theorem
+  exact Local.local_theorem P Q cong_tri poly.vertices poly.nonempty hP hQ
+    poly.radius_eq_one p_ ε δ r hε hr hr₁' hδ' ae₁' ae₂' span₁' span₂' be'

--- a/blueprint/src/chapters/bounding.tex
+++ b/blueprint/src/chapters/bounding.tex
@@ -1,9 +1,9 @@
 \chapter{Bounding Rotations}
 
 \begin{lemma} \label{lem:RaRalpha}
-\lean{Bounding.Rx_norm_one,Bounding.Ry_norm_one,Bounding.Rz_norm_one,Bounding.rotR_norm_one,Bounding.rotM_norm_one}
+\lean{Bounding.Rx_norm_one,Bounding.Ry_norm_one,Bounding.Rz_norm_one,Bounding.rotR_norm_one,Bounding.rotM_norm_one,Bounding.rotR'_norm_one,Bounding.rotMθ_norm_le_one,Bounding.rotMφ_norm_le_one}
 \leanok
-For any $\alpha, \theta,\varphi \in \R$ and $a \in \{x,y,z\}$ one has $\| R(\alpha)\| = \| R_a(\alpha)\| =\| M(\theta, \phi)\| = 1$.
+For any $\alpha, \theta,\varphi \in \R$ and $a \in \{x,y,z\}$ one has $\| R(\alpha)\| = \| R_a(\alpha)\| = \| R'(\alpha) \| =\| M(\theta, \phi)\| = 1$ and $\| M^\theta(\theta,\varphi)\|, \| M^\phi(\theta,\varphi)\| \leq 1$.
 \end{lemma}
 \begin{proof}
 \leanok

--- a/blueprint/src/chapters/rational.tex
+++ b/blueprint/src/chapters/rational.tex
@@ -93,7 +93,10 @@ RationalApprox.Mθ_difference_norm_bounded,
 RationalApprox.Mφ_difference_norm_bounded,
 RationalApprox.X_difference_norm_bounded,
 RationalApprox.Rℚ_norm_bounded,
-RationalApprox.Mℚ_norm_bounded }
+RationalApprox.Mℚ_norm_bounded,
+RationalApprox.R'ℚ_norm_bounded,
+RationalApprox.Mθℚ_norm_bounded,
+RationalApprox.Mφℚ_norm_bounded }
     Let $\alpha,\theta,\phi\in [-4,4]$. Then it holds that
     \begin{align*}
         \|R(\alpha)-R_{\Q}(\alpha)\|, \|R'(\alpha)-R_{\Q}'(\alpha)\|,\|X(\theta,\phi)-X_{\Q}(\theta, \phi)\|, \|M(\theta, \phi)-M_{\Q}(\theta, \phi)\|, \\
@@ -101,11 +104,8 @@ RationalApprox.Mℚ_norm_bounded }
         \|M^\phi(\theta,\phi) - M_{\Q}^\phi(\theta,\phi)\|\leq \kappa.
     \end{align*}
     Moreover,
-    %% \[
-    %%     \|R_{\Q}(\alpha)\|, \|R'_{\Q}(\alpha)\|, \|X_{\Q}(\theta, \phi)\|, \|M_{\Q}(\theta, \phi)\|, \|M_{\Q}^{\theta}(\theta,\varphi)\|, \|M_{\Q}^{\phi}(\theta,\varphi)\| \leq 1+\kappa
-    %% \]
     \[
-        \|R_{\Q}(\alpha)\|,  \|M_{\Q}(\theta, \phi)\| \leq 1+\kappa
+        \|R_{\Q}(\alpha)\|, \|R'_{\Q}(\alpha)\|, \|M_{\Q}(\theta, \phi)\|, \|M_{\Q}^{\theta}(\theta,\varphi)\|, \|M_{\Q}^{\phi}(\theta,\varphi)\| \leq 1+\kappa
     \]
 \end{corollary}
 
@@ -113,11 +113,7 @@ RationalApprox.Mℚ_norm_bounded }
 \leanok
 \uses{lem:dist_le_kappa,lem:RaRalpha}
     The first statement is a direct application of \cref{lem:dist_le_kappa} and the second statement follows immediately after using \cref{lem:RaRalpha} and the triangle inequality.
-
-Note: the original paper's Corollary 41 makes a stronger claim that the norms of the derivatives of the rotation matrices are
-bounded by $1 + \kappa$ as well. This doesn't directly follow from \cref{lem:RaRalpha} as currently
-stated. If we need these other bounds, we should strengthen \cref{lem:RaRalpha} to
-assert that the derivatives' operator norms are at most 1.
+    The derivative norm bounds follow similarly, using that the operator norms of $R'$, $M^\theta$, and $M^\phi$ are at most~$1$.
 \end{proof}
 
 \begin{lemma} \label{lem:A1AnB1Bn}
@@ -156,6 +152,7 @@ RationalApprox.bounds_kappa_RMφ
     \end{align}
 \end{lemma}
 \begin{proof}
+\leanok
 \uses{lem:A1AnB1Bn,corr:kappa1kappa}
 See \cite{polyhedron.without.rupert}, Lemma 44.
 \end{proof}
@@ -178,6 +175,7 @@ See \cite{polyhedron.without.rupert}, Lemma 44.
 \end{theorem}
 
 \begin{proof}
+\leanok
 \uses{thm:global,lem:boundskappa}
 \end{proof}
 
@@ -222,6 +220,7 @@ RationalApprox.bounds_kappa3_MQ
     \end{align}
 \end{lemma}
 \begin{proof}
+\leanok
 See \cite{polyhedron.without.rupert}, Lemma 49.
 \uses{lem:A1AnB1Bn}
 \end{proof}
@@ -230,31 +229,35 @@ See \cite{polyhedron.without.rupert}, Lemma 49.
 \begin{corollary} \label{corr:deltakappa}
 \leanok
 \lean{RationalApprox.delta_kappa}
-    In the setting of \cref{lem:boundskappa3}, let additionally $\thetab, \phib \in \R \cap [-4,4]$ and set $\overline{M} = M(\thetab, \phib)$, $\overline{M}_{\Q} = M_{\Q}(\thetab, \phib)$. Then
+    Let $P, Q \in \R^3$ with $\|P\|, \|Q\| \leq 1$ and $\widetilde{Q}$ a $\kappa$-rational approximation of $Q$.
+    Let $\alpha, \theta, \phi, \thetab, \phib \in [-4,4]$ and set $M = M(\theta, \phi)$, $M_{\Q} = M_{\Q}(\theta, \phi)$, $\overline{M} = M(\thetab, \phib)$, $\overline{M}_{\Q} = M_{\Q}(\thetab, \phib)$. Then
      \[
-|\|R(\alpha) M P - \overline{M} Q\|- \| R_{\Q}(\alpha) M_{\Q} \widetilde{P} - \overline{M}_{\Q} \widetilde{Q}\| | \leq 6 \kappa
+|\|R(\alpha) M P - \overline{M} Q\|- \| R_{\Q}(\alpha) M_{\Q} P - \overline{M}_{\Q} \widetilde{Q}\| | \leq 6 \kappa
      \]
+    Note that the rational side uses $P$ directly (not a rational approximation $\widetilde{P}$).
 \end{corollary}
 \begin{proof}
+\leanok
 See \cite{polyhedron.without.rupert}, Corollary 50.
-\uses{lem:boundskappa3}
+\uses{corr:kappa1kappa,lem:RaRalpha}
 \end{proof}
 
 
 \begin{corollary} \label{lem:boundskappa4}
 \leanok
 \lean{RationalApprox.bounds_kappa4}
-    In the setting of \cref{lem:boundskappa3}, let $\sqrt[+]{x}$ be an upper-$\Q$-square-root function and set $\|x\|_{+} \coloneqq \sqrt[+]{\|x\|^2}$. Set
+    In the setting of \cref{lem:boundskappa3}, let $\sqrt[+]{x}$ be an upper square-root function, i.e., $\sqrt{x} \leq \sqrt[+]{x}$ for all real $x \geq 0$ with rational output on rational input. Set $\|x\|_{+} \coloneqq \sqrt[+]{\|x\|^2}$. Set
     \[
         A =  \frac{\langle M P, M(P-Q)\rangle - 2 \epsilon  \|P-Q\| \cdot  (\sqrt{2}+\varepsilon)}{ \big(\| M P\|+\sqrt{2} \varepsilon \big) \cdot \big(\|M(P-Q)\|+2 \sqrt{2} \varepsilon\big)}
     \]
     as well as
     \[
-        A_{\Q} =         \frac{\langle M_{\Q} \widetilde{P}, M_{\Q} (\widetilde{P}-\widetilde{Q})\rangle - 10\kappa - 2 \epsilon ( \|\widetilde{P}-\widetilde{Q}\|_{+} + 2 \kappa ) \cdot  (\sqrt{2}+\varepsilon)}{ \big(\| M_{\Q} \widetilde{P}\|_{+}+\sqrt{2} \varepsilon + 3\kappa \big) \cdot \big(\|M_{\Q}(\widetilde{P}-\widetilde{Q})\|_{+}+2 \sqrt{2} \varepsilon + 6\kappa\big)}.
+        A_{\Q} =         \frac{\langle M_{\Q} \widetilde{P}, M_{\Q} (\widetilde{P}-\widetilde{Q})\rangle - 10\kappa - 2 \epsilon ( \|\widetilde{P}-\widetilde{Q}\| + 2 \kappa ) \cdot  (\sqrt{2}+\varepsilon)}{ \big(\| M_{\Q} \widetilde{P}\|_{+}+\sqrt{2} \varepsilon + 3\kappa \big) \cdot \big(\|M_{\Q}(\widetilde{P}-\widetilde{Q})\|_{+}+2 \sqrt{2} \varepsilon + 6\kappa\big)}.
     \]
-    Then it holds that $A \geq A_{\Q}$.
+    Assume that $A \geq 0$. Then it holds that $A \geq A_{\Q}$.
 \end{corollary}
 \begin{proof}
+\leanok
 See \cite{polyhedron.without.rupert}, Corollary 51.
 \uses{lem:boundskappa3}
 \end{proof}
@@ -273,14 +276,14 @@ See \cite{polyhedron.without.rupert}, Corollary 51.
         (-1)^{\sigma_Q} \langle \Xiib , \widetilde{Q}_i\rangle>\sqrt{2}\varepsilon + 3\kappa, \tag{A$^{\Q}_\epsilon$}
     \]
     for all $i=1,2,3$.
-    Moreover, assume that $\widetilde{P}_1,\widetilde{P}_2,\widetilde{P}_3$ are $\epsilon$-$\kappa$-spanning for $(\thetab_1,\phib_1)$ and that $\widetilde{Q}_1,\widetilde{Q}_2,\widetilde{Q}_3$ are $\epsilon$-$\kappa$-spanning for $(\thetab_2,\phib_2)$. Let $\sqrt[+]{x}$ and $\sqrt[-]{x}$ be upper- and lower-$\Q$-square-root functions, then set $\|Z\|_{+} \coloneqq \sqrt[+]{\|Z\|^2}$ and $\|Z\|_{-} \coloneqq \sqrt[-]{\|Z\|^2}$ for $Z \in \Q^n$.
+    Moreover, assume that $\widetilde{P}_1,\widetilde{P}_2,\widetilde{P}_3$ are $\epsilon$-$\kappa$-spanning for $(\thetab_1,\phib_1)$ and that $\widetilde{Q}_1,\widetilde{Q}_2,\widetilde{Q}_3$ are $\epsilon$-$\kappa$-spanning for $(\thetab_2,\phib_2)$. Let $\sqrt[+]{x}$ and $\sqrt[-]{x}$ be upper- and lower-square-root functions (bounding $\sqrt{x}$ from above/below for all real $x \geq 0$, with rational output on rational input), then set $\|Z\|_{+} \coloneqq \sqrt[+]{\|Z\|^2}$ and $\|Z\|_{-} \coloneqq \sqrt[-]{\|Z\|^2}$ for $Z \in \R^n$.
     Finally, assume that for all $i = 1,2,3$ and any $\widetilde{Q}_j \in \widetilde{\PPP} \setminus \widetilde{Q}_i$ it holds that
     \[
         \frac{\langle \Miib \widetilde{Q}_i,\Miib (\widetilde{Q}_i-\widetilde{Q}_j)\rangle - 10\kappa - 2 \epsilon ( \|\widetilde{Q}_i-\widetilde{Q}_j\|_{+} + 2 \kappa ) \cdot  (\sqrt{2}+\varepsilon)}{ \big(\|\Miib \widetilde{Q}_i\|_{+}+\sqrt{2} \varepsilon + 3\kappa \big) \cdot \big(\|\Miib(\widetilde{Q}_i-\widetilde{Q}_j)\|_{+}+2 \sqrt{2} \varepsilon + 6\kappa\big)} > \frac{\sqrt{5} \epsilon + \delta}{r}, \tag{B$^{\Q}_\epsilon$}
     \]
     for some $r >0$ such that $\min_{i=1,2,3}\| \Miib \widetilde{Q}_i \|_{-} > r + \sqrt{2} \epsilon + 3\kappa$ and for some $\delta \in \R$ with
     \[
-        \delta = \max_{i=1,2,3}\left\|R_{\Q}(\alphab) \Mib \widetilde{P}_i-\Miib \widetilde{Q}_i\right\|_{+}/2 + 3\kappa.
+        \delta \geq \max_{i=1,2,3}\left\|R_{\Q}(\alphab) \Mib \widetilde{P}_i-\Miib \widetilde{Q}_i\right\|_{+}/2 + 3\kappa.
     \]
     Then there exists no solution to Rupert's problem $R(\alpha) M(\theta_1,\phi_1)\PPP \subset  M(\theta_2,\phi_2)\PPP^\circ$ with
     \[
@@ -289,5 +292,6 @@ See \cite{polyhedron.without.rupert}, Corollary 51.
 \end{theorem}
 
 \begin{proof}
+\leanok
 \uses{thm:local,lem:boundskappa3,lem:boundskappa4,corr:deltakappa,lem:ekspanningespanning},
 \end{proof}


### PR DESCRIPTION
## Summary
Prove the two rational approximation bridge theorems that reduce the real-valued local and global theorems to their rational counterparts.

- **`rational_local`** ([SY25] Theorem 48): Bridge from rational preconditions (Aεℚ, Bεℚ, κSpanning, BoundRℚ, BoundDeltaℚ) to the real `local_theorem`, using κ-bounds from `BoundsKappa`, `BoundsKappa3`, `BoundsKappa4`, `DeltaKappa`, and `EpsKapSpanning`
- **`rational_global`** ([SY25] Theorem 43): Bridge from rational preconditions (Gℚ > maxHℚ with rational inner products) to the real `global_theorem`, using κ-bounds from `BoundsKappa` and `BoundsKappa3`
- Expose selected `BoundsKappa4` helper lemmas needed by the `RationalLocal` proof

**Definition fixes:**
- `Bεℚ` (RationalLocal): Use `Bεℚ.lhs` (rationalized) instead of `Bε.lhs`; add `su : UpperSqrt` parameter
- `BoundDeltaℚ` (RationalLocal): Add `+ 3 * κ` slack to account for κ-approximation error through composed maps
- `Gℚ` (RationalGlobal): Adjust slack/sign terms so the bridge inequality direction matches the proof obligations (Gℚ ≤ G)

**Blueprint updates:**
- Mark proofs as `\leanok`: `rational_global` (Thm 43), `rational_local` (Thm 48), `bounds_kappa` (Lemma 44), `bounds_kappa3` (Lemma 49), `delta_kappa` (Cor 50), `bounds_kappa4` (Cor 51)
- Add R', Mθ, Mφ norm bounds to `lem:RaRalpha` and `corr:kappa1kappa`
- Fix `delta_kappa` statement: uses P directly (not P̃)
- Fix `bounds_kappa4`: add A≥0 assumption, use ‖P̃-Q̃‖ not ‖P̃-Q̃‖₊
- Fix `rational_local`: δ≥ not δ=, clarify sqrt function definitions
- Remove outdated TODO about derivative norm bounds

Depends on #25.

## Test plan
- [x] `lake build` passes
- [x] No sorry warnings in `RationalLocal.lean` or `RationalGlobal.lean`
- [x] Only standard axioms (`propext`, `Classical.choice`, `Quot.sound`)