### PR TITLE
Add squaring trick and computable Aεℚ check infrastructure

### DIFF
--- a/Noperthedron/SolutionTable.lean
+++ b/Noperthedron/SolutionTable.lean
@@ -1,5 +1,7 @@
 import Noperthedron.SolutionTable.Basic
+import Noperthedron.SolutionTable.CheckAeComputable
 import Noperthedron.SolutionTable.Local
+import Noperthedron.SolutionTable.SquaringDecide
 import Noperthedron.SolutionTable.Global
 import Noperthedron.Nopert
 

--- a/Noperthedron/SolutionTable/CheckAeComputable.lean
+++ b/Noperthedron/SolutionTable/CheckAeComputable.lean
@@ -1,0 +1,93 @@
+import Noperthedron.RationalApprox.Basic
+
+/-!
+# Computable Aεℚ check via squaring trick
+
+Architecture:
+1. Given a row, compute `vecXℚ` from rational pose angles (computable ℚ)
+2. Given a rational approximate vertex `P'_i` (from lookup table)
+3. Compute inner product `⟪vecXℚ, P'_i⟫` as a rational number
+4. Apply squaring trick: check `|dot| - threshold > 0 ∧ (|dot| - threshold)² > 2ε²`
+   where threshold = `3κ + (1+κ)κ` (stricter than Aεℚ's `3κ` to absorb approx error)
+5. Bridge via `aeq_real_of_aeq_approx_strict`
+
+For native_decide, step 2 requires a computable rational vertex table
+(to be defined in a separate file with the 90 approximate nopert vertices).
+-/
+
+namespace Solution
+
+open RationalApprox
+
+/-! ### Computable rational arithmetic -/
+
+/-- Rational dot product of two ℚ³ vectors. -/
+def dotQ (a b : Fin 3 → ℚ) : ℚ :=
+  a 0 * b 0 + a 1 * b 1 + a 2 * b 2
+
+/-- vecXℚ components as rational functions of rational angles.
+    Matches `RationalApprox.vecXℚ` when cast to ℝ. -/
+def vecXQ (θ φ : ℚ) : Fin 3 → ℚ :=
+  fun
+  | 0 => cosℚ θ * sinℚ φ
+  | 1 => sinℚ θ * sinℚ φ
+  | 2 => cosℚ φ
+
+/-- The stricter threshold for Aεℚ on approximate triangles.
+    Standard threshold is `3κ`, we add `(1+κ)κ` for approximation error. -/
+def aeqStrictThreshold : ℚ :=
+  3 * (1 / 10^10) + (1 + 1 / 10^10) * (1 / 10^10)
+
+/-- Check if a single inner product exceeds the Aεℚ threshold via squaring.
+    Returns true if `|dot| > √2 * ε + aeqStrictThreshold`. -/
+def checkAeVertexSq (dot : ℚ) (ε : ℚ) : Bool :=
+  let shifted := dot - aeqStrictThreshold
+  shifted > 0 && shifted ^ 2 > 2 * ε ^ 2
+
+/-- Check Aεℚ for a triangle given rational vertex coordinates and pose data.
+    Tries both signs σ ∈ {-1, 1} and checks all 3 vertices. -/
+def checkAeTriSq (verts : Fin 3 → (Fin 3 → ℚ)) (X : Fin 3 → ℚ) (ε : ℚ) : Bool :=
+  let dots : Fin 3 → ℚ := fun i => dotQ X (verts i)
+  -- Try σ = 0 (positive sign): all dots must pass
+  (checkAeVertexSq (dots 0) ε && checkAeVertexSq (dots 1) ε && checkAeVertexSq (dots 2) ε) ||
+  -- Try σ = 1 (negative sign): all negated dots must pass
+  (checkAeVertexSq (-(dots 0)) ε && checkAeVertexSq (-(dots 1)) ε && checkAeVertexSq (-(dots 2)) ε)
+
+/-! ### Computable κSpanning check -/
+
+/-- Apply rotMℚ matrix to a ℚ³ vector, returning ℚ² result. -/
+def rotMQ_apply (θ φ : ℚ) (P : Fin 3 → ℚ) : Fin 2 → ℚ :=
+  fun
+  | 0 => -(sinℚ θ) * P 0 + (cosℚ θ) * P 1
+  | 1 => -(cosℚ θ) * (cosℚ φ) * P 0 - (sinℚ θ) * (cosℚ φ) * P 1 + (sinℚ φ) * P 2
+
+/-- Apply 90° rotation in ℚ². -/
+def rotR_pi2_apply (v : Fin 2 → ℚ) : Fin 2 → ℚ :=
+  fun
+  | 0 => -(v 1)
+  | 1 => v 0
+
+/-- Rational dot product of two ℚ² vectors. -/
+def dotQ2 (a b : Fin 2 → ℚ) : ℚ := a 0 * b 0 + a 1 * b 1
+
+/-- Compute the κSpanning inner product ⟪rotR(π/2)(rotMℚ θ φ P_i), rotMℚ θ φ P_{i+1}⟫
+    as a rational number. -/
+def spanInnerQ (θ φ : ℚ) (Pi Pj : Fin 3 → ℚ) : ℚ :=
+  dotQ2 (rotR_pi2_apply (rotMQ_apply θ φ Pi)) (rotMQ_apply θ φ Pj)
+
+/-- Check κSpanning inequality for a single pair via squaring trick.
+    Checks: inner > 2ε(√2+ε) + 12κ (extra 6κ for vertex approximation margin).
+    Rearranged: (inner - 2ε² - 12κ) > 0 ∧ (inner - 2ε² - 12κ)² > 8ε². -/
+def checkSpanPairSq (inner : ℚ) (ε : ℚ) : Bool :=
+  let κ : ℚ := 1 / 10^10
+  let shifted := inner - 2 * ε ^ 2 - 12 * κ
+  shifted > 0 && shifted ^ 2 > 8 * ε ^ 2
+
+/-- Check κSpanning for a triangle given rational vertex coordinates.
+    Checks all 3 pairs (i, i+1 mod 3). -/
+def checkSpanTriSq (θ φ : ℚ) (verts : Fin 3 → (Fin 3 → ℚ)) (ε : ℚ) : Bool :=
+  checkSpanPairSq (spanInnerQ θ φ (verts 0) (verts 1)) ε &&
+  checkSpanPairSq (spanInnerQ θ φ (verts 1) (verts 2)) ε &&
+  checkSpanPairSq (spanInnerQ θ φ (verts 2) (verts 0)) ε
+
+end Solution

--- a/Noperthedron/SolutionTable/SquaringDecide.lean
+++ b/Noperthedron/SolutionTable/SquaringDecide.lean
@@ -1,0 +1,54 @@
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+
+/-!
+# Squaring trick for eliminating √2 from decidable comparisons
+
+The key identities used:
+- `q > √2 * r + s ↔ q - s > 0 ∧ (q - s)² > 2 * r²` (when r ≥ 0)
+- `q > 2 * r * √2 + s ↔ q - s > 0 ∧ (q - s)² > 8 * r²` (when r ≥ 0)
+
+These eliminate √2 from comparisons, making them decidable over ℚ.
+-/
+
+namespace Solution
+
+open Real
+
+/-! ### Core squaring lemma -/
+
+/-- Squaring trick: `q > √2 * r + s` with `r ≥ 0` iff `q > s` and `(q-s)² > 2r²`. -/
+theorem gt_sqrt2_mul_add_iff {q r s : ℝ} (hr : 0 ≤ r) :
+    q > √2 * r + s ↔ q - s > 0 ∧ (q - s) ^ 2 > 2 * r ^ 2 := by
+  constructor
+  · intro h
+    constructor
+    · linarith [Real.sqrt_nonneg 2, mul_nonneg (Real.sqrt_nonneg 2) hr]
+    · have hqs : q - s > 0 := by
+        linarith [Real.sqrt_nonneg 2, mul_nonneg (Real.sqrt_nonneg 2) hr]
+      have hsq : √2 * r < q - s := by linarith
+      have h2 : (√2 * r) ^ 2 < (q - s) ^ 2 := by
+        exact sq_lt_sq' (by linarith [mul_nonneg (Real.sqrt_nonneg 2) hr]) hsq
+      simp [mul_pow, Real.sq_sqrt (by norm_num : (2 : ℝ) ≥ 0)] at h2
+      linarith
+  · rintro ⟨hqs, hsq⟩
+    -- Need: q > √2 * r + s, i.e., q - s > √2 * r
+    -- We know (q-s)² > 2r² and q - s > 0
+    by_contra h
+    push_neg at h
+    -- h : q ≤ √2 * r + s, so q - s ≤ √2 * r
+    have hle : q - s ≤ √2 * r := by linarith
+    have : (q - s) ^ 2 ≤ (√2 * r) ^ 2 := by
+      exact sq_le_sq' (by linarith [mul_nonneg (Real.sqrt_nonneg 2) hr]) hle
+    simp [mul_pow, Real.sq_sqrt (by norm_num : (2 : ℝ) ≥ 0)] at this
+    linarith
+
+/-- Variant for `q > 2 * ε * √2 + s`, used in κSpanning. -/
+theorem gt_two_mul_sqrt2_add_iff {q ε s : ℝ} (hε : 0 ≤ ε) :
+    q > 2 * ε * √2 + s ↔ q - s > 0 ∧ (q - s) ^ 2 > 8 * ε ^ 2 := by
+  have : 2 * ε * √2 = √2 * (2 * ε) := by ring
+  rw [this, gt_sqrt2_mul_add_iff (by linarith)]
+  constructor
+  · rintro ⟨h1, h2⟩; exact ⟨h1, by nlinarith⟩
+  · rintro ⟨h1, h2⟩; exact ⟨h1, by nlinarith⟩
+
+end Solution


### PR DESCRIPTION
## Summary
- **SquaringDecide.lean**: core lemmas eliminating √2 from decidable comparisons
  - `gt_sqrt2_mul_add_iff`: `q > √2*r + s ↔ q-s > 0 ∧ (q-s)² > 2r²` (when `r ≥ 0`)
  - `gt_two_mul_sqrt2_add_iff`: variant for `2ε√2` terms in κSpanning
- **CheckAeComputable.lean**: computable Bool check for Aεℚ condition
  - `dotQ`: rational inner product of two ℚ³ vectors
  - `vecXQ`: rational vecXℚ components from rational angles
  - `checkAeTriSq`: full Aεℚ Bool check via squaring trick, suitable for `native_decide`

Independent of other PRs.

## Test plan
- `lake build` CI