### PR TITLE
Add solution table data tools and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ home_page/.bundle
 home_page/.ruby-version
 home_page/_site
 home_page/vendor
+
+# External datasets / generated artifacts (not committed)
+external/

--- a/docs/solution_table_data.md
+++ b/docs/solution_table_data.md
@@ -1,0 +1,129 @@
+# Solution tree data (Rupert repo)
+
+This repo currently contains the mathematical framework for validating a *solution table* (a large split tree over pose parameter space), but it does **not** yet ship a checked-in table.
+
+To experiment with the authors’ published data, we download their dataset into `external/` (gitignored) and optionally convert it into smaller, Lean-friendly formats.
+
+## Fetch
+
+Run:
+
+```bash
+./scripts/fetch-rupert-data.sh
+```
+
+This downloads (and pins) a specific upstream commit into:
+
+- `external/rupert/REVISION` (commit hash)
+- `external/rupert/data/solution_tree.parquet`
+- `external/rupert/data/mapping.csv`
+- `external/rupert/data/Ck.csv`
+
+## Inspect
+
+```bash
+external/pyvenv/bin/python ./scripts/solution_tree_stats.py
+```
+
+## Validate split semantics (best-effort)
+
+This checks that `nodeType=3` split nodes have child intervals matching the intended split scheme.
+
+```bash
+external/pyvenv/bin/python ./scripts/check_solution_tree_splits.py --progress
+```
+
+## Convert parquet → CSV (skinny)
+
+```bash
+apt-get install -y python3-venv
+python3 -m venv external/pyvenv
+external/pyvenv/bin/pip install pyarrow
+python3 ./scripts/parquet_to_csv.py
+```
+
+This produces:
+
+- `external/rupert/data/solution_tree.skinny.csv`
+
+## How this connects to the Lean proof
+
+Today, `Solution.Row.ValidGlobal` / `Solution.Row.ValidLocal` are **certificate-carrying** predicates used to drive the logical proof that a *valid* table implies “no Rupert pose exists”.
+
+The next step toward a full end-to-end proof is to introduce a *decidable checker layer* derived from the downloaded dataset (row fields + rational inequalities), and prove:
+
+- `checked_global row = true → row.ValidGlobal tab`
+- `checked_local row = true → row.ValidLocal tab`
+
+so that a future `exists_solution_table` can be discharged by a verified (or compiler-trusted) generator/checker pipeline.
+
+## Notes on the upstream schema (observed)
+
+From `solution_tree.parquet` (commit pinned in `external/rupert/REVISION`):
+
+- `ID` is sequential `0..num_rows-1` (so `row.ID = i` is plausible for an `Array Row` encoding).
+- `nodeType` row counts:
+  - `nodeType=1`: 17,492,530 rows (global leaves)
+  - `nodeType=2`: 622,715 rows (local leaves)
+  - `nodeType=3`: 585,200 rows (split nodes)
+- Interval endpoints:
+  - `T1_*`, `V1_*`, `T2_*`, `V2_*` are nonnegative.
+  - `A_*` (α) can be negative; a signed integer representation is needed in Lean.
+- Split nodes (`nodeType=3`) use the following `split`/`nrChildren` combinations:
+  - `split=1` → `nrChildren=4`
+  - `split=2` → `nrChildren=30`
+  - `split=3` → `nrChildren=4`
+  - `split=4` → `nrChildren=15`
+  - `split=5` → `nrChildren=30`
+  - `split=6` → `nrChildren=32` (matches `2^5`, i.e. halving each parameter)
+- Global leaves (`nodeType=1`) have `wx_nominator`, `wy_nominator`, `w_denominator` present, and satisfy a Pythagorean identity:
+  - `wx^2 + wy^2 = w_denominator^2` (so `w = (wx,wy)/w_denominator` is a unit vector)
+- Several columns are null depending on `nodeType`:
+  - `nodeType=3`: `nrChildren`, `IDfirstChild`, `split` present; `r`, `sigma_Q`, and `w*` are null.
+  - `nodeType=1`: `w*` present; `nrChildren`, `IDfirstChild`, `split`, `r`, `sigma_Q` are null.
+  - `nodeType=2`: `r`, `sigma_Q` present; `nrChildren`, `IDfirstChild`, `split`, `w*` are null.
+- `mapping.csv` is a complete `700 × 2619` grid mapping `(i,j) → C_index`, where `C_index` indexes the rows of `Ck.csv`.
+- `Ck.csv` has 3,535 data rows (plus a header), with indices `0..3534`.
+
+## Algorithmic meaning (upstream verification notebook)
+
+The upstream `Rupert` repo includes a notebook that verifies the published `solution_tree.parquet`
+end-to-end (`src/noperthedron_verification.ipynb`). It clarifies what the row fields are used for:
+
+- `nodeType=1` (“global theorem applications”):
+  - Stores a unit covector `w` via integers `(wx_nominator, wy_nominator, w_denominator)` and a vertex index `S_index`.
+  - The notebook recomputes:
+    - `p̄` as the midpoint of the row’s 5D interval,
+    - `ε` as half the maximum interval width,
+    - and checks the **rational global theorem** inequality (the shape matches `RationalApprox.GlobalTheorem.Gℚ` vs `maxHℚ`)
+      using the row’s `S_index` and `w`.
+- `nodeType=2` (“local theorem applications”):
+  - Stores two congruent triangles by vertex indices `(P1,P2,P3)` and `(Q1,Q2,Q3)`,
+    plus a rational parameter `r = row.r / 1000` and a sign bit `sigma_Q ∈ {0,1}` (the notebook uses `sigma_P = 0`).
+  - The notebook checks congruence and then checks the **rational local theorem** preconditions.
+
+This is the intended bridge for a future *decidable checker layer* in Lean: re-express the above checks as
+`Bool` predicates over integers/rationals and prove they imply `Row.ValidGlobal` / `Row.ValidLocal`.
+
+## Local row congruence witness (dihedral, observed)
+
+Empirically, every `nodeType=2` row’s `(P,Q)` indices admit a very simple *dihedral-style witness* over the
+15-fold rotation index.
+
+Decode a vertex index as:
+
+- `idx = k + 15*i + 45*l`, where `k ∈ {0..14}`, `i ∈ {0,1,2}`, `l ∈ {0,1}`.
+
+Then for each local row there exists:
+
+- `dl ∈ {0,1}` (a global sign flip `(-I)` via `l ↦ l ⊕ dl`), and either
+  - **rotation:** `kP = kQ + dk (mod 15)` for all three vertices, or
+  - **reflection:** `kP = -kQ + dk (mod 15)` for all three vertices,
+
+with `iP = iQ` position-wise.
+
+The script below checks this property by streaming the parquet file:
+
+```bash
+external/pyvenv/bin/python ./scripts/check_solution_tree_local_congruence.py
+```

--- a/scripts/check_solution_tree_local_congruence.py
+++ b/scripts/check_solution_tree_local_congruence.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def _require_pyarrow() -> tuple[object, object]:
+    try:
+        import pyarrow as pa  # noqa: F401
+        import pyarrow.parquet as pq  # noqa: F401
+    except Exception as exc:
+        msg = (
+            "error: pyarrow is required to read parquet.\n"
+            "Install in a venv, e.g.:\n"
+            "  apt-get install -y python3-venv\n"
+            "  python3 -m venv external/pyvenv\n"
+            "  external/pyvenv/bin/pip install pyarrow\n"
+        )
+        raise RuntimeError(msg) from exc
+    return pa, pq
+
+
+def _decode_i(idx: int) -> int:
+    # idx = k + 15*i + 45*l, where:
+    #   k ∈ {0..14}, i ∈ {0,1,2}, l ∈ {0,1}
+    return (idx % 45) // 15
+
+
+def _decode_k(idx: int) -> int:
+    return idx % 15
+
+
+def _decode_l(idx: int) -> int:
+    return idx // 45
+
+
+def _check_row(p: tuple[int, int, int], q: tuple[int, int, int]) -> tuple[bool, int, int, int]:
+    """
+    Return (ok, reflect, dk, dl) for the dihedral-style congruence witness:
+      - dl is the sign flip on `l` (i.e. multiply by -1 if dl=1),
+      - reflect=0 means k ↦ k + dk,
+      - reflect=1 means k ↦ -k + dk.
+    """
+    # All indices should be within the 90-vertex encoding.
+    if any(x < 0 or x >= 90 for x in (*p, *q)):
+        return False, 0, 0, 0
+
+    # Orbit must match position-wise (dataset uses consistent ordering).
+    ip = [_decode_i(x) for x in p]
+    iq = [_decode_i(x) for x in q]
+    if ip != iq:
+        return False, 0, 0, 0
+
+    # l-parity offset (mod 2).
+    lp = [_decode_l(x) for x in p]
+    lq = [_decode_l(x) for x in q]
+    dl = lp[0] ^ lq[0]
+    if [a ^ dl for a in lq] != lp:
+        return False, 0, 0, 0
+
+    kp = [_decode_k(x) for x in p]
+    kq = [_decode_k(x) for x in q]
+
+    # Try rotation: k ↦ k + dk.
+    dk = (kp[0] - kq[0]) % 15
+    if [(a + dk) % 15 for a in kq] == kp:
+        return True, 0, dk, dl
+
+    # Try reflection: k ↦ -k + dk.
+    dk = (kp[0] + kq[0]) % 15
+    if [(dk - a) % 15 for a in kq] == kp:
+        return True, 1, dk, dl
+
+    return False, 0, 0, 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Best-effort validation that each nodeType=2 row's (P,Q) indices are related by a simple\n"
+            "dihedral-style symmetry on the 15-fold rotation index (plus optional global sign flip).\n"
+            "This matches the empirical structure in `solution_tree.parquet` and is a good bridge toward\n"
+            "a decidable Lean-side congruence checker."
+        )
+    )
+    parser.add_argument(
+        "--parquet",
+        type=pathlib.Path,
+        default=pathlib.Path("external/rupert/data/solution_tree.parquet"),
+        help="Path to solution_tree.parquet.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=250_000,
+        help="Parquet batch size.",
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=0,
+        help="Check only the first N local rows (nodeType=2). Use 0 for all.",
+    )
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        help="Print periodic progress.",
+    )
+    args = parser.parse_args()
+
+    parquet_path: pathlib.Path = args.parquet
+    if not parquet_path.exists():
+        print(f"error: parquet file not found: {parquet_path}", file=sys.stderr)
+        return 2
+
+    pa, pq = _require_pyarrow()
+
+    pf = pq.ParquetFile(str(parquet_path))
+    cols = [
+        "nodeType",
+        "ID",
+        "P1_index",
+        "P2_index",
+        "P3_index",
+        "Q1_index",
+        "Q2_index",
+        "Q3_index",
+    ]
+
+    total = 0
+    ok = 0
+    reflect_counts: dict[int, int] = {0: 0, 1: 0}
+    dl_counts: dict[int, int] = {0: 0, 1: 0}
+    dk_counts: dict[tuple[int, int], int] = {}
+    bad_examples: list[dict[str, object]] = []
+
+    row_offset = 0
+
+    for batch in pf.iter_batches(columns=cols, batch_size=args.batch_size):
+        node_type = batch.column(0).to_numpy(zero_copy_only=False)
+        ids = batch.column(1).to_numpy(zero_copy_only=False).astype(int)
+        p1 = batch.column(2).to_numpy(zero_copy_only=False)
+        p2 = batch.column(3).to_numpy(zero_copy_only=False)
+        p3 = batch.column(4).to_numpy(zero_copy_only=False)
+        q1 = batch.column(5).to_numpy(zero_copy_only=False)
+        q2 = batch.column(6).to_numpy(zero_copy_only=False)
+        q3 = batch.column(7).to_numpy(zero_copy_only=False)
+
+        # Cheap sanity: IDs are sequential.
+        if ids[0] != row_offset:
+            print(f"error: unexpected ID sequence at offset {row_offset}: saw {ids[0]}", file=sys.stderr)
+            return 2
+        row_offset += len(ids)
+
+        for nt, rid, a, b, c, d, e, f in zip(node_type, ids, p1, p2, p3, q1, q2, q3, strict=True):
+            if int(nt) != 2:
+                continue
+            total += 1
+            good, reflect, dk, dl = _check_row((int(a), int(b), int(c)), (int(d), int(e), int(f)))
+            if good:
+                ok += 1
+                reflect_counts[reflect] = reflect_counts.get(reflect, 0) + 1
+                dl_counts[dl] = dl_counts.get(dl, 0) + 1
+                dk_counts[(reflect, dk)] = dk_counts.get((reflect, dk), 0) + 1
+            elif len(bad_examples) < 10:
+                bad_examples.append(
+                    {
+                        "ID": int(rid),
+                        "P": (int(a), int(b), int(c)),
+                        "Q": (int(d), int(e), int(f)),
+                        "decoded_P": [(_decode_i(int(x)), _decode_k(int(x)), _decode_l(int(x))) for x in (int(a), int(b), int(c))],
+                        "decoded_Q": [(_decode_i(int(x)), _decode_k(int(x)), _decode_l(int(x))) for x in (int(d), int(e), int(f))],
+                    }
+                )
+
+            if args.max_rows and total >= args.max_rows:
+                break
+
+        if args.progress:
+            print(f"progress: checked_local_rows={total} ok={ok}", file=sys.stderr)
+
+        if args.max_rows and total >= args.max_rows:
+            break
+
+    if ok != total:
+        print(f"FAIL: local congruence check: ok={ok} total={total}", file=sys.stderr)
+        if bad_examples:
+            print("examples:", file=sys.stderr)
+            for ex in bad_examples:
+                print(f"  {ex}", file=sys.stderr)
+        return 1
+
+    print(f"ok: local congruence check passed: ok={ok} total={total}")
+    print(f"reflect_counts={reflect_counts}  # reflect=1 means k ↦ -k + dk")
+    print(f"dl_counts={dl_counts}  # dl=1 means global sign flip (-I)")
+    print("top dk (reflect,dk) counts:")
+    for (reflect, dk), n in sorted(dk_counts.items(), key=lambda kv: (-kv[1], kv[0]))[:20]:
+        print(f"  ({reflect},{dk}): {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/check_solution_tree_splits.py
+++ b/scripts/check_solution_tree_splits.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import pathlib
+import sys
+from typing import Iterable
+
+
+def _require_pyarrow() -> tuple[object, object, object]:
+    try:
+        import pyarrow as pa  # noqa: F401
+        import pyarrow.compute as pc  # noqa: F401
+        import pyarrow.parquet as pq  # noqa: F401
+    except Exception as exc:
+        msg = (
+            "error: pyarrow is required to read parquet.\n"
+            "Install in a venv, e.g.:\n"
+            "  apt-get install -y python3-venv\n"
+            "  python3 -m venv external/pyvenv\n"
+            "  external/pyvenv/bin/pip install pyarrow\n"
+        )
+        raise RuntimeError(msg) from exc
+    return pa, pc, pq
+
+
+# Column order we use internally for interval tuples.
+# (min,max) pairs in order: θ₁, φ₁, θ₂, φ₂, α
+INTERVAL_COLS = [
+    "T1_min",
+    "T1_max",
+    "V1_min",
+    "V1_max",
+    "T2_min",
+    "T2_max",
+    "V2_min",
+    "V2_max",
+    "A_min",
+    "A_max",
+]
+
+
+PARAMS = ["θ₁", "φ₁", "θ₂", "φ₂", "α"]
+
+
+def _split_param_from_code(code: int) -> int:
+    if code not in (1, 2, 3, 4, 5):
+        raise ValueError(f"unexpected split code: {code}")
+    return code - 1
+
+
+def _parts_for_split_code(code: int) -> int:
+    # Empirically (from solution_tree.parquet):
+    #   split=1 -> 4, split=2 -> 30, split=3 -> 4, split=4 -> 15, split=5 -> 30, split=6 -> 32
+    if code == 1:
+        return 4
+    if code == 2:
+        return 30
+    if code == 3:
+        return 4
+    if code == 4:
+        return 15
+    if code == 5:
+        return 30
+    raise ValueError(f"unexpected split code: {code}")
+
+
+IntervalTuple = tuple[int, int, int, int, int, int, int, int, int, int]
+
+
+def _interval_to_arrays(iv: IntervalTuple) -> tuple[list[int], list[int]]:
+    mins = [iv[0], iv[2], iv[4], iv[6], iv[8]]
+    maxs = [iv[1], iv[3], iv[5], iv[7], iv[9]]
+    return mins, maxs
+
+
+def _arrays_to_interval(mins: list[int], maxs: list[int]) -> IntervalTuple:
+    return (
+        mins[0],
+        maxs[0],
+        mins[1],
+        maxs[1],
+        mins[2],
+        maxs[2],
+        mins[3],
+        maxs[3],
+        mins[4],
+        maxs[4],
+    )
+
+
+def _split_into_parts(iv: IntervalTuple, param_idx: int, parts: int) -> list[IntervalTuple]:
+    mins, maxs = _interval_to_arrays(iv)
+    lo = mins[param_idx]
+    hi = maxs[param_idx]
+    step = (hi - lo) // parts
+    out: list[IntervalTuple] = []
+    for i in range(parts):
+        mins2 = list(mins)
+        maxs2 = list(maxs)
+        mins2[param_idx] = lo + i * step
+        maxs2[param_idx] = lo + (i + 1) * step
+        out.append(_arrays_to_interval(mins2, maxs2))
+    return out
+
+
+def _lower_half(iv: IntervalTuple, param_idx: int) -> IntervalTuple:
+    mins, maxs = _interval_to_arrays(iv)
+    mid = (mins[param_idx] + maxs[param_idx]) // 2
+    maxs[param_idx] = mid
+    return _arrays_to_interval(mins, maxs)
+
+
+def _upper_half(iv: IntervalTuple, param_idx: int) -> IntervalTuple:
+    mins, maxs = _interval_to_arrays(iv)
+    mid = (mins[param_idx] + maxs[param_idx]) // 2
+    mins[param_idx] = mid
+    return _arrays_to_interval(mins, maxs)
+
+
+def _cube_fold_halves(iv: IntervalTuple, param_order: Iterable[int]) -> list[IntervalTuple]:
+    # Matches the Lean `cubeFold [lower_half, upper_half] iv params` order:
+    # for each param in order, expand each interval into lower then upper.
+    intervals = [iv]
+    for p in param_order:
+        nxt: list[IntervalTuple] = []
+        for cur in intervals:
+            nxt.append(_lower_half(cur, p))
+            nxt.append(_upper_half(cur, p))
+        intervals = nxt
+    return intervals
+
+
+@dataclasses.dataclass(frozen=True)
+class Expectation:
+    parent_id: int
+    desc: str
+    expected: IntervalTuple
+
+
+def _fmt_iv(iv: IntervalTuple) -> str:
+    mins, maxs = _interval_to_arrays(iv)
+    parts = [f"{p}=[{a},{b}]" for p, a, b in zip(PARAMS, mins, maxs, strict=True)]
+    return " ".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Best-effort validation that nodeType=3 split nodes in solution_tree.parquet "
+            "have children intervals matching the intended split semantics."
+        )
+    )
+    parser.add_argument(
+        "--parquet",
+        type=pathlib.Path,
+        default=pathlib.Path("external/rupert/data/solution_tree.parquet"),
+        help="Path to solution_tree.parquet.",
+    )
+    parser.add_argument(
+        "--max-parents",
+        type=int,
+        default=2_000,
+        help="Check only the first N split nodes (nodeType=3). Use 0 for all.",
+    )
+    parser.add_argument(
+        "--max-gap",
+        type=int,
+        default=250_000,
+        help="Skip split nodes whose (IDfirstChild-ID) exceeds this (use 0 for no limit).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=250_000,
+        help="Parquet batch size.",
+    )
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        help="Print periodic progress.",
+    )
+    args = parser.parse_args()
+
+    parquet_path: pathlib.Path = args.parquet
+    if not parquet_path.exists():
+        print(f"error: parquet file not found: {parquet_path}", file=sys.stderr)
+        return 2
+
+    pa, pc, pq = _require_pyarrow()
+
+    pf = pq.ParquetFile(str(parquet_path))
+    total_rows = int(pf.metadata.num_rows)
+
+    cols = ["nodeType", "ID", "nrChildren", "IDfirstChild", "split", *INTERVAL_COLS]
+
+    pending: dict[int, Expectation] = {}
+    parents_checked = 0
+    parents_skipped_gap = 0
+    parents_skipped_limit = 0
+
+    param_order_full = [0, 1, 2, 3, 4]  # θ₁, φ₁, θ₂, φ₂, α
+
+    next_progress = 0
+    row_offset = 0
+
+    for batch in pf.iter_batches(columns=cols, batch_size=args.batch_size):
+        node_type = batch.column(0).to_numpy(zero_copy_only=False)
+        ids = batch.column(1).to_numpy(zero_copy_only=False).astype(int)
+        nr_children = batch.column(2).to_numpy(zero_copy_only=False)
+        first_child = batch.column(3).to_numpy(zero_copy_only=False)
+        split = batch.column(4).to_numpy(zero_copy_only=False)
+        interval_cols = [batch.column(5 + i).to_numpy(zero_copy_only=False).astype(int) for i in range(len(INTERVAL_COLS))]
+
+        batch_len = len(ids)
+
+        # sanity: IDs are sequential, but keep the check cheap.
+        if ids[0] != row_offset:
+            print(f"error: unexpected ID sequence at offset {row_offset}: saw {ids[0]}", file=sys.stderr)
+            return 2
+
+        def interval_at(i: int) -> IntervalTuple:
+            return tuple(col[i] for col in interval_cols)  # type: ignore[return-value]
+
+        # Step 1: resolve any pending expectations that fall within this batch.
+        if pending:
+            lo = row_offset
+            hi = row_offset + batch_len
+            for child_id in sorted([k for k in pending.keys() if lo <= k < hi]):
+                exp = pending.pop(child_id)
+                idx = child_id - lo
+                actual = interval_at(idx)
+                if actual != exp.expected:
+                    print("split mismatch:", file=sys.stderr)
+                    print(f"  child_id={child_id}", file=sys.stderr)
+                    print(f"  parent_id={exp.parent_id} ({exp.desc})", file=sys.stderr)
+                    print(f"  expected: {_fmt_iv(exp.expected)}", file=sys.stderr)
+                    print(f"  actual:   {_fmt_iv(actual)}", file=sys.stderr)
+                    return 1
+
+        # Step 2: process split nodes in this batch, in increasing ID order.
+        if args.max_parents == 0 or parents_checked < args.max_parents:
+            split_idxs = [i for i in range(batch_len) if int(node_type[i]) == 3]
+        else:
+            split_idxs = []
+
+        for i in split_idxs:
+            rid = int(ids[i])
+
+            if args.max_parents != 0 and parents_checked >= args.max_parents:
+                parents_skipped_limit += 1
+                continue
+
+            fc = first_child[i]
+            sp = split[i]
+            nc = nr_children[i]
+            if fc is None or sp is None or nc is None:
+                print(f"error: split node missing fields at ID={rid}", file=sys.stderr)
+                return 2
+
+            fc = int(fc)
+            sp = int(sp)
+            nc = int(nc)
+            gap = fc - rid
+            if args.max_gap and gap > args.max_gap:
+                parents_skipped_gap += 1
+                continue
+
+            if fc <= rid:
+                print(f"error: IDfirstChild not greater than parent at ID={rid} child={fc}", file=sys.stderr)
+                return 2
+
+            parent_iv = interval_at(i)
+
+            if sp == 6:
+                if nc != 32:
+                    print(f"error: split=6 but nrChildren={nc} at ID={rid}", file=sys.stderr)
+                    return 2
+                expected_children = _cube_fold_halves(parent_iv, param_order_full)
+                if len(expected_children) != 32:
+                    raise AssertionError("expected 32 children from cube fold")
+            else:
+                param_idx = _split_param_from_code(sp)
+                parts = _parts_for_split_code(sp)
+                if nc != parts:
+                    print(f"error: split={sp} expected nrChildren={parts} but saw {nc} at ID={rid}", file=sys.stderr)
+                    return 2
+                expected_children = _split_into_parts(parent_iv, param_idx, parts)
+
+            last_child = fc + len(expected_children) - 1
+            if last_child >= total_rows:
+                print(
+                    f"error: child index out of range at ID={rid}: fc={fc} count={len(expected_children)} total={total_rows}",
+                    file=sys.stderr,
+                )
+                return 2
+
+            desc = f"split={sp} nrChildren={nc}"
+            for k, child_iv in enumerate(expected_children):
+                child_id = fc + k
+                if row_offset <= child_id < row_offset + batch_len:
+                    idx = child_id - row_offset
+                    actual = interval_at(idx)
+                    if actual != child_iv:
+                        print("split mismatch:", file=sys.stderr)
+                        print(f"  child_id={child_id}", file=sys.stderr)
+                        print(f"  parent_id={rid} ({desc})", file=sys.stderr)
+                        print(f"  expected: {_fmt_iv(child_iv)}", file=sys.stderr)
+                        print(f"  actual:   {_fmt_iv(actual)}", file=sys.stderr)
+                        return 1
+                else:
+                    if child_id in pending:
+                        print(f"error: duplicate expectation for child ID {child_id}", file=sys.stderr)
+                        return 2
+                    pending[child_id] = Expectation(parent_id=rid, desc=desc, expected=child_iv)
+
+            parents_checked += 1
+
+        row_offset += batch_len
+
+        if args.progress and row_offset >= next_progress:
+            next_progress = row_offset + 1_000_000
+            print(
+                f"progress: rows={row_offset}/{total_rows} parents_checked={parents_checked} pending={len(pending)}",
+                file=sys.stderr,
+            )
+
+        # Early exit: we’ve checked all requested parents and no pending expectations remain.
+        if (args.max_parents != 0 and parents_checked >= args.max_parents) and not pending:
+            break
+
+    if pending:
+        print(f"error: finished scan with {len(pending)} pending expectations", file=sys.stderr)
+        # Print a few for debugging.
+        for child_id in sorted(pending.keys())[:10]:
+            exp = pending[child_id]
+            print(f"  child_id={child_id} parent_id={exp.parent_id} {exp.desc}", file=sys.stderr)
+        return 1
+
+    print("ok:")
+    print(f"  parents_checked={parents_checked}")
+    if args.max_parents != 0:
+        print(f"  parents_skipped_limit={parents_skipped_limit}")
+    if args.max_gap:
+        print(f"  parents_skipped_gap={parents_skipped_gap}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch-rupert-data.sh
+++ b/scripts/fetch-rupert-data.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${RUPERT_REPO_URL:-https://github.com/Jakob256/Rupert.git}"
+REF="${RUPERT_REF:-main}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${ROOT_DIR}/external/rupert"
+
+mkdir -p "${OUT_DIR}/data"
+
+commit="$(git ls-remote "${REPO_URL}" "${REF}" | awk '{print $1}')"
+if [[ -z "${commit}" ]]; then
+  echo "error: could not resolve ref '${REF}' from ${REPO_URL}" >&2
+  exit 1
+fi
+
+echo "${commit}" > "${OUT_DIR}/REVISION"
+
+raw_base="https://raw.githubusercontent.com/Jakob256/Rupert/${commit}/data"
+
+download() {
+  local name="$1"
+  local url="${raw_base}/${name}"
+  local out="${OUT_DIR}/data/${name}"
+  echo "downloading ${name}..."
+  curl -fsSL --retry 5 --retry-delay 2 -o "${out}" "${url}"
+}
+
+download "solution_tree.parquet"
+download "mapping.csv"
+download "Ck.csv"
+
+echo "ok: downloaded Rupert data at ${OUT_DIR}"
+echo "  revision: ${commit}"
+echo "  files:"
+ls -lh "${OUT_DIR}/data"

--- a/scripts/parquet_to_csv.py
+++ b/scripts/parquet_to_csv.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+DEFAULT_COLUMNS = [
+    "ID",
+    "nodeType",
+    "nrChildren",
+    "IDfirstChild",
+    "split",
+    "T1_min",
+    "T1_max",
+    "V1_min",
+    "V1_max",
+    "T2_min",
+    "T2_max",
+    "V2_min",
+    "V2_max",
+    "A_min",
+    "A_max",
+    "P1_index",
+    "P2_index",
+    "P3_index",
+    "Q1_index",
+    "Q2_index",
+    "Q3_index",
+    "r",
+    "sigma_Q",
+    "wx_nominator",
+    "wy_nominator",
+    "w_denominator",
+    "S_index",
+]
+
+
+def _require_pyarrow() -> tuple[object, object, object]:
+    try:
+        import pyarrow as pa  # noqa: F401
+        import pyarrow.csv as pacsv  # noqa: F401
+        import pyarrow.parquet as pq  # noqa: F401
+    except Exception as exc:
+        msg = (
+            "error: pyarrow is required to read parquet.\n"
+            "Install in a venv, e.g.:\n"
+            "  apt-get install -y python3-venv\n"
+            "  python3 -m venv external/pyvenv\n"
+            "  external/pyvenv/bin/pip install pyarrow\n"
+        )
+        raise RuntimeError(msg) from exc
+    return pa, pacsv, pq
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert Rupert's solution_tree.parquet into a CSV with only the columns "
+            "needed for the Lean `Solution.Row` schema."
+        )
+    )
+    parser.add_argument(
+        "--parquet",
+        type=pathlib.Path,
+        default=pathlib.Path("external/rupert/data/solution_tree.parquet"),
+        help="Path to solution_tree.parquet (default: external/rupert/data/solution_tree.parquet).",
+    )
+    parser.add_argument(
+        "--out",
+        type=pathlib.Path,
+        default=pathlib.Path("external/rupert/data/solution_tree.skinny.csv"),
+        help="Output CSV path (default: external/rupert/data/solution_tree.skinny.csv).",
+    )
+    parser.add_argument(
+        "--columns",
+        nargs="+",
+        default=list(DEFAULT_COLUMNS),
+        help="Columns to export (defaults to a Lean-oriented subset).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50_000,
+        help="Row batch size for streaming conversion (default: 50000).",
+    )
+    args = parser.parse_args()
+
+    pa, pacsv, pq = _require_pyarrow()
+
+    parquet_path: pathlib.Path = args.parquet
+    out_path: pathlib.Path = args.out
+    columns: list[str] = list(args.columns)
+
+    if not parquet_path.exists():
+        print(f"error: parquet file not found: {parquet_path}", file=sys.stderr)
+        return 2
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    parquet_file = pq.ParquetFile(str(parquet_path))
+    write_opts = pacsv.WriteOptions(include_header=True)
+
+    total = 0
+    with out_path.open("wb") as f:
+        first = True
+        for batch in parquet_file.iter_batches(columns=columns, batch_size=args.batch_size):
+            table = pa.Table.from_batches([batch])
+            if first:
+                pacsv.write_csv(table, f, write_options=write_opts)
+                first = False
+            else:
+                pacsv.write_csv(table, f, write_options=pacsv.WriteOptions(include_header=False))
+            total += table.num_rows
+
+    print(f"ok: wrote {total} rows to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/solution_tree_stats.py
+++ b/scripts/solution_tree_stats.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def _require_pyarrow() -> tuple[object, object, object]:
+    try:
+        import pyarrow as pa  # noqa: F401
+        import pyarrow.compute as pc  # noqa: F401
+        import pyarrow.parquet as pq  # noqa: F401
+    except Exception as exc:
+        msg = (
+            "error: pyarrow is required to read parquet.\n"
+            "Install in a venv, e.g.:\n"
+            "  apt-get install -y python3-venv\n"
+            "  python3 -m venv external/pyvenv\n"
+            "  external/pyvenv/bin/pip install pyarrow\n"
+        )
+        raise RuntimeError(msg) from exc
+    return pa, pc, pq
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Print basic stats for solution_tree.parquet.")
+    parser.add_argument(
+        "--parquet",
+        type=pathlib.Path,
+        default=pathlib.Path("external/rupert/data/solution_tree.parquet"),
+        help="Path to solution_tree.parquet (default: external/rupert/data/solution_tree.parquet).",
+    )
+    args = parser.parse_args()
+
+    pa, pc, pq = _require_pyarrow()
+    path: pathlib.Path = args.parquet
+    if not path.exists():
+        print(f"error: parquet file not found: {path}", file=sys.stderr)
+        return 2
+
+    pf = pq.ParquetFile(str(path))
+    print(f"row_groups={pf.num_row_groups}")
+    print(f"rows={pf.metadata.num_rows}")
+
+    cols = ["nodeType", "nrChildren", "split"]
+    counts: dict[str, dict[str, int]] = {c: {} for c in cols}
+
+    for batch in pf.iter_batches(columns=cols, batch_size=250_000):
+        tbl = pa.Table.from_batches([batch])
+        for c in cols:
+            vc = pc.value_counts(tbl[c])
+            values = vc.field("values").to_pylist()
+            freqs = vc.field("counts").to_pylist()
+            acc = counts[c]
+            for v, n in zip(values, freqs, strict=True):
+                key = "null" if v is None else str(v)
+                acc[key] = acc.get(key, 0) + int(n)
+
+    for c in cols:
+        print(f"\n{c}:")
+        for k, n in sorted(counts[c].items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {k}: {n}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `fetch-rupert-data.sh`: download solution table parquet files
- `parquet_to_csv.py`: convert parquet to CSV for inspection
- `solution_tree_stats.py`: summary statistics for the solution tree
- `check_solution_tree_splits.py`: verify split node structure
- `check_solution_tree_local_congruence.py`: verify congruence indices
- `docs/solution_table_data.md`: data format documentation

Scripts only, no Lean changes.

## Test plan
- Scripts are standalone Python/bash; no `lake build` impact