### PR TITLE
Update GoodPoly and ApproxGoodPoly to retain indexing information

### DIFF
--- a/Noperthedron/Basic.lean
+++ b/Noperthedron/Basic.lean
@@ -375,6 +375,24 @@ lemma rotM_periodic_φ {θ φ : ℝ} {k : ℤ} :
   ext v i; fin_cases i <;>
   · simp [rotM, rotM_mat]
 
+structure IndexedVertices (ι : Type) [Fintype ι] where
+  v : ι → ℝ³
+
+noncomputable
+def IndexedVertices.radius {ι : Type} [Fintype ι] [ne : Nonempty ι] (iv : IndexedVertices ι) : ℝ :=
+  (Finset.image (fun x ↦ ‖iv.v x‖) Finset.univ).max'
+    (by rw [Finset.image_nonempty]; exact Finset.univ_nonempty_iff.mpr ne)
+
+theorem indexed_vertices_radius_iff {r : ℝ} {ι : Type} [Fintype ι] [ne : Nonempty ι]
+    (iv : IndexedVertices ι) :
+    iv.radius = r ↔ (∃ i, ‖iv.v i‖ = r) ∧ ∀ i, ‖iv.v i‖ ≤ r := by
+  constructor
+  · intro h
+    simp only [IndexedVertices.radius, Finset.max'_eq_iff] at h
+    grind
+  · intro h
+    simpa [IndexedVertices.radius, Finset.max'_eq_iff]
+
 noncomputable
 def polyhedronRadius {n : ℕ} (S : Finset (E n)) (ne : S.Nonempty) : ℝ :=
   (S.image (‖·‖)).max' (by simp [Finset.image_nonempty]; exact ne)
@@ -396,17 +414,17 @@ theorem polyhedron_vertex_norm_le_radius {n : ℕ} (S : Finset (E n))
   apply Finset.le_max'
   exact Finset.mem_image_of_mem _ hv
 
-structure ApproxGoodPoly : Type where
-  vertices : Finset ℝ³
-  nonempty : vertices.Nonempty
-  nontriv : ∀ v ∈ vertices, ‖v‖ > 0
+structure ApproxGoodPoly (ι : Type) [Fintype ι] [Nonempty ι] : Type where
+  vertices : IndexedVertices ι
+  nontriv : ∀ i, 0 < ‖vertices.v i‖
 
-structure GoodPoly extends ApproxGoodPoly where
-  radius_eq_one : polyhedronRadius vertices nonempty = 1
+structure GoodPoly (ι : Type) [Fintype ι] [Nonempty ι] extends ApproxGoodPoly ι where
+  radius_eq_one : vertices.radius = 1
 
-def GoodPoly.hull (poly : GoodPoly) : Set ℝ³ :=
-  convexHull ℝ poly.vertices
+def GoodPoly.hull {ι : Type} [Fintype ι] [Nonempty ι] (poly : GoodPoly ι) : Set ℝ³ :=
+  convexHull ℝ { poly.vertices.v i | i }
 
-theorem GoodPoly.vertex_radius_le_one (poly : GoodPoly) : ∀ v ∈ poly.vertices, ‖v‖ ≤ 1 := by
+theorem GoodPoly.vertex_radius_le_one {ι : Type} [Fintype ι] [Nonempty ι] (poly : GoodPoly ι) :
+    ∀ i, ‖poly.vertices.v i‖ ≤ 1 := by
   have := poly.radius_eq_one
-  simp_all only [polyhedron_radius_iff, implies_true]
+  rw [indexed_vertices_radius_iff] at this; exact this.2

--- a/Noperthedron/Checker/KappaApprox.lean
+++ b/Noperthedron/Checker/KappaApprox.lean
@@ -116,10 +116,6 @@ lemma left_leg_all :
 
 /-! ## Right-leg bound: nopertListℚ vs nopertList -/
 
-/-- Cast a `Fin 3 → ℚ` to an `ℝ³` point. -/
-noncomputable def toR3 (v : Fin 3 → ℚ) : ℝ³ :=
-  WithLp.toLp 2 (fun i => (v i : ℝ))
-
 /-- The reduced angle index k' = min(k, 15-k) satisfies k' ≤ 7. -/
 private lemma reduced_le_seven (k : ℕ) (hk : k < 15) :
     (if k ≤ 7 then k else 15 - k) ≤ 7 := by
@@ -330,5 +326,13 @@ theorem vertex_close_index (j : VertexIndex) :
         norm_add_le _ _
     _ ≤ κ / 2 + κ / 2 := add_le_add (left_leg_norm j) (taylorVertex_close j)
     _ = κ := by ring
+
+def exact_κApprox_python : κApproxPoly ⟨exactVertex⟩ ⟨toR3 ∘ pythonVertex⟩ := {
+  bijection := Equiv.refl _
+  approx a := by
+    simp only [Equiv.refl_apply, Function.comp_apply]
+    rw [norm_sub_rev]
+    exact vertex_close_index a
+}
 
 end KappaApprox

--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -83,10 +83,10 @@ def H (p : Pose) (ε : ℝ) (w : ℝ²) (P : ℝ³) : ℝ :=
 A measure of how far all of the outer-shadow vertices can "reach" along w.
 -/
 noncomputable
-def maxH (p : Pose) (poly : GoodPoly) (ε : ℝ) (w : ℝ²) : ℝ :=
-  poly.vertices.image (H p ε w) |>.max' <| by
+def maxH {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Pose) (poly : GoodPoly ι) (ε : ℝ) (w : ℝ²) : ℝ :=
+  Finset.image (H p ε w ∘ poly.vertices.v) Finset.univ |>.max' <| by
     simp only [Finset.image_nonempty]
-    exact poly.nonempty
+    exact Finset.univ_nonempty_iff.mpr ne
 
 /--
 A compact way of saying "the pose satisfies the global theorem precondition at width ε".
@@ -94,31 +94,36 @@ We require the existence of some inner-shadow vertex S from the polyhedron, and 
 the direction we're projecting ℝ² → ℝ to find that S "sticks out too far" compared to all the
 other outer-shadow vertices P (which the calculation of H iterates over) in the polygon that lies in ℝ².
 -/
-structure GlobalTheoremPrecondition (poly : GoodPoly) (p : Pose) (ε : ℝ) : Type where
+structure GlobalTheoremPrecondition {ι : Type} [Fintype ι] [Nonempty ι]
+    (poly : GoodPoly ι) (p : Pose) (ε : ℝ) : Type where
   S : ℝ³
-  S_in_poly : S ∈ poly.vertices
+  S_in_poly : S ∈ Set.range poly.vertices.v
   w : ℝ²
   w_unit : ‖w‖ = 1
   exceeds : G p ε S w > maxH p poly ε w
 
 noncomputable
 def GlobalTheoremPrecondition.Sval
-    {poly : GoodPoly} {p : Pose} {ε : ℝ}
+    {ι : Type} [Fintype ι] [Nonempty ι]
+    {poly : GoodPoly ι} {p : Pose} {ε : ℝ}
     (hp : GlobalTheoremPrecondition poly p ε) (q : Pose) : ℝ :=
     ⟪hp.w, q.inner hp.S⟫
 
 theorem GlobalTheoremPrecondition.norm_S_le_one
-    {poly : GoodPoly} {p : Pose} {ε : ℝ}
-    (hp : GlobalTheoremPrecondition poly p ε) : ‖hp.S‖ ≤ 1 :=
-  poly.vertex_radius_le_one hp.S hp.S_in_poly
+    {ι : Type} [Fintype ι] [Nonempty ι]
+    {poly : GoodPoly ι} {p : Pose} {ε : ℝ}
+    (hp : GlobalTheoremPrecondition poly p ε) : ‖hp.S‖ ≤ 1 := by
+  obtain ⟨i, hi⟩ := hp.S_in_poly; rw [← hi]; exact poly.vertex_radius_le_one i
 
 theorem GlobalTheoremPrecondition.norm_S_gt_zero
-    {poly : GoodPoly} {p : Pose} {ε : ℝ}
-    (hp : GlobalTheoremPrecondition poly p ε) : 0 < ‖hp.S‖ :=
-  poly.nontriv hp.S hp.S_in_poly
+    {ι : Type} [Fintype ι] [Nonempty ι]
+    {poly : GoodPoly ι} {p : Pose} {ε : ℝ}
+    (hp : GlobalTheoremPrecondition poly p ε) : 0 < ‖hp.S‖ := by
+  obtain ⟨i, hi⟩ := hp.S_in_poly; rw [← hi]; exact poly.nontriv i
 
 theorem GlobalTheoremPrecondition.norm_S_ne_zero
-    {poly : GoodPoly} {p : Pose} {ε : ℝ}
+    {ι : Type} [Fintype ι] [Nonempty ι]
+    {poly : GoodPoly ι} {p : Pose} {ε : ℝ}
     (hp : GlobalTheoremPrecondition poly p ε) : 0 ≠ ‖hp.S‖ :=
   ne_of_lt hp.norm_S_gt_zero
 
@@ -127,16 +132,18 @@ def imgInner (p : Pose) (V : Finset ℝ³) (w : ℝ²) : Finset ℝ :=
   V.image fun P => ⟪w, p.inner P⟫
 
 noncomputable
-def maxInner (p : Pose) (poly: GoodPoly) (w : ℝ²) : ℝ :=
-  (imgInner p poly.vertices w).max' (by simp only [imgInner, Finset.image_nonempty]; exact poly.nonempty)
+def maxInner {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Pose) (poly : GoodPoly ι) (w : ℝ²) : ℝ :=
+  (imgInner p (Finset.image poly.vertices.v Finset.univ) w).max' (by
+    simp only [imgInner, Finset.image_nonempty, Finset.univ_nonempty_iff]; exact ne)
 
 noncomputable
 def imgOuter (p : Pose) (V : Finset ℝ³) (w : ℝ²) : Finset ℝ :=
   V.image fun P => ⟪w, p.outer P⟫
 
 noncomputable
-def maxOuter (p : Pose) (poly : GoodPoly) (w : ℝ²) : ℝ :=
-  (imgOuter p poly.vertices w).max' (by simp only [imgOuter, Finset.image_nonempty]; exact poly.nonempty)
+def maxOuter {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Pose) (poly : GoodPoly ι) (w : ℝ²) : ℝ :=
+  (imgOuter p (Finset.image poly.vertices.v Finset.univ) w).max' (by
+    simp only [imgOuter, Finset.image_nonempty, Finset.univ_nonempty_iff]; exact ne)
 
 /--
 This is where we use hull_scalar_prod. The text in [SY25] this corresponds to is:
@@ -144,30 +151,41 @@ This is where we use hull_scalar_prod. The text in [SY25] this corresponds to is
 "As noted before, Rupert’s condition and Lemma 18 imply in particular that
 max_{P} ⟪ R(α) M(θ₁, φ₁), P, w ⟫ < max_{P} ⟪ M(θ₂, φ₂), P, w ⟫"
 -/
-theorem global_theorem_le_reasoning (p : Pose)
-    (poly : GoodPoly)
-    (h_rupert : RupertPose p (convexHull ℝ poly.vertices)) (w : ℝ²) :
+private lemma hull_eq_convexHull_finset {ι : Type} [Fintype ι] [Nonempty ι]
+    (poly : GoodPoly ι) :
+    poly.hull = convexHull ℝ ↑(Finset.image poly.vertices.v Finset.univ) := by
+  unfold GoodPoly.hull
+  congr 1
+  ext x
+  simp [Set.mem_range]
+
+theorem global_theorem_le_reasoning {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Pose)
+    (poly : GoodPoly ι)
+    (h_rupert : RupertPose p poly.hull) (w : ℝ²) :
     maxInner p poly w ≤ maxOuter p poly w
     := by
+  let verts := Finset.image poly.vertices.v Finset.univ
+  have verts_ne : verts.Nonempty := by
+    simp only [verts, Finset.image_nonempty, Finset.univ_nonempty_iff]; exact ne
+  have h_rupert' : RupertPose p (convexHull ℝ ↑verts) := by
+    rwa [← hull_eq_convexHull_finset]
   simp only [maxInner]
   refine Finset.max'_le _ _ _ ?_
   intro y hy
   simp only [maxOuter, imgOuter]
-  simp only [imgInner, Finset.mem_image] at hy
-  obtain ⟨v, ⟨hv, hv'⟩⟩ := hy
-  rw [← hv']
-  clear hv'
-  change ⟪w, p.inner v⟫ ≤ (poly.vertices.image (⟪w, p.outer ·⟫)).max' _
-  convert_to ⟪w, p.inner v⟫ ≤ ((poly.vertices.image p.outer).image (⟪w, ·⟫)).max' (by
-      simp only [Finset.image_nonempty]; exact poly.nonempty)
+  simp only [imgInner] at hy
+  obtain ⟨v, hv, rfl⟩ := Finset.mem_image.mp hy
+  change ⟪w, p.inner v⟫ ≤ (verts.image (⟪w, p.outer ·⟫)).max' _
+  convert_to ⟪w, p.inner v⟫ ≤ ((verts.image p.outer).image (⟪w, ·⟫)).max' (by
+      simp only [Finset.image_nonempty]; exact verts_ne)
   · simp [Finset.image_image]; rfl
   let S := p.inner v
-  let V := poly.vertices.image p.outer
-  have Vne : V.Nonempty := by simp only [V, Finset.image_nonempty]; exact poly.nonempty
+  let V := verts.image p.outer
+  have Vne : V.Nonempty := by simp only [V, Finset.image_nonempty]; exact verts_ne
   change ⟪w, S⟫ ≤ Finset.max' (V.image (⟪w, ·⟫)) _
   refine hull_scalar_prod V Vne S ?_ w
   simp only [Finset.coe_image, V, S]
-  exact p.is_rupert_imp_inner_in_outer poly.vertices h_rupert v hv
+  exact p.is_rupert_imp_inner_in_outer verts h_rupert' v hv
 
 lemma rotproj_inner_pose_eq {S : ℝ³} {w : ℝ²} (p : Pose) : rotproj_inner S w p.innerParams = ⟪p.inner S, w⟫ := by
   simp only [rotproj_inner, Pose.inner, innerProj, PoseLike.inner, Pose.innerParams,
@@ -182,7 +200,8 @@ This is the function that Theorem 17's proof calls `f`.
 It always returns a unit vector.
 -/
 noncomputable
-def GlobalTheoremPrecondition.fu {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+def GlobalTheoremPrecondition.fu {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι]
+    {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) : ℝ³ → ℝ :=
   rotproj_inner_unit pc.S pc.w
 
@@ -190,7 +209,8 @@ def GlobalTheoremPrecondition.fu {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
 This is an outer-shadow analog of `fu`
 -/
 noncomputable
-def GlobalTheoremPrecondition.fu_outer {pbar : Pose} {ε : ℝ} {poly : GoodPoly} (P : ℝ³)
+def GlobalTheoremPrecondition.fu_outer {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι]
+    {poly : GoodPoly ι} (P : ℝ³)
     (pc : GlobalTheoremPrecondition poly pbar ε) : ℝ² → ℝ :=
   rotproj_outer_unit P pc.w
 
@@ -198,23 +218,24 @@ def GlobalTheoremPrecondition.fu_outer {pbar : Pose} {ε : ℝ} {poly : GoodPoly
 This is the function that Theorem 17's proof calls `f`, but multiplied by ‖S‖.
 -/
 noncomputable
-def GlobalTheoremPrecondition.f {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+def GlobalTheoremPrecondition.f {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι]
+    {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) : ℝ³ → ℝ :=
   rotproj_inner pc.S pc.w
 
-theorem f_pose_eq_sval {p pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+theorem f_pose_eq_sval {p pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     pc.f p.innerParams = pc.Sval p := by
   simp only [GlobalTheoremPrecondition.f, GlobalTheoremPrecondition.Sval]
   rw [rotproj_inner_pose_eq]
   apply real_inner_comm
 
-theorem f_pose_eq_inner {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+theorem f_pose_eq_inner {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     pc.f pbar.innerParams = ⟪pbar.inner pc.S, pc.w⟫ := by
   rw [f_pose_eq_sval, GlobalTheoremPrecondition.Sval, real_inner_comm]
 
-theorem GlobalTheoremPrecondition.fu_pose_eq_outer {p pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+theorem GlobalTheoremPrecondition.fu_pose_eq_outer {p pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) {P : ℝ³} (hP : ‖P‖ ≠ 0) :
     pc.fu_outer P p.outerParams * ‖P‖ = ⟪pc.w, p.outer P⟫ := by
   simp only [GlobalTheoremPrecondition.fu_outer, rotproj_outer_unit, Pose.outer, outerProj,
@@ -235,14 +256,14 @@ lemma fderiv_rotproj_inner_unit (pbar : Pose) (S : ℝ³) (w : ℝ²) :
   rw [heq, (Differentiable.rotproj_inner S w).differentiableAt.hasFDerivAt.const_smul ‖S‖⁻¹ |>.fderiv,
     HasFDerivAt.rotproj_inner pbar S w |>.fderiv]
 
-lemma partials_helper0a {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper0a {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     (fderiv ℝ (rotproj_inner_unit pc.S pc.w) pbar.innerParams) (EuclideanSpace.single 0 1) =
     ‖pc.S‖⁻¹ * ⟪pbar.rotR' (pbar.rotM₁ pc.S), pc.w⟫ := by
   rw [fderiv_rotproj_inner_unit pbar pc.S pc.w]
   simp [rotproj_inner']
 
-lemma partials_helper0 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper0 {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     ‖pc.S‖ * nth_partial 0 pc.fu pbar.innerParams =
     ⟪pbar.rotR' (pbar.rotM₁ pc.S), pc.w⟫ := by
@@ -250,14 +271,14 @@ lemma partials_helper0 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
   simp only [nth_partial, GlobalTheoremPrecondition.fu, Fin.isValue, partials_helper0a]
   field_simp
 
-lemma partials_helper1a {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper1a {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     (fderiv ℝ (rotproj_inner_unit pc.S pc.w) pbar.innerParams) (EuclideanSpace.single 1 1) =
     ‖pc.S‖⁻¹ * ⟪pbar.rotR (pbar.rotM₁θ pc.S), pc.w⟫ := by
   rw [fderiv_rotproj_inner_unit pbar pc.S pc.w]
   simp [rotproj_inner']
 
-lemma partials_helper1 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper1 {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     ‖pc.S‖ * nth_partial 1 pc.fu pbar.innerParams =
     ⟪pbar.rotR (pbar.rotM₁θ pc.S), pc.w⟫ := by
@@ -265,14 +286,14 @@ lemma partials_helper1 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
   simp only [nth_partial, GlobalTheoremPrecondition.fu, Fin.isValue, partials_helper1a]
   field_simp
 
-lemma partials_helper2a {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper2a {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     (fderiv ℝ (rotproj_inner_unit pc.S pc.w) pbar.innerParams) (EuclideanSpace.single 2 1) =
     ‖pc.S‖⁻¹ * ⟪pbar.rotR (pbar.rotM₁φ pc.S), pc.w⟫ := by
   rw [fderiv_rotproj_inner_unit pbar pc.S pc.w]
   simp [rotproj_inner']
 
-lemma partials_helper2 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper2 {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     ‖pc.S‖ * nth_partial 2 pc.fu pbar.innerParams =
     ⟪pbar.rotR (pbar.rotM₁φ pc.S), pc.w⟫ := by
@@ -298,7 +319,7 @@ private lemma nth_partial_rotproj_outer_1 (pbar : Pose) (P : ℝ³) (w : ℝ²) 
   rw [(HasFDerivAt.rotM_outer pbar P).fderiv]
   ext i; simp [rotM'_apply]
 
-lemma partials_helper3 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper3 {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) (P : ℝ³) :
     ‖P‖ * nth_partial 0 (GlobalTheoremPrecondition.fu_outer P pc) pbar.outerParams =
     ⟪pbar.rotM₂θ P, pc.w⟫ := by
@@ -312,7 +333,7 @@ lemma partials_helper3 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
     simp only [Pose.rotM₂θ]
     field_simp
 
-lemma partials_helper4 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper4 {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) (P : ℝ³) :
     ‖P‖ * nth_partial 1 (GlobalTheoremPrecondition.fu_outer P pc) pbar.outerParams =
     ⟪pbar.rotM₂φ P, pc.w⟫ := by
@@ -326,28 +347,28 @@ lemma partials_helper4 {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
     simp only [Pose.rotM₂φ]
     field_simp
 
-lemma partials_helper {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     |⟪pbar.rotR' (pbar.rotM₁ pc.S), pc.w⟫| + |⟪pbar.rotR (pbar.rotM₁θ pc.S), pc.w⟫| +
       |⟪pbar.rotR (pbar.rotM₁φ pc.S), pc.w⟫| = (‖pc.S‖ * ∑ i, |nth_partial i pc.fu pbar.innerParams|) := by
   rw [Finset.mul_sum, Fin.sum_univ_three, ← abs_norm, ← abs_mul, ← abs_mul, ← abs_mul,
     partials_helper0, partials_helper1, partials_helper2]
 
-lemma partials_helper_outer {pbar : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma partials_helper_outer {pbar : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) (P : ℝ³) :
     |⟪pbar.rotM₂θ P, pc.w⟫| + |⟪pbar.rotM₂φ P, pc.w⟫| =
     ‖P‖ * ∑ i, |nth_partial i (pc.fu_outer P) pbar.outerParams| := by
   rw [Finset.mul_sum, Fin.sum_univ_two, ← abs_norm, ← abs_mul, ← abs_mul]
   rw [partials_helper3 pc P, partials_helper4 pc P]
 
-theorem fu_times_norm_S_eq_f {pbar p : Pose} {ε : ℝ} {poly : GoodPoly}
+theorem fu_times_norm_S_eq_f {pbar p : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     pc.fu p.innerParams * ‖pc.S‖ = pc.f p.innerParams := by
   have := pc.norm_S_ne_zero
   simp only [GlobalTheoremPrecondition.fu, GlobalTheoremPrecondition.f, rotproj_inner_unit, rotproj_inner]
   field_simp
 
-lemma rotproj_helper {pbar p : Pose} {ε : ℝ} {poly : GoodPoly}
+lemma rotproj_helper {pbar p : Pose} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι] {poly : GoodPoly ι}
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     |pc.fu pbar.innerParams - pc.fu p.innerParams| * ‖pc.S‖ = |⟪pbar.inner pc.S, pc.w⟫ - pc.Sval p| := by
   rw [← f_pose_eq_sval, ← f_pose_eq_inner]
@@ -358,9 +379,10 @@ lemma rotproj_helper {pbar p : Pose} {ε : ℝ} {poly : GoodPoly}
 /--
 Use the analytic bounds on rotations, Lemmas 19 and 20.
 -/
-lemma global_theorem_inequality_ii (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
+lemma global_theorem_inequality_ii {ι : Type} [Fintype ι] [Nonempty ι]
+    (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
     (p_near_pbar : p ∈ pbar.closed_ball ε)
-    (poly : GoodPoly)
+    (poly : GoodPoly ι)
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     G pbar ε pc.S pc.w ≤ pc.Sval p := by
   have S_norm_pos : 0 < ‖pc.S‖ := pc.norm_S_gt_zero
@@ -382,25 +404,29 @@ lemma global_theorem_inequality_ii (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
 /--
 Use the analytic bounds on rotations, Lemmas 19 and 20.
 -/
-lemma global_theorem_inequality_iv (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
+lemma global_theorem_inequality_iv {ι : Type} [Fintype ι] [Nonempty ι]
+    (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
     (p_near_pbar : p ∈ pbar.closed_ball ε)
-    (poly : GoodPoly)
+    (poly : GoodPoly ι)
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     maxOuter p poly pc.w ≤ maxH pbar poly ε pc.w := by
   -- First of all, we can relate these two maximums by relating
   -- their components.
-  suffices h : ∀ vert ∈ poly.vertices,
-      ⟪pc.w, p.outer vert⟫ ≤ H pbar ε pc.w vert by
-    simp only [maxH, maxOuter, imgOuter, Finset.max'_le_iff, Finset.mem_image, forall_exists_index,
-      and_imp, forall_apply_eq_imp_iff₂]
-    simp only [Finset.max', Finset.sup'_image,
-      Finset.le_sup'_iff]
-    exact fun a ha => Exists.intro a ⟨ha, h a ha⟩
-  -- Now we're just considering a single polyhedron vertex P
-  intro P hP
-  have P_norm_pos : 0 < ‖P‖ := poly.nontriv P hP
+  suffices h : ∀ i : ι,
+      ⟪pc.w, p.outer (poly.vertices.v i)⟫ ≤ H pbar ε pc.w (poly.vertices.v i) by
+    simp only [maxOuter, maxH, imgOuter]
+    apply Finset.max'_le
+    simp only [Finset.mem_image, Finset.mem_univ, true_and]
+    rintro _ ⟨_, ⟨i, rfl⟩, rfl⟩
+    refine le_trans (h i) ?_
+    show (H pbar ε pc.w ∘ poly.vertices.v) i ≤ _
+    exact Finset.le_max' _ _ (Finset.mem_image_of_mem _ (Finset.mem_univ i))
+  -- Now we're just considering a single polyhedron vertex
+  intro i
+  set P := poly.vertices.v i
+  have P_norm_pos : 0 < ‖P‖ := poly.nontriv i
   have P_norm_nonzero : ‖P‖ ≠ 0 := Ne.symm (ne_of_lt P_norm_pos)
-  have P_norm_le_one : ‖P‖ ≤ 1 := poly.vertex_radius_le_one P hP
+  have P_norm_le_one : ‖P‖ ≤ 1 := poly.vertex_radius_le_one i
 
   have hz := bounded_partials_control_difference
     (pc.fu_outer P) (rotation_partials_exist_outer P_norm_pos)
@@ -425,14 +451,17 @@ lemma global_theorem_inequality_iv (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
 /--
 Here we run through the "sequence of inequalities [which yield] the desired contradiction"
 -/
-theorem global_theorem_gt_reasoning (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
+theorem global_theorem_gt_reasoning {ι : Type} [Fintype ι] [Nonempty ι]
+    (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
     (p_near_pbar : p ∈ pbar.closed_ball ε)
-    (poly : GoodPoly)
+    (poly : GoodPoly ι)
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     maxInner p poly pc.w > maxOuter p poly pc.w := by
-  have sval_in_img_inner : pc.Sval p ∈ imgInner p poly.vertices pc.w := by
-    simp only [Finset.mem_image, imgInner, GlobalTheoremPrecondition.Sval]
-    use pc.S, pc.S_in_poly
+  have sval_in_img_inner : pc.Sval p ∈ imgInner p (Finset.image poly.vertices.v Finset.univ) pc.w := by
+    simp only [Finset.mem_image, imgInner, GlobalTheoremPrecondition.Sval, Finset.mem_univ,
+      true_and]
+    obtain ⟨i, hi⟩ := pc.S_in_poly
+    exact ⟨pc.S, ⟨i, hi⟩, rfl⟩
   calc
     maxInner p poly pc.w
     _ ≥ pc.Sval p := Finset.le_max' (H2 := sval_in_img_inner)
@@ -443,8 +472,9 @@ theorem global_theorem_gt_reasoning (pbar p : Pose) (ε : ℝ) (hε : 0 ≤ ε)
 /--
 The Global Theorem, [SY25] Theorem 17
 -/
-theorem global_theorem (pbar : Pose) (ε : ℝ) (hε : 0 ≤ ε)
-    (poly : GoodPoly)
+theorem global_theorem {ι : Type} [Fintype ι] [Nonempty ι]
+    (pbar : Pose) (ε : ℝ) (hε : 0 ≤ ε)
+    (poly : GoodPoly ι)
     (_poly_pointsym : PointSym poly.hull)
     (pc : GlobalTheoremPrecondition poly pbar ε) :
     ¬ ∃ p ∈ pbar.closed_ball ε, RupertPose p poly.hull := by
@@ -458,8 +488,14 @@ The Global Theorem specialized to the noperthedron.
 -/
 theorem global_theorem_nopert (pbar : Pose) (ε : ℝ) (hε : 0 ≤ ε)
     (pc : GlobalTheoremPrecondition Noperthedron.exactPoly pbar ε) :
-    ¬ ∃ p ∈ pbar.closed_ball ε, RupertPose p Noperthedron.exactShape.hull :=
-  global_theorem pbar ε hε Noperthedron.exactPoly
-      Noperthedron.exactShape_point_symmetric pc
+    ¬ ∃ p ∈ pbar.closed_ball ε, RupertPose p Noperthedron.exactShape.hull := by
+  have : Noperthedron.exactPoly.hull = Noperthedron.exactShape.hull := by
+    unfold GoodPoly.hull Noperthedron.exactPoly Noperthedron.exactShape Shape.hull
+    congr 1
+    ext x
+    simp [Set.mem_range, Noperthedron.exactVerts]
+  rw [← this]
+  exact global_theorem pbar ε hε Noperthedron.exactPoly
+      (this ▸ Noperthedron.exactShape_point_symmetric) pc
 
 end GlobalTheorem

--- a/Noperthedron/RationalApprox/Basic.lean
+++ b/Noperthedron/RationalApprox/Basic.lean
@@ -60,9 +60,10 @@ def κApproxMat {m n : ℕ}
 def κApproxPoint {m n : ℕ} (A A' : Matrix (Fin m) (Fin n) ℝ) : Prop :=
   ‖(A - A').toEuclideanLin.toContinuousLinearMap‖ ≤ κ
 
-structure κApproxPoly (A B : Finset ℝ³) where
-  bijection : A ≃ B
-  approx : ∀ a : A, ‖(a : ℝ³) - bijection a‖ ≤ κ
+structure κApproxPoly {ι₁ ι₂ : Type} [Fintype ι₁] [Fintype ι₂]
+    (A : IndexedVertices ι₁) (B : IndexedVertices ι₂) where
+  bijection : ι₁ ≃ ι₂
+  approx : ∀ a : ι₁, ‖(A.v a : ℝ³) - B.v (bijection a)‖ ≤ κ
 
 end
 

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.Data.Set.Operations
 import Noperthedron.Global
 import Noperthedron.PointSym
 import Noperthedron.PoseInterval
@@ -28,10 +29,11 @@ def Hℚ (p : Pose) (ε : ℝ) (w : ℝ²) (P : ℝ³) : ℝ :=
 A measure of how far all of the outer-shadow vertices can "reach" along w.
 -/
 noncomputable
-def maxHℚ (p : Pose) (poly : ApproxGoodPoly) (ε : ℝ) (w : ℝ²) : ℝ :=
-  poly.vertices.image (Hℚ p ε w) |>.max' <| by
+def maxHℚ {ι : Type} [Fintype ι] [ne : Nonempty ι]
+    (p : Pose) (poly : ApproxGoodPoly ι) (ε : ℝ) (w : ℝ²) : ℝ :=
+  Finset.image (Hℚ p ε w ∘ poly.vertices.v) Finset.univ  |>.max' <| by
     simp only [Finset.image_nonempty]
-    exact poly.nonempty
+    exact Finset.univ_nonempty_iff.mpr ne
 
 /--
 A compact way of saying "the pose satisfies the rational global theorem precondition at width ε".
@@ -39,10 +41,11 @@ We require the existence of some inner-shadow vertex S from the polyhedron, and 
 the direction we're projecting ℝ² → ℝ to find that S "sticks out too far" compared to all the
 other outer-shadow vertices P (which the calculation of H iterates over) in the polygon that lies in ℝ².
 -/
-structure RationalGlobalTheoremPrecondition (poly : GoodPoly) (poly_ : ApproxGoodPoly)
+structure RationalGlobalTheoremPrecondition {ι : Type} [Fintype ι] [Nonempty ι]
+    (poly : GoodPoly ι) (poly_ : ApproxGoodPoly ι)
     (happrox : κApproxPoly poly.vertices poly_.vertices) (p : Pose) (ε : ℝ) : Type where
   S : ℝ³
-  S_in_poly : S ∈ poly_.vertices
+  S_in_poly : S ∈ Set.range poly_.vertices.v
   p_in_4 : fourInterval.contains p
   w : ℝ²
   w_unit : ‖w‖ = 1
@@ -127,34 +130,40 @@ private lemma H_le_Hℚ {pbar : Pose} {ε : ℝ} (hε : 0 ≤ ε)
 /--
 [SY25] Theorem 43
 -/
-theorem rational_global (pbar : Pose) (ε : ℝ) (hε : 0 ≤ ε)
-    (poly : GoodPoly) (poly_ : ApproxGoodPoly)
+theorem rational_global {ι : Type} [Fintype ι] [Nonempty ι]
+    (pbar : Pose) (ε : ℝ) (hε : 0 ≤ ε)
+    (poly : GoodPoly ι) (poly_ : ApproxGoodPoly ι)
     (happrox : κApproxPoly poly.vertices poly_.vertices)
     (_poly_pointsym : PointSym poly.hull)
     (pc : RationalGlobalTheoremPrecondition poly poly_ happrox pbar ε) :
     ¬ ∃ p ∈ pbar.closed_ball ε, RupertPose p poly.hull := by
-  -- Step 1: Map S from poly_ to poly
-  let S_real := happrox.bijection.symm ⟨pc.S, pc.S_in_poly⟩
-  have hS_in : (S_real : ℝ³) ∈ poly.vertices := S_real.property
-  have hS_approx : ‖(S_real : ℝ³) - pc.S‖ ≤ κ := by
-    simpa [S_real, Equiv.apply_symm_apply] using happrox.approx S_real
-  have hS_norm : ‖(S_real : ℝ³)‖ ≤ 1 := poly.vertex_radius_le_one _ hS_in
+  -- Step 1: Map S from poly_ to poly via the bijection
+  obtain ⟨j, hj⟩ := pc.S_in_poly  -- j : ι, hj : poly_.vertices.v j = pc.S
+  let i := happrox.bijection.symm j
+  let S_real := poly.vertices.v i
+  have hS_in : S_real ∈ Set.range poly.vertices.v := ⟨i, rfl⟩
+  have hS_approx : ‖S_real - pc.S‖ ≤ κ := by
+    rw [← hj]; show ‖poly.vertices.v (happrox.bijection.symm j) - poly_.vertices.v j‖ ≤ κ
+    have := happrox.approx (happrox.bijection.symm j)
+    rwa [Equiv.apply_symm_apply] at this
+  have hS_norm : ‖S_real‖ ≤ 1 := poly.vertex_radius_le_one i
   -- Step 2: Show maxH_real ≤ maxHℚ
   have h_maxH_le : GlobalTheorem.maxH pbar poly ε pc.w ≤ maxHℚ pbar poly_ ε pc.w := by
     unfold GlobalTheorem.maxH maxHℚ
     apply Finset.max'_le
-    intro _ hh_real
-    rcases Finset.mem_image.mp hh_real with ⟨P, hP_mem, rfl⟩
-    -- Map P to P_
-    let P_ := happrox.bijection ⟨P, hP_mem⟩
-    have hP_norm : ‖P‖ ≤ 1 := poly.vertex_radius_le_one P hP_mem
-    have hP_approx : ‖P - (P_ : ℝ³)‖ ≤ κ := by simpa [P_] using happrox.approx ⟨P, hP_mem⟩
-    calc GlobalTheorem.H pbar ε pc.w P
-      _ ≤ Hℚ pbar ε pc.w P_ := H_le_Hℚ hε hP_norm hP_approx pc.w_unit pc.p_in_4
-      _ ≤ (poly_.vertices.image (Hℚ pbar ε pc.w)).max' _ := by
-          apply Finset.le_max'
-          exact Finset.mem_image_of_mem _ P_.property
-  -- Step 4: Build the precondition and apply global_theorem
+    simp only [Function.comp, Finset.mem_image, Finset.mem_univ, true_and]
+    rintro _ ⟨k, rfl⟩
+    -- Map vertex k to approximate vertex
+    let k' := happrox.bijection k
+    have hk_norm : ‖poly.vertices.v k‖ ≤ 1 := poly.vertex_radius_le_one k
+    have hk_approx : ‖poly.vertices.v k - poly_.vertices.v k'‖ ≤ κ := happrox.approx k
+    calc GlobalTheorem.H pbar ε pc.w (poly.vertices.v k)
+      _ ≤ Hℚ pbar ε pc.w (poly_.vertices.v k') :=
+          H_le_Hℚ hε hk_norm hk_approx pc.w_unit pc.p_in_4
+      _ ≤ _ := by
+          show (Hℚ pbar ε pc.w ∘ poly_.vertices.v) k' ≤ _
+          exact Finset.le_max' _ _ (Finset.mem_image_of_mem _ (Finset.mem_univ k'))
+  -- Step 3: Build the precondition and apply global_theorem
   exact GlobalTheorem.global_theorem pbar ε hε poly _poly_pointsym {
     S := S_real
     S_in_poly := hS_in

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -25,9 +25,10 @@ def Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose) (ε : ℝ) (su : UpperSqrt) : ℝ
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
 -/
-def Bεℚ (Q : Triangle) (poly : Finset Euc(3)) (p : Pose) (ε δ r : ℝ) (su : UpperSqrt) : Prop :=
-  ∀ i : Fin 3, ∀ v ∈ poly, v ≠ Q i →
-    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q i) v p ε su
+def Bεℚ {ι : Type} [Fintype ι] (Q_ : Triangle) (Qi : Fin 3 → ι)
+    (v_ : ι → Euc(3)) (p : Pose) (ε δ r : ℝ) (su : UpperSqrt) : Prop :=
+  ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
+    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε su
 
 end Local.Triangle
 
@@ -68,9 +69,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (ae₁ : (transportTri Pi hpoly).Aεℚ p_.vecX₁ℚ ε) (ae₂ : (transportTri Qi hpoly).Aεℚ p_.vecX₂ℚ ε)
     (span₁ : (transportTri Pi hpoly).κSpanning p_.θ₁ p_.φ₁ ε)
     (span₂ : (transportTri Qi hpoly).κSpanning p_.θ₂ p_.φ₂ ε)
-    (be : ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
-        (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs ((transportTri Qi hpoly) i)
-          (poly_.vertices.v (hpoly.bijection k)) p_ ε su)
+    (be : (transportTri Qi hpoly).Bεℚ Qi
+          (fun k => poly_.vertices.v (hpoly.bijection k)) p_ ε δ r su)
     : ¬∃ p ∈ p_.closed_ball ε, RupertPose p poly.hull := by
   -- Define the triangles from indices
   let P : Triangle := fun i => poly.vertices.v (Pi i)

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -34,54 +34,65 @@ end Local.Triangle
 namespace RationalApprox.LocalTheorem
 
 /--
-If we have a triangle `P` in `poly`, yield the corresponding
-triangle in `poly_` which κ-approximates P.
+If we have indices `Pi` for a triangle in `poly`, yield the corresponding
+triangle in `poly_` which κ-approximates it.
 -/
-def transportTri {poly : GoodPoly} {poly_ : ApproxGoodPoly} {P : Triangle}
-    (hP : ∀ i, P i ∈ poly.vertices)
-    (hpoly : κApproxPoly poly.vertices poly_.vertices) : Triangle :=
-  fun i => hpoly.bijection ⟨P i, hP i⟩
+def transportTri {ι : Type} [Fintype ι]
+    {A : IndexedVertices ι} {B : IndexedVertices ι}
+    (Pi : Fin 3 → ι)
+    (hpoly : κApproxPoly A B) : Triangle :=
+  fun i => B.v (hpoly.bijection (Pi i))
 
 /-- The condition on δ -/
-def BoundDeltaℚ (δ : ℝ) (p : Pose) (P Q : Triangle) (su : UpperSqrt) : Prop :=
-  ∀ i : Fin 3, δ ≥ su.norm (p.rotR (p.rotM₁ℚ (P i)) - p.rotM₂ℚ (Q i))/2 + 3 * κ
+def BoundDeltaℚ (δ : ℝ) (p : Pose) (P_ Q_ : Triangle) (su : UpperSqrt) : Prop :=
+  ∀ i : Fin 3, δ ≥ su.norm (p.rotR (p.rotM₁ℚ (P_ i)) - p.rotM₂ℚ (Q_ i))/2 + 3 * κ
 
 /-- The condition on r -/
-def BoundRℚ (r ε : ℝ) (p : Pose) (Q : Triangle) (sl : LowerSqrt) : Prop :=
-  ∀ i : Fin 3, sl.norm (p.rotM₂ℚ (Q i)) > r + √2 * ε + 3 * κ
+def BoundRℚ (r ε : ℝ) (p : Pose) (Q_ : Triangle) (sl : LowerSqrt) : Prop :=
+  ∀ i : Fin 3, sl.norm (p.rotM₂ℚ (Q_ i)) > r + √2 * ε + 3 * κ
 
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"
 -/
-theorem rational_local (poly : GoodPoly) (poly_ : ApproxGoodPoly)
+theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
+    (poly : GoodPoly ι) (poly_ : ApproxGoodPoly ι)
     (hpoly : κApproxPoly poly.vertices poly_.vertices)
-    (P Q : Triangle)
-    (cong_tri : P.Congruent Q)
-    (hP : ∀ i, P i ∈ poly.vertices) (hQ : ∀ i, Q i ∈ poly.vertices)
+    (Pi Qi : Fin 3 → ι)
+    (cong_tri : Triangle.Congruent (fun i => poly.vertices.v (Pi i))
+                (fun i => poly.vertices.v (Qi i)))
     (p_ : Pose) (hp : fourInterval.contains p_)
     (ε δ r : ℝ) (hε : 0 < ε) (hr : 0 < r)
     (su : UpperSqrt) (sl : LowerSqrt)
-    (hr₁ : BoundRℚ r ε p_ (transportTri hQ hpoly) sl)
-    (hδ : BoundDeltaℚ δ p_ (transportTri hP hpoly) (transportTri hQ hpoly) su)
-    (ae₁ : (transportTri hP hpoly).Aεℚ p_.vecX₁ℚ ε) (ae₂ : (transportTri hQ hpoly).Aεℚ p_.vecX₂ℚ ε)
-    (span₁ : (transportTri hP hpoly).κSpanning p_.θ₁ p_.φ₁ ε)
-    (span₂ : (transportTri hQ hpoly).κSpanning p_.θ₂ p_.φ₂ ε)
-    (be : (transportTri hQ hpoly).Bεℚ poly_.vertices p_ ε δ r su)
+    (hr₁ : BoundRℚ r ε p_ (transportTri Qi hpoly) sl)
+    (hδ : BoundDeltaℚ δ p_ (transportTri Pi hpoly) (transportTri Qi hpoly) su)
+    (ae₁ : (transportTri Pi hpoly).Aεℚ p_.vecX₁ℚ ε) (ae₂ : (transportTri Qi hpoly).Aεℚ p_.vecX₂ℚ ε)
+    (span₁ : (transportTri Pi hpoly).κSpanning p_.θ₁ p_.φ₁ ε)
+    (span₂ : (transportTri Qi hpoly).κSpanning p_.θ₂ p_.φ₂ ε)
+    (be : ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
+        (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs ((transportTri Qi hpoly) i)
+          (poly_.vertices.v (hpoly.bijection k)) p_ ε su)
     : ¬∃ p ∈ p_.closed_ball ε, RupertPose p poly.hull := by
+  -- Define the triangles from indices
+  let P : Triangle := fun i => poly.vertices.v (Pi i)
+  let Q : Triangle := fun i => poly.vertices.v (Qi i)
   -- Abbreviations for transported triangles
-  set P_ := transportTri hP hpoly
-  set Q_ := transportTri hQ hpoly
+  set P_ := transportTri Pi hpoly
+  set Q_ := transportTri Qi hpoly
+  -- The finset of vertices
+  let verts := Finset.image poly.vertices.v Finset.univ
+  have verts_ne : verts.Nonempty :=
+    Finset.image_nonempty.mpr (Finset.univ_nonempty_iff.mpr ‹_›)
   -- Angle subtypes
   set θ₁ : Set.Icc (-4 : ℝ) 4 := ⟨p_.θ₁, hp.1⟩
   set φ₁ : Set.Icc (-4 : ℝ) 4 := ⟨p_.φ₁, hp.2.2.1⟩
   set θ₂ : Set.Icc (-4 : ℝ) 4 := ⟨p_.θ₂, hp.2.1⟩
   set φ₂ : Set.Icc (-4 : ℝ) 4 := ⟨p_.φ₂, hp.2.2.2.1⟩
   -- Vertex norm bounds
-  have hPnorm (i : Fin 3) : ‖P i‖ ≤ 1 := poly.vertex_radius_le_one _ (hP i)
-  have hQnorm (i : Fin 3) : ‖Q i‖ ≤ 1 := poly.vertex_radius_le_one _ (hQ i)
+  have hPnorm (i : Fin 3) : ‖P i‖ ≤ 1 := poly.vertex_radius_le_one (Pi i)
+  have hQnorm (i : Fin 3) : ‖Q i‖ ≤ 1 := poly.vertex_radius_le_one (Qi i)
   -- Approximation bounds
-  have hPapprox (i : Fin 3) : ‖P i - P_ i‖ ≤ κ := hpoly.approx ⟨P i, hP i⟩
-  have hQapprox (i : Fin 3) : ‖Q i - Q_ i‖ ≤ κ := hpoly.approx ⟨Q i, hQ i⟩
+  have hPapprox (i : Fin 3) : ‖P i - P_ i‖ ≤ κ := hpoly.approx (Pi i)
+  have hQapprox (i : Fin 3) : ‖Q i - Q_ i‖ ≤ κ := hpoly.approx (Qi i)
   -- Bridge: κSpanning → Spanning
   have span₁' : P.Spanning p_.θ₁ p_.φ₁ ε :=
     ek_spanning_imp_e_spanning P P_ (fun i => hPapprox i) hPnorm hp.1 hp.2.2.1 span₁
@@ -175,21 +186,22 @@ theorem rational_local (poly : GoodPoly) (poly_ : ApproxGoodPoly)
     have h6k : 4 * κ + 2 * κ ^ 2 ≤ 6 * κ := by unfold κ; norm_num
     linarith [hsu]
   -- Bridge: Bεℚ → Bε
-  have be' : Q.Bε poly.vertices p_ ε δ r := by
+  have hP_mem (i : Fin 3) : P i ∈ verts := Finset.mem_image.mpr ⟨Pi i, Finset.mem_univ _, rfl⟩
+  have hQ_mem (i : Fin 3) : Q i ∈ verts := Finset.mem_image.mpr ⟨Qi i, Finset.mem_univ _, rfl⟩
+  have be' : Q.Bε verts p_ ε δ r := by
     intro i v hv hne
     -- Map v to v_ in poly_
-    let bij_v := hpoly.bijection ⟨v, hv⟩
-    have hv_ : (bij_v : ℝ³) ∈ poly_.vertices := bij_v.property
-    have hne_ : (bij_v : ℝ³) ≠ Q_ i := by
-      intro h; apply hne
-      have h1 : bij_v = hpoly.bijection ⟨Q i, hQ i⟩ := Subtype.coe_injective h
-      exact congr_arg Subtype.val (hpoly.bijection.injective h1)
-    have hvapprox : ‖v - (bij_v : ℝ³)‖ ≤ κ := hpoly.approx ⟨v, hv⟩
-    have hvnorm : ‖v‖ ≤ 1 := poly.vertex_radius_le_one v hv
-    set v_ : ℝ³ := (bij_v : ℝ³)
+    simp only [verts, Finset.mem_image, Finset.mem_univ, true_and] at hv
+    obtain ⟨k, rfl⟩ := hv
+    -- v is poly.vertices.v k; map to poly_.vertices.v (bijection k)
+    let k' := hpoly.bijection k
+    set v_ : ℝ³ := poly_.vertices.v k'
+    have hvapprox : ‖poly.vertices.v k - v_‖ ≤ κ := hpoly.approx k
+    have hvnorm : ‖poly.vertices.v k‖ ≤ 1 := poly.vertex_radius_le_one k
     -- Get the Bεℚ hypothesis
-    have hbe := be i v_ hv_ hne_
-    show (δ + √5 * ε) / r < Local.Triangle.Bε.lhs (Q i) v p_ ε
+    have hne_k : k ≠ Qi i := fun h => hne (congr_arg poly.vertices.v h)
+    have hbe := be i k hne_k
+    show (δ + √5 * ε) / r < Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
     have hsu_ge : su.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le su _
@@ -220,28 +232,28 @@ theorem rational_local (poly : GoodPoly) (poly_ : ApproxGoodPoly)
         · positivity
       linarith [hBεℚ_num_pos]
     -- From inner_product_bound_10kappa: |innerA - innerAℚ| ≤ 10κ
-    have hQv_norm : ‖Q i - v‖ ≤ 2 := calc
-      ‖Q i - v‖ ≤ ‖Q i‖ + ‖v‖ := norm_sub_le _ _
+    have hQv_norm : ‖Q i - poly.vertices.v k‖ ≤ 2 := calc
+      ‖Q i - poly.vertices.v k‖ ≤ ‖Q i‖ + ‖poly.vertices.v k‖ := norm_sub_le _ _
       _ ≤ 1 + 1 := add_le_add (hQnorm i) hvnorm
       _ = 2 := by ring
-    have hQv_approx : ‖(Q i - v) - (Q_ i - v_)‖ ≤ 2 * κ := calc
-      ‖(Q i - v) - (Q_ i - v_)‖ = ‖(Q i - Q_ i) - (v - v_)‖ := by congr 1; abel
-      _ ≤ ‖Q i - Q_ i‖ + ‖v - v_‖ := norm_sub_le _ _
+    have hQv_approx : ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖ ≤ 2 * κ := calc
+      ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖ = ‖(Q i - Q_ i) - (poly.vertices.v k - v_)‖ := by congr 1; abel
+      _ ≤ ‖Q i - Q_ i‖ + ‖poly.vertices.v k - v_‖ := norm_sub_le _ _
       _ ≤ κ + κ := add_le_add (hQapprox i) hvapprox
       _ = 2 * κ := by ring
-    have h_inner_10 : |⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - v)⟫ -
+    have h_inner_10 : |⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ -
         ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫| ≤ 10 * κ :=
       inner_product_bound_10kappa (θ := θ₂) (φ := φ₂) (hQnorm i) hQv_norm (hQapprox i) hQv_approx
-    have h_norm_QR : ‖Q i - v‖ ≤ ‖Q_ i - v_‖ + 2 * κ :=
-      calc ‖Q i - v‖
-        _ ≤ ‖Q_ i - v_‖ + ‖(Q i - v) - (Q_ i - v_)‖ := norm_le_insert' _ _
+    have h_norm_QR : ‖Q i - poly.vertices.v k‖ ≤ ‖Q_ i - v_‖ + 2 * κ :=
+      calc ‖Q i - poly.vertices.v k‖
+        _ ≤ ‖Q_ i - v_‖ + ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖ := norm_le_insert' _ _
         _ ≤ ‖Q_ i - v_‖ + 2 * κ := by grw [hQv_approx]
-    have hA_nonneg : 0 ≤ ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - v)⟫ -
-        2 * ε * ‖Q i - v‖ * (√2 + ε) := by
+    have hA_nonneg : 0 ≤ ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ -
+        2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) := by
       have h_inner_le : ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ ≤
-          ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - v)⟫ :=
+          ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ :=
         sub_le_of_abs_sub_le_left h_inner_10
-      have h_eps_term : 2 * ε * ‖Q i - v‖ * (√2 + ε) ≤
+      have h_eps_term : 2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) ≤
           2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
         apply mul_le_mul_of_nonneg_right
         · exact mul_le_mul_of_nonneg_left h_norm_QR (by linarith)
@@ -249,8 +261,8 @@ theorem rational_local (poly : GoodPoly) (poly_ : ApproxGoodPoly)
       linarith [hAℚ_num_pos]
     -- Apply bounds_kappa4 (note: P Q P_ Q_ θ φ are explicit in bounds_kappa4)
     have hbk4 : bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su ≤
-        bounds_kappa4_A (Q i) v θ₂ φ₂ ε :=
-      bounds_kappa4 (Q i) v (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hε su hA_nonneg
+        bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε :=
+      bounds_kappa4 (Q i) (poly.vertices.v k) (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hε su hA_nonneg
     -- Bεℚ.lhs ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ in numerator, denominators def. equal)
     have hBεℚ_le : Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε su ≤
         bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su := by
@@ -271,12 +283,26 @@ theorem rational_local (poly : GoodPoly) (poly_ : ApproxGoodPoly)
         · positivity
       grw [h_sub_le]
     -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
-    have hA_eq : bounds_kappa4_A (Q i) v θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) v p_ ε := rfl
+    have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
     -- Combine
     calc (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε su := hbe
       _ ≤ bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su := hBεℚ_le
-      _ ≤ bounds_kappa4_A (Q i) v θ₂ φ₂ ε := hbk4
-      _ = Local.Triangle.Bε.lhs (Q i) v p_ ε := hA_eq
+      _ ≤ bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := hbk4
+      _ = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := hA_eq
   -- Apply local_theorem
-  exact Local.local_theorem P Q cong_tri poly.vertices poly.nonempty hP hQ
-    poly.radius_eq_one p_ ε δ r hε hr hr₁' hδ' ae₁' ae₂' span₁' span₂' be'
+  -- Need to convert hull: poly.hull = (Local.shape_of verts).hull
+  have hull_eq : (Local.shape_of verts).hull = poly.hull := by
+    simp only [Local.shape_of, Shape.hull, GoodPoly.hull, verts]
+    congr 1; ext x; simp [Set.mem_range]
+  have radius_eq : polyhedronRadius verts verts_ne = 1 := by
+    rw [polyhedron_radius_iff]
+    constructor
+    · obtain ⟨i, hi⟩ := (indexed_vertices_radius_iff poly.vertices).mp poly.radius_eq_one |>.1
+      exact ⟨poly.vertices.v i, Finset.mem_image.mpr ⟨i, Finset.mem_univ _, rfl⟩, hi⟩
+    · intro v hv
+      simp only [verts, Finset.mem_image, Finset.mem_univ, true_and] at hv
+      obtain ⟨k, rfl⟩ := hv
+      exact poly.vertex_radius_le_one k
+  rw [← hull_eq]
+  exact Local.local_theorem P Q cong_tri verts verts_ne hP_mem hQ_mem
+    radius_eq p_ ε δ r hε hr hr₁' hδ' ae₁' ae₂' span₁' span₂' be'

--- a/Noperthedron/SolutionTable/Global.lean
+++ b/Noperthedron/SolutionTable/Global.lean
@@ -1,3 +1,4 @@
+import Noperthedron.Checker.KappaApprox
 import Noperthedron.RationalApprox.RationalGlobal
 import Noperthedron.SolutionTable.Basic
 import Noperthedron.Vertices.Exact
@@ -13,5 +14,6 @@ theorem valid_global_imp_no_rupert (tab : Table) (row : Row)
   have hε : 0 ≤ ε := by sorry
   rintro ⟨q, hqi, hqr⟩
   have hq := q ∈ pbar.closed_ball ε
-  have := RationalApprox.GlobalTheorem.rational_global pbar ε hε
+  have := RationalApprox.GlobalTheorem.rational_global
+            pbar ε hε exactPoly pythonPoly KappaApprox.exact_κApprox_python
   sorry

--- a/Noperthedron/Tightening.lean
+++ b/Noperthedron/Tightening.lean
@@ -30,14 +30,14 @@ lemma rotR_add_pi_eq_if_pointsym {α : ℝ} (X : Set ℝ²) (hX : PointSym X) :
   rw [this, Set.image_comp]
   exact neg_image_eq_if_pointsym (rotR α '' X) (rotR_preserves_pointsymmetry X hX)
 
-lemma rotation_preserves_nopert_vertices (x : ℝ³) (hx : x ∈ exactPoly.vertices) (k : ℤ) :
-    RzC (2 * π * k / 15) x ∈ exactPoly.vertices := by
-  simp only [exactPoly, exactVerts, exactVertex,
+lemma rotation_preserves_nopert_vertices (x : ℝ³) (hx : x ∈ exactVerts) (k : ℤ) :
+    RzC (2 * π * k / 15) x ∈ exactVerts := by
+  simp only [exactVerts, exactVertex,
     Finset.mem_image, Finset.mem_univ, true_and] at hx
   obtain ⟨⟨k, ℓ, i⟩, hb⟩ := hx
   rename_i K
   subst hb
-  simp only [exactPoly, exactVerts, exactVertex, Finset.mem_image, Finset.mem_univ, true_and]
+  simp only [exactVerts, exactVertex, Finset.mem_image, Finset.mem_univ, true_and]
   rw [ContinuousLinearMap.map_smul_of_tower]
   simp only [← RzC_coe, ← ContinuousLinearMap.mul_apply, ← AddChar.map_add_eq_mul RzC]
   refine ⟨⟨⟨(((↑↑k : ℤ) + K) % 15).toNat, by omega⟩, ℓ, i⟩, ?_⟩

--- a/Noperthedron/Vertices/Exact.lean
+++ b/Noperthedron/Vertices/Exact.lean
@@ -141,11 +141,19 @@ theorem exactVerts_radius_one : polyhedronRadius exactVerts exactVerts_nonempty 
     exact exactVertex_norm_le_one _
 
 noncomputable
-def exactPoly : GoodPoly := {
-  vertices := exactVerts,
-  nonempty := exactVerts_nonempty,
-  nontriv := exactVerts_nontriv,
-  radius_eq_one := exactVerts_radius_one
+def exactPoly : GoodPoly VertexIndex := {
+  vertices := ⟨exactVertex⟩,
+  nontriv := by
+    rintro j
+    refine exactVerts_nontriv _ ?_
+    simp [exactVerts]
+  radius_eq_one := by
+    rw [indexed_vertices_radius_iff]
+    constructor
+    · use ⟨0, 0, 0⟩
+      simp [exactVertex, exactVertex, Cpt, Bounding.Rz_preserves_norm, Nopert.c1_norm_one]
+    · intro j
+      exact exactVertex_norm_le_one j
 }
 
 theorem exactVerts_pointsym : PointSym exactVertSet := by

--- a/Noperthedron/Vertices/Index.lean
+++ b/Noperthedron/Vertices/Index.lean
@@ -9,7 +9,7 @@ structure VertexIndex : Type where
   k : Fin 15
   ℓ : Fin 2
   i : Fin 3
-deriving Fintype, DecidableEq, Repr
+deriving Fintype, DecidableEq, Repr, Nonempty
 
 def VertexIndex.ofFin90 (j : Fin 90) : VertexIndex :=
  ⟨⟨j.val % 15, by omega⟩, ⟨j.val / 45, by omega⟩, ⟨(j.val % 45) / 15, by omega⟩⟩

--- a/Noperthedron/Vertices/Python.lean
+++ b/Noperthedron/Vertices/Python.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Rat.Defs
 
+import Noperthedron.Basic
 import Noperthedron.Vertices.Index
 
 namespace Noperthedron
@@ -112,3 +113,15 @@ def pythonVertexCurried : Fin 2 → Fin 3 → Fin 15 → Fin 3 → ℚ := ![
 ]
 
 def pythonVertex (idx : VertexIndex) : Fin 3 → ℚ := pythonVertexCurried idx.ℓ idx.i idx.k
+
+/-- Cast a `Fin 3 → ℚ` to an `ℝ³` point. -/
+noncomputable def toR3 (v : Fin 3 → ℚ) : ℝ³ :=
+  WithLp.toLp 2 (fun i => (v i : ℝ))
+
+noncomputable
+def pythonPoly : ApproxGoodPoly VertexIndex := {
+  vertices := ⟨toR3 ∘ pythonVertex⟩,
+  nontriv := by
+    intro j
+    sorry
+}


### PR DESCRIPTION
This gives us `exact_κApprox_python`, which makes it so we can actually apply the rational global theorem in `SolutionTable/Global.lean`.