### PR TITLE
add type parameter to Polyhedron, so we can have rational polyhedra

### DIFF
--- a/Noperthedron/Basic.lean
+++ b/Noperthedron/Basic.lean
@@ -364,19 +364,27 @@ lemma rotM_periodic_φ {θ φ : ℝ} {k : ℤ} :
   · simp [rotM, rotM_mat]
 
 /-- A convex polyhedron, given as a finite indexed set of vertices. -/
-structure Polyhedron (ι : Type) [Fintype ι] where
-  v : ι → ℝ³
+structure Polyhedron (ι X : Type) where
+  v : ι → X
 
-def Polyhedron.hull {ι : Type} [Fintype ι] (poly : Polyhedron ι) : Set ℝ³ :=
+/-- Cast a `Fin 3 → ℚ` to an `ℝ³` point. -/
+noncomputable def toR3 (v : Fin 3 → ℚ) : ℝ³ :=
+  WithLp.toLp 2 (fun i => (v i : ℝ))
+
+noncomputable
+def Polyhedron.toReal {ι : Type} (p : Polyhedron ι (Fin 3 → ℚ)) : Polyhedron ι ℝ³ :=
+  ⟨fun j => toR3 (p.v j)⟩
+
+def Polyhedron.hull {ι : Type} [Fintype ι] (poly : Polyhedron ι ℝ³) : Set ℝ³ :=
   convexHull ℝ { poly.v i | i }
 
 noncomputable
-def Polyhedron.radius {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Polyhedron ι) : ℝ :=
+def Polyhedron.radius {ι X : Type} [Fintype ι] [ne : Nonempty ι] [Norm X] (p : Polyhedron ι X) : ℝ :=
   (Finset.image (fun x ↦ ‖p.v x‖) Finset.univ).max'
     (by rw [Finset.image_nonempty]; exact Finset.univ_nonempty_iff.mpr ne)
 
-theorem Polyhedron.radius_iff {r : ℝ} {ι : Type} [Fintype ι] [ne : Nonempty ι]
-    (iv : Polyhedron ι) :
+theorem Polyhedron.radius_iff {r : ℝ} {ι X : Type} [Fintype ι] [ne : Nonempty ι] [Norm X]
+    (iv : Polyhedron ι X) :
     iv.radius = r ↔ (∃ i, ‖iv.v i‖ = r) ∧ ∀ i, ‖iv.v i‖ ≤ r := by
   constructor
   · intro h
@@ -386,7 +394,7 @@ theorem Polyhedron.radius_iff {r : ℝ} {ι : Type} [Fintype ι] [ne : Nonempty 
     simpa [Polyhedron.radius, Finset.max'_eq_iff]
 
 structure GoodPoly (ι : Type) [Fintype ι] [Nonempty ι] where
-  vertices : Polyhedron ι
+  vertices : Polyhedron ι ℝ³
   nontriv : ∀ i, 0 < ‖vertices.v i‖
   radius_eq_one : vertices.radius = 1
 

--- a/Noperthedron/Checker/Agreement.lean
+++ b/Noperthedron/Checker/Agreement.lean
@@ -195,10 +195,10 @@ theorem computeGQ_eq_Gℚ (θ₁ φ₁ α ε : ℚ) (S : Fin 3 → ℚ) (w : Fin
     ((computeGQ θ₁ φ₁ α ε S w : ℚ) : ℝ) =
     Gℚ p (ε : ℝ) (WithLp.toLp 2 (castℝ S)) (WithLp.toLp 2 (castℝ w)) := by
   unfold computeGQ Gℚ
-  simp only [Pose.innerℚ, Pose.rotRℚ, Pose.rotR'ℚ,
-             Pose.rotM₁ℚ, Pose.rotM₁θℚ, Pose.rotM₁φℚ,
-             RationalApprox.rotRℚ, RationalApprox.rotR'ℚ,
-             RationalApprox.rotMℚ, RationalApprox.rotMθℚ, RationalApprox.rotMφℚ,
+  simp only [Pose.innerℚℝ, Pose.rotRℚℝ, Pose.rotR'ℚℝ,
+             Pose.rotM₁ℚℝ, Pose.rotM₁θℚℝ, Pose.rotM₁φℚℝ,
+             RationalApprox.rotRℚℝ, RationalApprox.rotR'ℚℝ,
+             RationalApprox.rotMℚℝ, RationalApprox.rotMθℚℝ, RationalApprox.rotMφℚℝ,
              ContinuousLinearMap.comp_apply]
   rw [← hθ₁, ← hφ₁, ← hα]
   rw [inner_RM_eq, inner_R'M_eq, inner_RMθ_eq, inner_RMφ_eq]
@@ -210,8 +210,8 @@ theorem computeHQ_eq_Hℚ (θ₂ φ₂ ε : ℚ) (w : Fin 2 → ℚ) (P : Fin 3 
     ((computeHQ θ₂ φ₂ ε w P : ℚ) : ℝ) =
     Hℚ p (ε : ℝ) (WithLp.toLp 2 (castℝ w)) (WithLp.toLp 2 (castℝ P)) := by
   unfold computeHQ Hℚ
-  simp only [Pose.rotM₂ℚ, Pose.rotM₂θℚ, Pose.rotM₂φℚ,
-             RationalApprox.rotMℚ, RationalApprox.rotMθℚ, RationalApprox.rotMφℚ]
+  simp only [Pose.rotM₂ℚℝ, Pose.rotM₂θℚℝ, Pose.rotM₂φℚℝ,
+             RationalApprox.rotMℚℝ, RationalApprox.rotMθℚℝ, RationalApprox.rotMφℚℝ]
   rw [← hθ₂, ← hφ₂]
   rw [inner_M_eq, inner_Mθ_eq, inner_Mφ_eq]
   push_cast [κQ_cast]

--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -83,7 +83,8 @@ def H (p : Pose ℝ) (ε : ℝ) (w : ℝ²) (P : ℝ³) : ℝ :=
 A measure of how far all of the outer-shadow vertices can "reach" along w.
 -/
 noncomputable
-def maxH {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Pose ℝ) (poly : GoodPoly ι) (ε : ℝ) (w : ℝ²) : ℝ :=
+def maxH {ι : Type} [Fintype ι] [ne : Nonempty ι]
+    (p : Pose ℝ) (poly : GoodPoly ι) (ε : ℝ) (w : ℝ²) : ℝ :=
   Finset.image (H p ε w ∘ poly.vertices.v) Finset.univ |>.max' <| by
     simp only [Finset.image_nonempty]
     exact Finset.univ_nonempty_iff.mpr ne
@@ -132,7 +133,8 @@ def imgInner (p : Pose ℝ) (V : Finset ℝ³) (w : ℝ²) : Finset ℝ :=
   V.image fun P => ⟪w, p.inner P⟫
 
 noncomputable
-def maxInner {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Pose ℝ) (poly : GoodPoly ι) (w : ℝ²) : ℝ :=
+def maxInner {ι : Type} [Fintype ι] [ne : Nonempty ι]
+    (p : Pose ℝ) (poly : GoodPoly ι) (w : ℝ²) : ℝ :=
   (imgInner p (Finset.image poly.vertices.v Finset.univ) w).max' (by
     simp only [imgInner, Finset.image_nonempty, Finset.univ_nonempty_iff]; exact ne)
 
@@ -141,7 +143,8 @@ def imgOuter (p : Pose ℝ) (V : Finset ℝ³) (w : ℝ²) : Finset ℝ :=
   V.image fun P => ⟪w, p.outer P⟫
 
 noncomputable
-def maxOuter {ι : Type} [Fintype ι] [ne : Nonempty ι] (p : Pose ℝ) (poly : GoodPoly ι) (w : ℝ²) : ℝ :=
+def maxOuter {ι : Type} [Fintype ι] [ne : Nonempty ι]
+    (p : Pose ℝ) (poly : GoodPoly ι) (w : ℝ²) : ℝ :=
   (imgOuter p (Finset.image poly.vertices.v Finset.univ) w).max' (by
     simp only [imgOuter, Finset.image_nonempty, Finset.univ_nonempty_iff]; exact ne)
 
@@ -199,8 +202,7 @@ It always returns a unit vector.
 -/
 noncomputable
 def GlobalTheoremPrecondition.fu {pbar : Pose ℝ} {ε : ℝ} {ι : Type} [Fintype ι] [Nonempty ι]
-    {poly : GoodPoly ι}
-    (pc : GlobalTheoremPrecondition poly pbar ε) : ℝ³ → ℝ :=
+    {poly : GoodPoly ι} (pc : GlobalTheoremPrecondition poly pbar ε) : ℝ³ → ℝ :=
   rotproj_inner_unit pc.S pc.w
 
 /--

--- a/Noperthedron/RationalApprox/Basic.lean
+++ b/Noperthedron/RationalApprox/Basic.lean
@@ -92,46 +92,46 @@ These are merely linear instead of continuous-linear because
 .toContinuousLinearMap only works on Cauchy-complete spaces.
 -/
 noncomputable
-def rotMℚ (θ φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+def rotMℚℝ (θ φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
   rotMℚ_mat θ φ |>.toEuclideanLin.toContinuousLinearMap
 
 noncomputable
-def rotMθℚ (θ φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+def rotMθℚℝ (θ φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
   rotMθℚ_mat θ φ |>.toEuclideanLin.toContinuousLinearMap
 
 noncomputable
-def rotMφℚ (θ φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+def rotMφℚℝ (θ φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
   rotMφℚ_mat θ φ |>.toEuclideanLin.toContinuousLinearMap
 
 noncomputable
-def rotRℚ (α : ℝ) : ℝ² →L[ℝ] ℝ² :=
+def rotRℚℝ (α : ℝ) : ℝ² →L[ℝ] ℝ² :=
   rotRℚ_mat α |>.toEuclideanLin.toContinuousLinearMap
 
 noncomputable
-def rotR'ℚ (α : ℝ) : ℝ² →L[ℝ] ℝ² :=
+def rotR'ℚℝ (α : ℝ) : ℝ² →L[ℝ] ℝ² :=
   rotR'ℚ_mat α |>.toEuclideanLin.toContinuousLinearMap
 
 noncomputable
-def vecXLℚ (θ φ : ℝ) : Euc(1) →L[ℝ] ℝ³ :=
+def vecXLℚℝ (θ φ : ℝ) : Euc(1) →L[ℝ] ℝ³ :=
   vecXℚ_mat θ φ |>.toEuclideanLin.toContinuousLinearMap
 
 noncomputable
-def vecXℚ (θ : ℝ) (φ : ℝ) : ℝ³ :=
+def vecXℚℝ (θ : ℝ) (φ : ℝ) : ℝ³ :=
   !₂[ cosℚ θ * sinℚ φ, sinℚ θ * sinℚ φ, cosℚ φ ]
 
 noncomputable section
-def _root_.Pose.rotRℚ (p : Pose ℝ) : ℝ² →L[ℝ] ℝ² := _root_.RationalApprox.rotRℚ p.α
-def _root_.Pose.rotR'ℚ (p : Pose ℝ) : ℝ² →L[ℝ] ℝ² := _root_.RationalApprox.rotR'ℚ p.α
-def _root_.Pose.rotM₁ℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMℚ p.θ₁ p.φ₁
-def _root_.Pose.rotM₂ℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMℚ p.θ₂ p.φ₂
-def _root_.Pose.rotM₁θℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMθℚ p.θ₁ p.φ₁
-def _root_.Pose.rotM₂θℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMθℚ p.θ₂ p.φ₂
-def _root_.Pose.rotM₁φℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMφℚ p.θ₁ p.φ₁
-def _root_.Pose.rotM₂φℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMφℚ p.θ₂ p.φ₂
-def _root_.Pose.innerℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := p.rotRℚ ∘L p.rotM₁ℚ
-def _root_.Pose.outerℚ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := p.rotM₂
-def _root_.Pose.vecX₁ℚ (p : Pose ℝ) : ℝ³ := vecXℚ (p.θ₁) (p.φ₁)
-def _root_.Pose.vecX₂ℚ (p : Pose ℝ) : ℝ³ := vecXℚ (p.θ₂) (p.φ₂)
+def _root_.Pose.rotRℚℝ (p : Pose ℝ) : ℝ² →L[ℝ] ℝ² := _root_.RationalApprox.rotRℚℝ p.α
+def _root_.Pose.rotR'ℚℝ (p : Pose ℝ) : ℝ² →L[ℝ] ℝ² := _root_.RationalApprox.rotR'ℚℝ p.α
+def _root_.Pose.rotM₁ℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMℚℝ p.θ₁ p.φ₁
+def _root_.Pose.rotM₂ℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMℚℝ p.θ₂ p.φ₂
+def _root_.Pose.rotM₁θℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMθℚℝ p.θ₁ p.φ₁
+def _root_.Pose.rotM₂θℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMθℚℝ p.θ₂ p.φ₂
+def _root_.Pose.rotM₁φℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMφℚℝ p.θ₁ p.φ₁
+def _root_.Pose.rotM₂φℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := _root_.RationalApprox.rotMφℚℝ p.θ₂ p.φ₂
+def _root_.Pose.innerℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := p.rotRℚℝ ∘L p.rotM₁ℚℝ
+def _root_.Pose.outerℚℝ (p : Pose ℝ) : ℝ³ →L[ℝ] ℝ² := p.rotM₂
+def _root_.Pose.vecX₁ℚℝ (p : Pose ℝ) : ℝ³ := vecXℚℝ (p.θ₁) (p.φ₁)
+def _root_.Pose.vecX₂ℚℝ (p : Pose ℝ) : ℝ³ := vecXℚℝ (p.θ₂) (p.φ₂)
 end
 
 structure UpperSqrt where

--- a/Noperthedron/RationalApprox/Basic.lean
+++ b/Noperthedron/RationalApprox/Basic.lean
@@ -61,7 +61,7 @@ def κApproxPoint {m n : ℕ} (A A' : Matrix (Fin m) (Fin n) ℝ) : Prop :=
   ‖(A - A').toEuclideanLin.toContinuousLinearMap‖ ≤ κ
 
 structure κApproxPoly {ι₁ ι₂ : Type} [Fintype ι₁] [Fintype ι₂]
-    (A : Polyhedron ι₁) (B : Polyhedron ι₂) where
+    (A : Polyhedron ι₁ ℝ³) (B : Polyhedron ι₂ ℝ³) where
   bijection : ι₁ ≃ ι₂
   approx : ∀ a : ι₁, ‖(A.v a : ℝ³) - B.v (bijection a)‖ ≤ κ
 

--- a/Noperthedron/RationalApprox/BoundsKappa.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa.lean
@@ -37,21 +37,21 @@ private lemma inner_three_kappa {E F : Type*}
 -/
 
 lemma bounds_kappa_M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotM θ φ P, w⟫ - ⟪rotMℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
+    ‖⟪rotM θ φ P, w⟫ - ⟪rotMℚℝ θ φ P_, w⟫‖ ≤ 3 * κ :=
   inner_three_kappa
     (Mℚ_norm_bounded (θ.property) (φ.property))
     (M_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 lemma bounds_kappa_Mθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotMθ θ φ P, w⟫ - ⟪rotMθℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
+    ‖⟪rotMθ θ φ P, w⟫ - ⟪rotMθℚℝ θ φ P_, w⟫‖ ≤ 3 * κ :=
   inner_three_kappa
     (Mθℚ_norm_bounded (θ.property) (φ.property))
     (Mθ_difference_norm_bounded _ _ (θ.property) (φ.property))
     hP approx hw
 
 lemma bounds_kappa_Mφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotMφ θ φ P, w⟫ - ⟪rotMφℚ θ φ P_, w⟫‖ ≤ 3 * κ :=
+    ‖⟪rotMφ θ φ P, w⟫ - ⟪rotMφℚℝ θ φ P_, w⟫‖ ≤ 3 * κ :=
   inner_three_kappa
     (Mφℚ_norm_bounded (θ.property) (φ.property))
     (Mφ_difference_norm_bounded _ _ (θ.property) (φ.property))
@@ -93,7 +93,7 @@ private lemma inner_four_kappa {E F G : Type*}
     _ ≤ 4 * κ := by unfold κ; norm_num
 
 lemma bounds_kappa_RM (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR α (rotM θ φ P), w⟫ - ⟪rotRℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+    ‖⟪rotR α (rotM θ φ P), w⟫ - ⟪rotRℚℝ α (rotMℚℝ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
     (R_difference_norm_bounded _ (α.property))
@@ -102,7 +102,7 @@ lemma bounds_kappa_RM (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : 
     hP approx hw
 
 lemma bounds_kappa_R'M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR' α (rotM θ φ P), w⟫ - ⟪rotR'ℚ α (rotMℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+    ‖⟪rotR' α (rotM θ φ P), w⟫ - ⟪rotR'ℚℝ α (rotMℚℝ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR'_norm_one _))
     (R'_difference_norm_bounded _ (α.property))
@@ -111,7 +111,7 @@ lemma bounds_kappa_R'M (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw :
     hP approx hw
 
 lemma bounds_kappa_RMθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR α (rotMθ θ φ P), w⟫ - ⟪rotRℚ α (rotMθℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+    ‖⟪rotR α (rotMθ θ φ P), w⟫ - ⟪rotRℚℝ α (rotMθℚℝ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
     (R_difference_norm_bounded _ (α.property))
@@ -120,7 +120,7 @@ lemma bounds_kappa_RMθ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw 
     hP approx hw
 
 lemma bounds_kappa_RMφ (hP : ‖P‖ ≤ 1) (approx : ‖P - P_‖ ≤ κ) (hw : ‖w‖ = 1) :
-    ‖⟪rotR α (rotMφ θ φ P), w⟫ - ⟪rotRℚ α (rotMφℚ θ φ P_), w⟫‖ ≤ 4 * κ :=
+    ‖⟪rotR α (rotMφ θ φ P), w⟫ - ⟪rotRℚℝ α (rotMφℚℝ θ φ P_), w⟫‖ ≤ 4 * κ :=
   inner_four_kappa
     (le_of_eq (Bounding.rotR_norm_one _))
     (R_difference_norm_bounded _ (α.property))

--- a/Noperthedron/RationalApprox/BoundsKappa3.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa3.lean
@@ -21,26 +21,26 @@ is the image of the unit basis vector under the column-matrix linear map `vecXL`
 
 private lemma vecX_sub_vecXℚ_norm_le (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     (hφ : φ ∈ Set.Icc (-4) 4) :
-    ‖vecX θ φ - vecXℚ θ φ‖ ≤ κ := by
+    ‖vecX θ φ - vecXℚℝ θ φ‖ ≤ κ := by
   -- vecX θ φ - vecXℚ θ φ = (vecXL θ φ - vecXLℚ θ φ) (single 0 1)
-  have h_eq : vecX θ φ - vecXℚ θ φ = (vecXL θ φ - vecXLℚ θ φ) (EuclideanSpace.single 0 1) := by
-    simp [vecX, vecXℚ, vecXL, vecX_mat, vecXLℚ, vecXℚ_mat, ContinuousLinearMap.sub_apply,
+  have h_eq : vecX θ φ - vecXℚℝ θ φ = (vecXL θ φ - vecXLℚℝ θ φ) (EuclideanSpace.single 0 1) := by
+    simp [vecX, vecXℚℝ, vecXL, vecX_mat, vecXLℚℝ, vecXℚ_mat, ContinuousLinearMap.sub_apply,
       Matrix.toLpLin_apply]
     ext i; fin_cases i <;> simp
   rw [h_eq]
-  calc ‖(vecXL θ φ - vecXLℚ θ φ) (EuclideanSpace.single 0 1)‖
-    _ ≤ ‖vecXL θ φ - vecXLℚ θ φ‖ * ‖EuclideanSpace.single (𝕜 := ℝ) 0 (1 : ℝ)‖ :=
+  calc ‖(vecXL θ φ - vecXLℚℝ θ φ) (EuclideanSpace.single 0 1)‖
+    _ ≤ ‖vecXL θ φ - vecXLℚℝ θ φ‖ * ‖EuclideanSpace.single (𝕜 := ℝ) 0 (1 : ℝ)‖ :=
         ContinuousLinearMap.le_opNorm _ _
-    _ = ‖vecXL θ φ - vecXLℚ θ φ‖ * 1 := by rw [PiLp.norm_single, norm_one]
-    _ = ‖vecXL θ φ - vecXLℚ θ φ‖ := mul_one _
+    _ = ‖vecXL θ φ - vecXLℚℝ θ φ‖ * 1 := by rw [PiLp.norm_single, norm_one]
+    _ = ‖vecXL θ φ - vecXLℚℝ θ φ‖ := mul_one _
     _ ≤ κ := X_difference_norm_bounded θ φ hθ hφ
 
 private lemma vecXℚ_norm_le (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     (hφ : φ ∈ Set.Icc (-4) 4) :
-    ‖vecXℚ θ φ‖ ≤ 1 + κ := by
-  calc ‖vecXℚ θ φ‖
-    _ ≤ ‖vecX θ φ‖ + ‖vecX θ φ - vecXℚ θ φ‖ := norm_le_insert _ _
-    _ = 1 + ‖vecX θ φ - vecXℚ θ φ‖ := by rw [vecX_norm_one]
+    ‖vecXℚℝ θ φ‖ ≤ 1 + κ := by
+  calc ‖vecXℚℝ θ φ‖
+    _ ≤ ‖vecX θ φ‖ + ‖vecX θ φ - vecXℚℝ θ φ‖ := norm_le_insert _ _
+    _ = 1 + ‖vecX θ φ - vecXℚℝ θ φ‖ := by rw [vecX_norm_one]
     _ ≤ 1 + κ := by gcongr; exact vecX_sub_vecXℚ_norm_le θ φ hθ hφ
 
 /-!
@@ -48,15 +48,15 @@ private lemma vecXℚ_norm_le (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
 -/
 
 lemma bounds_kappa3_X (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
-    ‖⟪vecX θ φ, P⟫ - ⟪vecXℚ θ φ, P_⟫‖ ≤ 3 * κ := by
+    ‖⟪vecX θ φ, P⟫ - ⟪vecXℚℝ θ φ, P_⟫‖ ≤ 3 * κ := by
   -- Decompose: ⟪vecX, P⟫ - ⟪vecXℚ, P_⟫ = ⟪vecX - vecXℚ, P⟫ + ⟪vecXℚ, P - P_⟫
-  have decomp : ⟪vecX θ φ, P⟫ - ⟪vecXℚ θ φ, P_⟫ =
-      ⟪vecX θ φ - vecXℚ θ φ, P⟫ + ⟪vecXℚ θ φ, P - P_⟫ := by
+  have decomp : ⟪vecX θ φ, P⟫ - ⟪vecXℚℝ θ φ, P_⟫ =
+      ⟪vecX θ φ - vecXℚℝ θ φ, P⟫ + ⟪vecXℚℝ θ φ, P - P_⟫ := by
     simp [inner_sub_left, inner_sub_right]
   rw [decomp, Real.norm_eq_abs]
-  calc |⟪vecX ↑θ ↑φ - vecXℚ ↑θ ↑φ, P⟫ + ⟪vecXℚ ↑θ ↑φ, P - P_⟫|
-    _ ≤ |⟪vecX ↑θ ↑φ - vecXℚ ↑θ ↑φ, P⟫| + |⟪vecXℚ ↑θ ↑φ, P - P_⟫| := abs_add_le _ _
-    _ ≤ ‖vecX ↑θ ↑φ - vecXℚ ↑θ ↑φ‖ * ‖P‖ + ‖vecXℚ ↑θ ↑φ‖ * ‖P - P_‖ :=
+  calc |⟪vecX ↑θ ↑φ - vecXℚℝ ↑θ ↑φ, P⟫ + ⟪vecXℚℝ ↑θ ↑φ, P - P_⟫|
+    _ ≤ |⟪vecX ↑θ ↑φ - vecXℚℝ ↑θ ↑φ, P⟫| + |⟪vecXℚℝ ↑θ ↑φ, P - P_⟫| := abs_add_le _ _
+    _ ≤ ‖vecX ↑θ ↑φ - vecXℚℝ ↑θ ↑φ‖ * ‖P‖ + ‖vecXℚℝ ↑θ ↑φ‖ * ‖P - P_‖ :=
         add_le_add (abs_real_inner_le_norm _ _) (abs_real_inner_le_norm _ _)
     _ ≤ κ * 1 + (1 + κ) * κ :=
         add_le_add
@@ -67,35 +67,35 @@ lemma bounds_kappa3_X (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
     _ ≤ 3 * κ := by unfold κ; norm_num
 
 lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
-    ‖⟪rotM θ φ P, rotM θ φ Q⟫ - ⟪rotMℚ θ φ P_, rotMℚ θ φ Q_⟫‖ ≤ 5 * κ := by
+    ‖⟪rotM θ φ P, rotM θ φ Q⟫ - ⟪rotMℚℝ θ φ P_, rotMℚℝ θ φ Q_⟫‖ ≤ 5 * κ := by
   rw [Real.norm_eq_abs]
-  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
     M_difference_norm_bounded _ _ (θ.property) (φ.property)
-  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+  have hMℚnorm : ‖rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
     Mℚ_norm_bounded (θ.property) (φ.property)
   -- Decompose: ⟪rotM P, rotM Q⟫ - ⟪rotMℚ P_, rotMℚ Q_⟫
   --   = ⟪rotM P - rotMℚ P_, rotM Q⟫ + ⟪rotMℚ P_, rotM Q - rotMℚ Q_⟫
-  have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫ =
-      ⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
-      ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫ := by
+  have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotMℚℝ ↑θ ↑φ) Q_⟫ =
+      ⟪(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+      ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_⟫ := by
     simp [inner_sub_left, inner_sub_right]
   rw [decomp]
   -- Bound ‖rotM P - rotMℚ P_‖ and ‖rotM Q - rotMℚ Q_‖
-  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 :=
+  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hMdiff hMℚnorm hP Papprox
-  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 2 * κ + κ ^ 2 :=
+  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hMdiff hMℚnorm hQ Qapprox
   -- Bound ‖rotM Q‖
   have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 1 := clm_unit_apply_le (le_of_eq (Bounding.rotM_norm_one _ _)) hQ
   -- Bound ‖rotMℚ P_‖
-  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) :=
+  have hMℚP_ : ‖(rotMℚℝ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) :=
     approx_image_norm_le hMℚnorm hP Papprox
-  calc |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
-        ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫|
-    _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
-        |⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫| := abs_add_le _ _
-    _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q‖ +
-        ‖(rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ :=
+  calc |⟪(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+        ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_⟫|
+    _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
+        |⟪(rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_⟫| := abs_add_le _ _
+    _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q‖ +
+        ‖(rotMℚℝ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_‖ :=
         add_le_add (abs_real_inner_le_norm _ _) (abs_real_inner_le_norm _ _)
     _ ≤ (2 * κ + κ ^ 2) * 1 + (1 + κ) * (1 + κ) * (2 * κ + κ ^ 2) :=
         add_le_add
@@ -105,13 +105,13 @@ lemma bounds_kappa3_M (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P 
     _ ≤ 5 * κ := by unfold κ; norm_num
 
 lemma bounds_kappa3_MQ (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_‖ ≤ κ) :
-    |(‖rotM θ φ Q‖ - ‖rotMℚ θ φ Q_‖)| ≤ 3 * κ := by
-  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    |(‖rotM θ φ Q‖ - ‖rotMℚℝ θ φ Q_‖)| ≤ 3 * κ := by
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
     M_difference_norm_bounded _ _ (θ.property) (φ.property)
-  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+  have hMℚnorm : ‖rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
     Mℚ_norm_bounded (θ.property) (φ.property)
   -- Reverse triangle inequality + clm_approx_apply_sub
-  calc |(‖rotM θ φ Q‖ - ‖rotMℚ θ φ Q_‖)|
-    _ ≤ ‖rotM θ φ Q - rotMℚ θ φ Q_‖ := abs_norm_sub_norm_le _ _
+  calc |(‖rotM θ φ Q‖ - ‖rotMℚℝ θ φ Q_‖)|
+    _ ≤ ‖rotM θ φ Q - rotMℚℝ θ φ Q_‖ := abs_norm_sub_norm_le _ _
     _ ≤ 2 * κ + κ ^ 2 := clm_approx_apply_sub hMdiff hMℚnorm hQ Qapprox
     _ ≤ 3 * κ := by unfold κ; norm_num

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -20,8 +20,8 @@ def bounds_kappa4_A := (⟪rotM θ φ P, rotM θ φ (P - Q)⟫ - 2 * ε * ‖P -
 
 noncomputable
 def bounds_kappa4_Aℚ (s : UpperSqrt) :=
-  (⟪rotMℚ θ φ P_, rotMℚ θ φ (P_ - Q_)⟫ - 10 * κ - 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)) /
-  ((s.norm (rotMℚ θ φ P_) + √2 * ε + 3 * κ) * (s.norm (rotMℚ θ φ (P_ - Q_)) + 2 * √2 * ε + 6 * κ))
+  (⟪rotMℚℝ θ φ P_, rotMℚℝ θ φ (P_ - Q_)⟫ - 10 * κ - 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)) /
+  ((s.norm (rotMℚℝ θ φ P_) + √2 * ε + 3 * κ) * (s.norm (rotMℚℝ θ φ (P_ - Q_)) + 2 * √2 * ε + 6 * κ))
 
 /-- An `UpperSqrt` overestimates the Euclidean norm. -/
 lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖ ≤ s.norm v := by
@@ -36,37 +36,37 @@ lemma inner_product_bound_10kappa
     {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (hR : ‖Q‖ ≤ 2)
     (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ 2 * κ) :
-    |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫| ≤ 10 * κ := by
-  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotMℚℝ ↑θ ↑φ) Q_⟫| ≤ 10 * κ := by
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
     M_difference_norm_bounded _ _ (θ.property) (φ.property)
-  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+  have hMℚnorm : ‖rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
     Mℚ_norm_bounded (θ.property) (φ.property)
   -- Decompose: ⟪rotM P, rotM Q⟫ - ⟪rotMℚ P_, rotMℚ Q_⟫
   --   = ⟪rotM P - rotMℚ P_, rotM Q⟫ + ⟪rotMℚ P_, rotM Q - rotMℚ Q_⟫
-  have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) Q_⟫ =
-      ⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
-      ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫ := by
+  have decomp : ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) Q⟫ - ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotMℚℝ ↑θ ↑φ) Q_⟫ =
+      ⟪(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+      ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_⟫ := by
     simp [inner_sub_left, inner_sub_right]
   rw [decomp]
   -- Bound ‖rotM P - rotMℚ P_‖
-  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 :=
+  have hAP : ‖(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hMdiff hMℚnorm hP Papprox
   -- Bound ‖rotM Q - rotMℚ Q_‖ (with ‖Q‖ ≤ 2 and ‖Q - Q_‖ ≤ 2κ)
-  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ ≤ 4 * κ + 2 * κ ^ 2 :=
+  have hBQ : ‖(rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_‖ ≤ 4 * κ + 2 * κ ^ 2 :=
     clm_approx_apply_sub₂ hMdiff hMℚnorm hR Qapprox
   -- Bound ‖rotM Q‖
   have hMQ : ‖(rotM ↑θ ↑φ) Q‖ ≤ 2 := by
     have := ContinuousLinearMap.le_opNorm (rotM ↑θ ↑φ) Q
     rw [Bounding.rotM_norm_one, one_mul] at this; linarith
   -- Bound ‖rotMℚ P_‖
-  have hMℚP_ : ‖(rotMℚ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) :=
+  have hMℚP_ : ‖(rotMℚℝ ↑θ ↑φ) P_‖ ≤ (1 + κ) * (1 + κ) :=
     approx_image_norm_le hMℚnorm hP Papprox
-  calc |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
-        ⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫|
-    _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
-        |⟪(rotMℚ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_⟫| := abs_add_le _ _
-    _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q‖ +
-        ‖(rotMℚ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q - (rotMℚ ↑θ ↑φ) Q_‖ :=
+  calc |⟪(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫ +
+        ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_⟫|
+    _ ≤ |⟪(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q⟫| +
+        |⟪(rotMℚℝ ↑θ ↑φ) P_, (rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_⟫| := abs_add_le _ _
+    _ ≤ ‖(rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q‖ +
+        ‖(rotMℚℝ ↑θ ↑φ) P_‖ * ‖(rotM ↑θ ↑φ) Q - (rotMℚℝ ↑θ ↑φ) Q_‖ :=
         add_le_add (abs_real_inner_le_norm _ _) (abs_real_inner_le_norm _ _)
     _ ≤ (2 * κ + κ ^ 2) * 2 + (1 + κ) * (1 + κ) * (4 * κ + 2 * κ ^ 2) :=
         add_le_add
@@ -80,7 +80,7 @@ lemma inner_product_bound_10kappa
 lemma norm_diff_bound_3kappa
     {P P_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) :
-    ‖(rotM ↑θ ↑φ) P‖ ≤ ‖(rotMℚ ↑θ ↑φ) P_‖ + 3 * κ := by
+    ‖(rotM ↑θ ↑φ) P‖ ≤ ‖(rotMℚℝ ↑θ ↑φ) P_‖ + 3 * κ := by
   have h := bounds_kappa3_MQ (θ := θ) (φ := φ) hP Papprox
   rw [abs_le] at h
   linarith [h.1]
@@ -91,10 +91,10 @@ lemma norm_diff_bound_6kappa
     {P Q P_ Q_ : ℝ³} {θ φ : Set.Icc (-4 : ℝ) 4}
     (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1)
     (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ) :
-    ‖(rotM ↑θ ↑φ) (P - Q)‖ ≤ ‖(rotMℚ ↑θ ↑φ) (P_ - Q_)‖ + 6 * κ := by
-  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    ‖(rotM ↑θ ↑φ) (P - Q)‖ ≤ ‖(rotMℚℝ ↑θ ↑φ) (P_ - Q_)‖ + 6 * κ := by
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
     M_difference_norm_bounded _ _ (θ.property) (φ.property)
-  have hMℚnorm : ‖rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
+  have hMℚnorm : ‖rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ 1 + κ :=
     Mℚ_norm_bounded (θ.property) (φ.property)
   have hPQ_norm : ‖P - Q‖ ≤ 2 := by
     calc ‖P - Q‖ ≤ ‖P‖ + ‖Q‖ := norm_sub_le _ _
@@ -106,9 +106,9 @@ lemma norm_diff_bound_6kappa
       _ ≤ κ + κ := add_le_add Papprox Qapprox
       _ = 2 * κ := by ring
   -- ‖M(P-Q) - Mℚ(P_-Q_)‖ ≤ ‖(M-Mℚ)(P-Q)‖ + ‖Mℚ((P-Q)-(P_-Q_))‖
-  have h_diff : ‖(rotM ↑θ ↑φ) (P - Q) - (rotMℚ ↑θ ↑φ) (P_ - Q_)‖ ≤ 6 * κ :=
+  have h_diff : ‖(rotM ↑θ ↑φ) (P - Q) - (rotMℚℝ ↑θ ↑φ) (P_ - Q_)‖ ≤ 6 * κ :=
     (clm_approx_apply_sub₂ hMdiff hMℚnorm hPQ_norm hPQ_approx).trans (by unfold κ; norm_num)
-  linarith [norm_le_insert' ((rotM ↑θ ↑φ) (P - Q)) ((rotMℚ ↑θ ↑φ) (P_ - Q_))]
+  linarith [norm_le_insert' ((rotM ↑θ ↑φ) (P - Q)) ((rotMℚℝ ↑θ ↑φ) (P_ - Q_))]
 
 /-- [SY25] Corollary 51 -/
 lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ)
@@ -117,11 +117,11 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
     bounds_kappa4_Aℚ P_ Q_ θ φ ε s ≤ bounds_kappa4_A P Q θ φ ε := by
   -- Abbreviate the numerators and denominators
   set numA := ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)
-  set numAℚ := ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) (P_ - Q_)⟫ - 10 * κ -
+  set numAℚ := ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotMℚℝ ↑θ ↑φ) (P_ - Q_)⟫ - 10 * κ -
     2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)
   set denA := (‖(rotM ↑θ ↑φ) P‖ + √2 * ε) * (‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε)
-  set denAℚ := (s.norm ((rotMℚ ↑θ ↑φ) P_) + √2 * ε + 3 * κ) *
-    (s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ)
+  set denAℚ := (s.norm ((rotMℚℝ ↑θ ↑φ) P_) + √2 * ε + 3 * κ) *
+    (s.norm ((rotMℚℝ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ)
   -- The goal becomes numAℚ / denAℚ ≤ numA / denA after unfolding
   change numAℚ / denAℚ ≤ numA / denA
   -- Step 1: numAℚ ≤ numA
@@ -137,7 +137,7 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
         _ ≤ κ + κ := add_le_add Papprox Qapprox
         _ = 2 * κ := by ring
     have h_inner : |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ -
-        ⟪(rotMℚ ↑θ ↑φ) P_, (rotMℚ ↑θ ↑φ) (P_ - Q_)⟫| ≤ 10 * κ :=
+        ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotMℚℝ ↑θ ↑φ) (P_ - Q_)⟫| ≤ 10 * κ :=
       inner_product_bound_10kappa hP hPQ_norm Papprox hPQ_approx
     replace h_inner := sub_le_of_abs_sub_le_left h_inner
     have h_norm_PQ : ‖P - Q‖ ≤ ‖P_ - Q_‖ + 2 * κ := by
@@ -158,14 +158,14 @@ lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - 
   have h_denA_le : denA ≤ denAℚ := by
     -- Factor 1: ‖rotM P‖ + √2ε ≤ s.norm(rotMℚ P_) + √2ε + 3κ
     have h_f1 : ‖(rotM ↑θ ↑φ) P‖ + √2 * ε ≤
-        s.norm ((rotMℚ ↑θ ↑φ) P_) + √2 * ε + 3 * κ := by
+        s.norm ((rotMℚℝ ↑θ ↑φ) P_) + √2 * ε + 3 * κ := by
       linarith [norm_diff_bound_3kappa hP Papprox (θ := θ) (φ := φ),
-        UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) P_)]
+        UpperSqrt_norm_le s ((rotMℚℝ ↑θ ↑φ) P_)]
     -- Factor 2: ‖rotM (P-Q)‖ + 2√2ε ≤ s.norm(rotMℚ (P_-Q_)) + 2√2ε + 6κ
     have h_f2 : ‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε ≤
-        s.norm ((rotMℚ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ := by
+        s.norm ((rotMℚℝ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ := by
       linarith [norm_diff_bound_6kappa hP hQ Papprox Qapprox (θ := θ) (φ := φ),
-        UpperSqrt_norm_le s ((rotMℚ ↑θ ↑φ) (P_ - Q_))]
+        UpperSqrt_norm_le s ((rotMℚℝ ↑θ ↑φ) (P_ - Q_))]
     exact mul_le_mul h_f1 h_f2 (by positivity) (le_trans (by positivity) h_f1)
   -- Step 3: Apply div_le_div₀
   exact div_le_div₀ hA_nonneg h_numAℚ_le (by positivity) h_denA_le

--- a/Noperthedron/RationalApprox/DeltaKappa.lean
+++ b/Noperthedron/RationalApprox/DeltaKappa.lean
@@ -15,35 +15,35 @@ variable {P : ℝ³} {Q Q_ : ℝ³} {α θ φ θ_ φ_ : Set.Icc (-4 : ℝ) 4}
 -/
 
 lemma delta_kappa (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Qapprox : ‖Q - Q_‖ ≤ κ) :
-    |‖rotR α (rotM θ φ P) - rotM θ_ φ_ Q‖ - ‖rotRℚ α (rotMℚ θ φ P) - rotMℚ θ_ φ_ Q_‖| ≤ 6 * κ := by
-  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
+    |‖rotR α (rotM θ φ P) - rotM θ_ φ_ Q‖ - ‖rotRℚℝ α (rotMℚℝ θ φ P) - rotMℚℝ θ_ φ_ Q_‖| ≤ 6 * κ := by
+  have hMdiff : ‖rotM (θ : ℝ) (φ : ℝ) - rotMℚℝ (θ : ℝ) (φ : ℝ)‖ ≤ κ :=
     M_difference_norm_bounded _ _ (θ.property) (φ.property)
-  have hRdiff : ‖rotR (α : ℝ) - rotRℚ (α : ℝ)‖ ≤ κ :=
+  have hRdiff : ‖rotR (α : ℝ) - rotRℚℝ (α : ℝ)‖ ≤ κ :=
     R_difference_norm_bounded _ (α.property)
   -- Term 1: ‖rotR(rotM P) - rotRℚ(rotMℚ P)‖ ≤ 2κ + κ²
   -- Decompose at the R level: A = rotR, Aℚ = rotRℚ, P = rotM P, P_ = rotMℚ P
-  have term1 : ‖rotR α (rotM θ φ P) - rotRℚ α (rotMℚ θ φ P)‖ ≤ 2 * κ + κ ^ 2 :=
+  have term1 : ‖rotR α (rotM θ φ P) - rotRℚℝ α (rotMℚℝ θ φ P)‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub hRdiff (Rℚ_norm_bounded _ (α.property))
       (clm_unit_apply_le (le_of_eq (Bounding.rotM_norm_one _ _)) hP)
-      (by rw [show (rotM ↑θ ↑φ) P - (rotMℚ ↑θ ↑φ) P = (rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P from
+      (by rw [show (rotM ↑θ ↑φ) P - (rotMℚℝ ↑θ ↑φ) P = (rotM ↑θ ↑φ - rotMℚℝ ↑θ ↑φ) P from
               (ContinuousLinearMap.sub_apply _ _ _).symm]
-          calc ‖(rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ) P‖
-            _ ≤ ‖rotM ↑θ ↑φ - rotMℚ ↑θ ↑φ‖ * ‖P‖ := ContinuousLinearMap.le_opNorm _ _
+          calc ‖(rotM ↑θ ↑φ - rotMℚℝ ↑θ ↑φ) P‖
+            _ ≤ ‖rotM ↑θ ↑φ - rotMℚℝ ↑θ ↑φ‖ * ‖P‖ := ContinuousLinearMap.le_opNorm _ _
             _ ≤ κ * 1 := mul_le_mul hMdiff hP (norm_nonneg _) (by norm_num [κ])
             _ = κ := mul_one κ)
   -- Term 2: ‖rotM' Q - rotMℚ' Q_‖ ≤ 2κ + κ²
-  have term2 : ‖rotM θ_ φ_ Q - rotMℚ θ_ φ_ Q_‖ ≤ 2 * κ + κ ^ 2 :=
+  have term2 : ‖rotM θ_ φ_ Q - rotMℚℝ θ_ φ_ Q_‖ ≤ 2 * κ + κ ^ 2 :=
     clm_approx_apply_sub (M_difference_norm_bounded _ _ (θ_.property) (φ_.property))
       (Mℚ_norm_bounded (θ_.property) (φ_.property)) hQ Qapprox
   -- Combine using reverse triangle inequality
   calc |‖rotR ↑α ((rotM ↑θ ↑φ) P) - (rotM ↑θ_ ↑φ_) Q‖ -
-        ‖rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P) - (rotMℚ ↑θ_ ↑φ_) Q_‖|
+        ‖rotRℚℝ ↑α ((rotMℚℝ ↑θ ↑φ) P) - (rotMℚℝ ↑θ_ ↑φ_) Q_‖|
     _ ≤ ‖(rotR ↑α ((rotM ↑θ ↑φ) P) - (rotM ↑θ_ ↑φ_) Q) -
-          (rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P) - (rotMℚ ↑θ_ ↑φ_) Q_)‖ :=
+          (rotRℚℝ ↑α ((rotMℚℝ ↑θ ↑φ) P) - (rotMℚℝ ↑θ_ ↑φ_) Q_)‖ :=
         abs_norm_sub_norm_le _ _
-    _ = ‖(rotR ↑α ((rotM ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P)) -
-          ((rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_)‖ := by congr 1; abel
-    _ ≤ ‖rotR ↑α ((rotM ↑θ ↑φ) P) - rotRℚ ↑α ((rotMℚ ↑θ ↑φ) P)‖ +
-          ‖(rotM ↑θ_ ↑φ_) Q - (rotMℚ ↑θ_ ↑φ_) Q_‖ := norm_sub_le _ _
+    _ = ‖(rotR ↑α ((rotM ↑θ ↑φ) P) - rotRℚℝ ↑α ((rotMℚℝ ↑θ ↑φ) P)) -
+          ((rotM ↑θ_ ↑φ_) Q - (rotMℚℝ ↑θ_ ↑φ_) Q_)‖ := by congr 1; abel
+    _ ≤ ‖rotR ↑α ((rotM ↑θ ↑φ) P) - rotRℚℝ ↑α ((rotMℚℝ ↑θ ↑φ) P)‖ +
+          ‖(rotM ↑θ_ ↑φ_) Q - (rotMℚℝ ↑θ_ ↑φ_) Q_‖ := norm_sub_le _ _
     _ ≤ (2 * κ + κ ^ 2) + (2 * κ + κ ^ 2) := add_le_add term1 term2
     _ ≤ 6 * κ := by unfold κ; norm_num

--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -22,7 +22,7 @@ open Local (Triangle)
 structure _root_.Local.Triangle.κSpanning (P : Triangle) (θ φ ε : ℝ) : Prop where
   pos : 0 < ε
   lt : ∀ i : Fin 3, 2 * ε * (√2 + ε) + 6 * κ <
-      ⟪rotR (π / 2) (rotMℚ θ φ (P i)), rotMℚ θ φ (P (i + 1))⟫
+      ⟪rotR (π / 2) (rotMℚℝ θ φ (P i)), rotMℚℝ θ φ (P (i + 1))⟫
 
 def κApproxTri (A A' : Triangle) : Prop :=
   ∀ i, ‖A i - A' i‖ ≤ κ
@@ -92,7 +92,7 @@ private lemma rotM_transpose_adjoint (θ φ : ℝ) :
   rfl
 
 private lemma rotMℚ_transpose_adjoint (θ φ : ℝ) :
-    (rotMℚ_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap = (rotMℚ θ φ).adjoint := by
+    (rotMℚ_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap = (rotMℚℝ θ φ).adjoint := by
   rw [← Matrix.conjTranspose_eq_transpose_of_trivial (A := rotMℚ_mat θ φ),
       Matrix.toEuclideanLin_conjTranspose_eq_adjoint (A := rotMℚ_mat θ φ)]
   rfl
@@ -107,9 +107,9 @@ theorem ek_spanning_imp_e_spanning (P P' : Triangle)
   · have lt := hspan.lt
     intro i
     suffices h : |⟪(rotR (π / 2)) (rotM θ φ (P i)),  rotM θ φ (P (i + 1))⟫
-                 - ⟪(rotR (π / 2)) (rotMℚ θ φ (P' i)), rotMℚ θ φ (P' (i + 1))⟫| ≤ 6 * κ by
+                 - ⟪(rotR (π / 2)) (rotMℚℝ θ φ (P' i)), rotMℚℝ θ φ (P' (i + 1))⟫| ≤ 6 * κ by
       calc ⟪(rotR (π / 2)) ((rotM θ φ) (P i)), (rotM θ φ) (P (i + 1))⟫
-      _ ≥ ⟪(rotR (π / 2)) (rotMℚ θ φ (P' i)), rotMℚ θ φ (P' (i + 1))⟫ - 6 * κ :=
+      _ ≥ ⟪(rotR (π / 2)) (rotMℚℝ θ φ (P' i)), rotMℚℝ θ φ (P' (i + 1))⟫ - 6 * κ :=
         sub_le_of_abs_sub_le_left h
       _ > 2 * ε * (√2 + ε) := lt_tsub_of_add_lt_right (hspan.lt i)
 
@@ -122,7 +122,7 @@ theorem ek_spanning_imp_e_spanning (P P' : Triangle)
       (rotMℚ_mat θ φ)ᵀ.toEuclideanLin.toContinuousLinearMap,
       rotR (π / 2), rotR (π / 2),
       rotM θ φ,
-      rotMℚ θ φ,
+      rotMℚℝ θ φ,
       mapOfCovec (P i),
       mapOfCovec (P' i)
     ⟧
@@ -144,7 +144,7 @@ theorem ek_spanning_imp_e_spanning (P P' : Triangle)
     have hva : ⟪(rotR (π / 2)) ((rotM θ φ) (P i)), (rotM θ φ) (P (i + 1))⟫ = mv.valB := by
       simp [MatVec.valB, mv, mapOfCovec_single, rotM_transpose_adjoint, mapOfVec_apply,
         ContinuousLinearMap.adjoint_inner_right, real_inner_comm]
-    have hvb : ⟪(rotR (π / 2)) (rotMℚ θ φ (P' i)), rotMℚ θ φ (P' (i + 1))⟫ = mv.valA := by
+    have hvb : ⟪(rotR (π / 2)) (rotMℚℝ θ φ (P' i)), rotMℚℝ θ φ (P' (i + 1))⟫ = mv.valA := by
       simp [MatVec.valA, mv, mapOfCovec_single, rotMℚ_transpose_adjoint, mapOfVec_apply,
         ContinuousLinearMap.adjoint_inner_right, real_inner_comm]
     have hdbb : mv.DiffBoundedBy κ := by
@@ -163,8 +163,8 @@ theorem ek_spanning_imp_e_spanning (P P' : Triangle)
           simp only [← map_sub, Matrix.transpose_sub]
         rw [h, norm_transpose_euc_lin]
         calc ‖(rotMℚ_mat θ φ - rotM_mat θ φ).toEuclideanLin.toContinuousLinearMap‖
-          _ = ‖rotMℚ θ φ - rotM θ φ‖ := by simp [rotMℚ, rotM, ← map_sub]
-          _ = ‖rotM θ φ - rotMℚ θ φ‖ := norm_sub_rev _ _
+          _ = ‖rotMℚℝ θ φ - rotM θ φ‖ := by simp [rotMℚℝ, rotM, ← map_sub]
+          _ = ‖rotM θ φ - rotMℚℝ θ φ‖ := norm_sub_rev _ _
           _ ≤ κ := M_difference_norm_bounded θ φ hθ hφ
       · -- ‖rotR (π/2) - rotR (π/2)‖ ≤ κ  i.e., 0 ≤ κ
         norm_num [κ]

--- a/Noperthedron/RationalApprox/MatrixBounds.lean
+++ b/Noperthedron/RationalApprox/MatrixBounds.lean
@@ -26,7 +26,7 @@ def vecX_approx : Matrix (Fin 3) (Fin 1) DistLeKappaEntry :=
   !![ (.cos, .sin); (.sin, .sin); (.one, .cos) ]
 
 /-- Proof of [SY25] Corollary 41 -/
-theorem R_difference_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotR α - rotRℚ α‖ ≤ κ := by
+theorem R_difference_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotR α - rotRℚℝ α‖ ≤ κ := by
   let z_ : Set.Icc (-4 : ℝ) 4 := ⟨0, by norm_num⟩
   let α_ : Set.Icc (-4 : ℝ) 4 := ⟨α, hα⟩
 
@@ -36,15 +36,15 @@ theorem R_difference_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
-  have h : rotRℚ α = clinApprox rotR_approx z_ α_ := by
-    simp [rotRℚ, rotRℚ_mat, clinApprox, rotR_approx, α_]
+  have h : rotRℚℝ α = clinApprox rotR_approx z_ α_ := by
+    simp [rotRℚℝ, rotRℚ_mat, clinApprox, rotR_approx, α_]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
   exact norm_matrix_actual_approx_le_kappa (m := ⟨2, by norm_num⟩) (n := ⟨2, by norm_num⟩)
     rotR_approx z_ α_
 
-theorem R'_difference_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotR' α - rotR'ℚ α‖ ≤ κ := by
+theorem R'_difference_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotR' α - rotR'ℚℝ α‖ ≤ κ := by
   let z_ : Set.Icc (-4 : ℝ) 4 := ⟨0, by norm_num⟩
   let α_ : Set.Icc (-4 : ℝ) 4 := ⟨α, hα⟩
 
@@ -54,8 +54,8 @@ theorem R'_difference_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : �
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
-  have h : rotR'ℚ α = clinApprox rotR'_approx z_ α_ := by
-    simp [rotR'ℚ, rotR'ℚ_mat, clinApprox, rotR'_approx, α_]
+  have h : rotR'ℚℝ α = clinApprox rotR'_approx z_ α_ := by
+    simp [rotR'ℚℝ, rotR'ℚ_mat, clinApprox, rotR'_approx, α_]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
@@ -63,7 +63,7 @@ theorem R'_difference_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : �
     rotR'_approx z_ α_
 
 theorem M_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
-    (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotM θ φ - rotMℚ θ φ‖ ≤ κ := by
+    (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotM θ φ - rotMℚℝ θ φ‖ ≤ κ := by
   let θ_ : Set.Icc (-4 : ℝ) 4 := ⟨θ, hθ⟩
   let φ_ : Set.Icc (-4 : ℝ) 4 := ⟨φ, hφ⟩
 
@@ -73,8 +73,8 @@ theorem M_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
-  have h : rotMℚ θ φ = clinApprox rotM_approx θ_ φ_ := by
-    simp [rotMℚ, rotMℚ_mat, clinApprox, rotM_approx, θ_, φ_]
+  have h : rotMℚℝ θ φ = clinApprox rotM_approx θ_ φ_ := by
+    simp [rotMℚℝ, rotMℚ_mat, clinApprox, rotM_approx, θ_, φ_]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
@@ -82,7 +82,7 @@ theorem M_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     rotM_approx θ_ φ_
 
 theorem Mθ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
-    (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotMθ θ φ - rotMθℚ θ φ‖ ≤ κ := by
+    (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotMθ θ φ - rotMθℚℝ θ φ‖ ≤ κ := by
   let θ_ : Set.Icc (-4 : ℝ) 4 := ⟨θ, hθ⟩
   let φ_ : Set.Icc (-4 : ℝ) 4 := ⟨φ, hφ⟩
 
@@ -92,8 +92,8 @@ theorem Mθ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
-  have h : rotMθℚ θ φ = clinApprox rotMθ_approx θ_ φ_ := by
-    simp [rotMθℚ, rotMθℚ_mat, clinApprox, rotMθ_approx, θ_, φ_]
+  have h : rotMθℚℝ θ φ = clinApprox rotMθ_approx θ_ φ_ := by
+    simp [rotMθℚℝ, rotMθℚ_mat, clinApprox, rotMθ_approx, θ_, φ_]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
@@ -101,7 +101,7 @@ theorem Mθ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     rotMθ_approx θ_ φ_
 
 theorem Mφ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
-    (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotMφ θ φ - rotMφℚ θ φ‖ ≤ κ := by
+    (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotMφ θ φ - rotMφℚℝ θ φ‖ ≤ κ := by
   let θ_ : Set.Icc (-4 : ℝ) 4 := ⟨θ, hθ⟩
   let φ_ : Set.Icc (-4 : ℝ) 4 := ⟨φ, hφ⟩
 
@@ -111,8 +111,8 @@ theorem Mφ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
-  have h : rotMφℚ θ φ = clinApprox rotMφ_approx θ_ φ_ := by
-    simp [rotMφℚ, rotMφℚ_mat, clinApprox, rotMφ_approx, θ_, φ_]
+  have h : rotMφℚℝ θ φ = clinApprox rotMφ_approx θ_ φ_ := by
+    simp [rotMφℚℝ, rotMφℚ_mat, clinApprox, rotMφ_approx, θ_, φ_]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
@@ -120,7 +120,7 @@ theorem Mφ_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     rotMφ_approx θ_ φ_
 
 theorem X_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
-    (hφ : φ ∈ Set.Icc (-4) 4) : ‖vecXL θ φ - vecXLℚ θ φ‖ ≤ κ := by
+    (hφ : φ ∈ Set.Icc (-4) 4) : ‖vecXL θ φ - vecXLℚℝ θ φ‖ ≤ κ := by
   let θ_ : Set.Icc (-4 : ℝ) 4 := ⟨θ, hθ⟩
   let φ_ : Set.Icc (-4 : ℝ) 4 := ⟨φ, hφ⟩
 
@@ -130,8 +130,8 @@ theorem X_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
 
-  have h : vecXLℚ θ φ = clinApprox vecX_approx θ_ φ_ := by
-    simp only [vecXLℚ, vecXℚ_mat, clinApprox, vecX_approx, θ_, φ_,
+  have h : vecXLℚℝ θ φ = clinApprox vecX_approx θ_ φ_ := by
+    simp only [vecXLℚℝ, vecXℚ_mat, clinApprox, vecX_approx, θ_, φ_,
         EmbeddingLike.apply_eq_iff_eq,]
     ext i j; fin_cases i <;> fin_cases j <;> simp
   rw [h]
@@ -139,36 +139,36 @@ theorem X_difference_norm_bounded (θ φ : ℝ) (hθ : θ ∈ Set.Icc (-4) 4)
   exact norm_matrix_actual_approx_le_kappa (m := ⟨3, by norm_num⟩) (n := ⟨1, by norm_num⟩)
     vecX_approx θ_ φ_
 
-theorem Rℚ_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotRℚ α‖ ≤ 1 + κ := by
-  calc ‖rotRℚ α‖
-  _ ≤ ‖rotR α‖ + ‖rotR α - rotRℚ α‖ := norm_le_insert (rotR α) (rotRℚ α)
-  _ = 1        + ‖rotR α - rotRℚ α‖ := by rw [Bounding.rotR_norm_one]
+theorem Rℚ_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotRℚℝ α‖ ≤ 1 + κ := by
+  calc ‖rotRℚℝ α‖
+  _ ≤ ‖rotR α‖ + ‖rotR α - rotRℚℝ α‖ := norm_le_insert (rotR α) (rotRℚℝ α)
+  _ = 1        + ‖rotR α - rotRℚℝ α‖ := by rw [Bounding.rotR_norm_one]
   _ ≤ 1 + κ := by grw [R_difference_norm_bounded α hα]
 
-theorem Mℚ_norm_bounded {θ φ : ℝ} (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotMℚ θ φ‖ ≤ 1 + κ := by
-  calc ‖rotMℚ θ φ‖
-  _ ≤ ‖rotM θ φ‖ + ‖rotM θ φ - rotMℚ θ φ‖ := norm_le_insert (rotM θ φ) (rotMℚ θ φ)
-  _ = 1        + ‖rotM θ φ - rotMℚ θ φ‖ := by rw [Bounding.rotM_norm_one]
+theorem Mℚ_norm_bounded {θ φ : ℝ} (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4) : ‖rotMℚℝ θ φ‖ ≤ 1 + κ := by
+  calc ‖rotMℚℝ θ φ‖
+  _ ≤ ‖rotM θ φ‖ + ‖rotM θ φ - rotMℚℝ θ φ‖ := norm_le_insert (rotM θ φ) (rotMℚℝ θ φ)
+  _ = 1        + ‖rotM θ φ - rotMℚℝ θ φ‖ := by rw [Bounding.rotM_norm_one]
   _ ≤ 1 + κ := by grw [M_difference_norm_bounded θ φ hθ hφ]
 
-theorem R'ℚ_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotR'ℚ α‖ ≤ 1 + κ := by
-  calc ‖rotR'ℚ α‖
-  _ ≤ ‖rotR' α‖ + ‖rotR' α - rotR'ℚ α‖ := norm_le_insert (rotR' α) (rotR'ℚ α)
-  _ = 1 + ‖rotR' α - rotR'ℚ α‖ := by rw [Bounding.rotR'_norm_one]
+theorem R'ℚ_norm_bounded (α : ℝ) (hα : α ∈ Set.Icc (-4) 4) : ‖rotR'ℚℝ α‖ ≤ 1 + κ := by
+  calc ‖rotR'ℚℝ α‖
+  _ ≤ ‖rotR' α‖ + ‖rotR' α - rotR'ℚℝ α‖ := norm_le_insert (rotR' α) (rotR'ℚℝ α)
+  _ = 1 + ‖rotR' α - rotR'ℚℝ α‖ := by rw [Bounding.rotR'_norm_one]
   _ ≤ 1 + κ := by grw [R'_difference_norm_bounded α hα]
 
 theorem Mθℚ_norm_bounded {θ φ : ℝ} (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4) :
-    ‖rotMθℚ θ φ‖ ≤ 1 + κ := by
-  calc ‖rotMθℚ θ φ‖
-  _ ≤ ‖rotMθ θ φ‖ + ‖rotMθ θ φ - rotMθℚ θ φ‖ := norm_le_insert _ _
-  _ ≤ 1 + ‖rotMθ θ φ - rotMθℚ θ φ‖ := by gcongr; exact Bounding.rotMθ_norm_le_one _ _
+    ‖rotMθℚℝ θ φ‖ ≤ 1 + κ := by
+  calc ‖rotMθℚℝ θ φ‖
+  _ ≤ ‖rotMθ θ φ‖ + ‖rotMθ θ φ - rotMθℚℝ θ φ‖ := norm_le_insert _ _
+  _ ≤ 1 + ‖rotMθ θ φ - rotMθℚℝ θ φ‖ := by gcongr; exact Bounding.rotMθ_norm_le_one _ _
   _ ≤ 1 + κ := by gcongr; exact Mθ_difference_norm_bounded _ _ hθ hφ
 
 theorem Mφℚ_norm_bounded {θ φ : ℝ} (hθ : θ ∈ Set.Icc (-4) 4) (hφ : φ ∈ Set.Icc (-4) 4) :
-    ‖rotMφℚ θ φ‖ ≤ 1 + κ := by
-  calc ‖rotMφℚ θ φ‖
-  _ ≤ ‖rotMφ θ φ‖ + ‖rotMφ θ φ - rotMφℚ θ φ‖ := norm_le_insert _ _
-  _ ≤ 1 + ‖rotMφ θ φ - rotMφℚ θ φ‖ := by gcongr; exact Bounding.rotMφ_norm_le_one _ _
+    ‖rotMφℚℝ θ φ‖ ≤ 1 + κ := by
+  calc ‖rotMφℚℝ θ φ‖
+  _ ≤ ‖rotMφ θ φ‖ + ‖rotMφ θ φ - rotMφℚℝ θ φ‖ := norm_le_insert _ _
+  _ ≤ 1 + ‖rotMφ θ φ - rotMφℚℝ θ φ‖ := by gcongr; exact Bounding.rotMφ_norm_le_one _ _
   _ ≤ 1 + κ := by gcongr; exact Mφ_difference_norm_bounded _ _ hθ hφ
 
 /-- Convert `Set.Icc` membership from `ℤ` bounds to `ℝ` bounds. -/

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -15,7 +15,7 @@ A measure of how far an inner-shadow vertex S can "stick out"
 -/
 noncomputable
 def Gℚ (p : Pose ℝ) (ε : ℝ) (S : ℝ³) (w : ℝ²) : ℝ :=
-  ⟪p.innerℚ S, w⟫ - (ε * (|⟪p.rotR'ℚ (p.rotM₁ℚ S), w⟫| + |⟪p.rotRℚ (p.rotM₁θℚ S), w⟫| + |⟪p.rotRℚ (p.rotM₁φℚ S), w⟫|)
+  ⟪p.innerℚℝ S, w⟫ - (ε * (|⟪p.rotR'ℚℝ (p.rotM₁ℚℝ S), w⟫| + |⟪p.rotRℚℝ (p.rotM₁θℚℝ S), w⟫| + |⟪p.rotRℚℝ (p.rotM₁φℚℝ S), w⟫|)
   + 9 * ε^2 / 2 + 4 * κ * (1 + 3 * ε))
 
 /--
@@ -23,7 +23,7 @@ A measure of how far an outer-shadow vertex P can "reach" along w.
 -/
 noncomputable
 def Hℚ (p : Pose ℝ) (ε : ℝ) (w : ℝ²) (P : ℝ³) : ℝ :=
-  ⟪p.rotM₂ℚ P, w⟫ + ε * (|⟪p.rotM₂θℚ P, w⟫| + |⟪p.rotM₂φℚ P, w⟫|) + 2 * ε^2 + 3 * κ * (1 + 2 * ε)
+  ⟪p.rotM₂ℚℝ P, w⟫ + ε * (|⟪p.rotM₂θℚℝ P, w⟫| + |⟪p.rotM₂φℚℝ P, w⟫|) + 2 * ε^2 + 3 * κ * (1 + 2 * ε)
 
 /--
 A measure of how far all of the outer-shadow vertices can "reach" along w.
@@ -65,31 +65,31 @@ private lemma Gℚ_le_G {pbar : Pose ℝ} {ε : ℝ} (hε : 0 ≤ ε)
   set φ₁ : Set.Icc (-4 : ℝ) 4 := ⟨pbar.φ₁, hp.φ₁Bound⟩
   set α_ : Set.Icc (-4 : ℝ) 4 := ⟨pbar.α, hp.αBound⟩
   -- inner ≈ innerℚ with 4κ bound
-  have h_inner : ‖⟪pbar.rotR (pbar.rotM₁ S), w⟫ - ⟪pbar.rotRℚ (pbar.rotM₁ℚ S_), w⟫‖ ≤ 4 * κ := by
-    show ‖⟪rotR ↑α_ (rotM ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotRℚ ↑α_ (rotMℚ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
+  have h_inner : ‖⟪pbar.rotR (pbar.rotM₁ S), w⟫ - ⟪pbar.rotRℚℝ (pbar.rotM₁ℚℝ S_), w⟫‖ ≤ 4 * κ := by
+    show ‖⟪rotR ↑α_ (rotM ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotRℚℝ ↑α_ (rotMℚℝ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
     exact bounds_kappa_RM hS hS_approx hw
   -- The inner is ⟪pbar.inner S, w⟫ = ⟪pbar.rotR (pbar.rotM₁ S), w⟫
   have h_inner_eq : ⟪(pbar.inner S : ℝ²), w⟫ = ⟪pbar.rotR (pbar.rotM₁ S), w⟫ := by
     simp [Pose.inner_eq_RM pbar]
   -- innerℚ = rotRℚ ∘ rotM₁ℚ
-  have h_innerQ_eq : ⟪pbar.innerℚ S_, w⟫ = ⟪pbar.rotRℚ (pbar.rotM₁ℚ S_), w⟫ := by
-    simp [Pose.innerℚ, ContinuousLinearMap.comp_apply]
+  have h_innerQ_eq : ⟪pbar.innerℚℝ S_, w⟫ = ⟪pbar.rotRℚℝ (pbar.rotM₁ℚℝ S_), w⟫ := by
+    simp [Pose.innerℚℝ, ContinuousLinearMap.comp_apply]
   -- R'M bound
-  have h_R'M : ‖⟪pbar.rotR' (pbar.rotM₁ S), w⟫ - ⟪pbar.rotR'ℚ (pbar.rotM₁ℚ S_), w⟫‖ ≤ 4 * κ := by
-    show ‖⟪rotR' ↑α_ (rotM ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotR'ℚ ↑α_ (rotMℚ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
+  have h_R'M : ‖⟪pbar.rotR' (pbar.rotM₁ S), w⟫ - ⟪pbar.rotR'ℚℝ (pbar.rotM₁ℚℝ S_), w⟫‖ ≤ 4 * κ := by
+    show ‖⟪rotR' ↑α_ (rotM ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotR'ℚℝ ↑α_ (rotMℚℝ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
     exact bounds_kappa_R'M hS hS_approx hw
   -- RMθ bound
-  have h_RMθ : ‖⟪pbar.rotR (pbar.rotM₁θ S), w⟫ - ⟪pbar.rotRℚ (pbar.rotM₁θℚ S_), w⟫‖ ≤ 4 * κ := by
-    show ‖⟪rotR ↑α_ (rotMθ ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotRℚ ↑α_ (rotMθℚ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
+  have h_RMθ : ‖⟪pbar.rotR (pbar.rotM₁θ S), w⟫ - ⟪pbar.rotRℚℝ (pbar.rotM₁θℚℝ S_), w⟫‖ ≤ 4 * κ := by
+    show ‖⟪rotR ↑α_ (rotMθ ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotRℚℝ ↑α_ (rotMθℚℝ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
     exact bounds_kappa_RMθ hS hS_approx hw
   -- RMφ bound
-  have h_RMφ : ‖⟪pbar.rotR (pbar.rotM₁φ S), w⟫ - ⟪pbar.rotRℚ (pbar.rotM₁φℚ S_), w⟫‖ ≤ 4 * κ := by
-    show ‖⟪rotR ↑α_ (rotMφ ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotRℚ ↑α_ (rotMφℚ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
+  have h_RMφ : ‖⟪pbar.rotR (pbar.rotM₁φ S), w⟫ - ⟪pbar.rotRℚℝ (pbar.rotM₁φℚℝ S_), w⟫‖ ≤ 4 * κ := by
+    show ‖⟪rotR ↑α_ (rotMφ ↑θ₁ ↑φ₁ S), w⟫ - ⟪rotRℚℝ ↑α_ (rotMφℚℝ ↑θ₁ ↑φ₁ S_), w⟫‖ ≤ 4 * κ
     exact bounds_kappa_RMφ hS hS_approx hw
   -- Now combine: Gℚ ≤ G
   rw [h_inner_eq, h_innerQ_eq]
   -- inner bound: real ≥ rational - 4κ
-  have hi_le : ⟪pbar.rotRℚ (pbar.rotM₁ℚ S_), w⟫ ≤ ⟪pbar.rotR (pbar.rotM₁ S), w⟫ + 4 * κ := by
+  have hi_le : ⟪pbar.rotRℚℝ (pbar.rotM₁ℚℝ S_), w⟫ ≤ ⟪pbar.rotR (pbar.rotM₁ S), w⟫ + 4 * κ := by
     have := (Real.norm_eq_abs _).symm ▸ h_inner; rw [abs_le] at this; linarith [this.1]
   -- |abs_real| ≤ |abs_rational| + 4κ for the three ε-coefficient terms
   have hR'_abs := abs_le_abs_add_of_norm_sub_le h_R'M
@@ -106,20 +106,20 @@ private lemma H_le_Hℚ {pbar : Pose ℝ} {ε : ℝ} (hε : 0 ≤ ε)
   set θ₂ : Set.Icc (-4 : ℝ) 4 := ⟨pbar.θ₂, hp.θ₂Bound⟩
   set φ₂ : Set.Icc (-4 : ℝ) 4 := ⟨pbar.φ₂, hp.φ₂Bound⟩
   -- M bound
-  have h_M : ‖⟪pbar.rotM₂ P, w⟫ - ⟪pbar.rotM₂ℚ P_, w⟫‖ ≤ 3 * κ := by
-    show ‖⟪rotM ↑θ₂ ↑φ₂ P, w⟫ - ⟪rotMℚ ↑θ₂ ↑φ₂ P_, w⟫‖ ≤ 3 * κ
+  have h_M : ‖⟪pbar.rotM₂ P, w⟫ - ⟪pbar.rotM₂ℚℝ P_, w⟫‖ ≤ 3 * κ := by
+    show ‖⟪rotM ↑θ₂ ↑φ₂ P, w⟫ - ⟪rotMℚℝ ↑θ₂ ↑φ₂ P_, w⟫‖ ≤ 3 * κ
     exact bounds_kappa_M hP hP_approx hw
   -- Mθ bound
-  have h_Mθ : ‖⟪pbar.rotM₂θ P, w⟫ - ⟪pbar.rotM₂θℚ P_, w⟫‖ ≤ 3 * κ := by
-    show ‖⟪rotMθ ↑θ₂ ↑φ₂ P, w⟫ - ⟪rotMθℚ ↑θ₂ ↑φ₂ P_, w⟫‖ ≤ 3 * κ
+  have h_Mθ : ‖⟪pbar.rotM₂θ P, w⟫ - ⟪pbar.rotM₂θℚℝ P_, w⟫‖ ≤ 3 * κ := by
+    show ‖⟪rotMθ ↑θ₂ ↑φ₂ P, w⟫ - ⟪rotMθℚℝ ↑θ₂ ↑φ₂ P_, w⟫‖ ≤ 3 * κ
     exact bounds_kappa_Mθ hP hP_approx hw
   -- Mφ bound
-  have h_Mφ : ‖⟪pbar.rotM₂φ P, w⟫ - ⟪pbar.rotM₂φℚ P_, w⟫‖ ≤ 3 * κ := by
-    show ‖⟪rotMφ ↑θ₂ ↑φ₂ P, w⟫ - ⟪rotMφℚ ↑θ₂ ↑φ₂ P_, w⟫‖ ≤ 3 * κ
+  have h_Mφ : ‖⟪pbar.rotM₂φ P, w⟫ - ⟪pbar.rotM₂φℚℝ P_, w⟫‖ ≤ 3 * κ := by
+    show ‖⟪rotMφ ↑θ₂ ↑φ₂ P, w⟫ - ⟪rotMφℚℝ ↑θ₂ ↑φ₂ P_, w⟫‖ ≤ 3 * κ
     exact bounds_kappa_Mφ hP hP_approx hw
   -- Combine: H ≤ Hℚ
   -- Extract scalar bounds from norm bounds
-  have hm_le : ⟪pbar.rotM₂ P, w⟫ ≤ ⟪pbar.rotM₂ℚ P_, w⟫ + 3 * κ := by
+  have hm_le : ⟪pbar.rotM₂ P, w⟫ ≤ ⟪pbar.rotM₂ℚℝ P_, w⟫ + 3 * κ := by
     have := (Real.norm_eq_abs _).symm ▸ h_M; rw [abs_le] at this; linarith [this.2]
   -- Absolute value bounds: |real| ≤ |rational| + 3κ
   have hθ_abs := abs_le_abs_add_of_norm_sub_le h_Mθ

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -42,13 +42,13 @@ the direction we're projecting ℝ² → ℝ to find that S "sticks out too far"
 other outer-shadow vertices P (which the calculation of H iterates over) in the polygon that lies in ℝ².
 -/
 structure RationalGlobalTheoremPrecondition {ι : Type} [Fintype ι] [Nonempty ι]
-    (poly : GoodPoly ι) (poly_ : Polyhedron ι ℝ³)
-    (happrox : κApproxPoly poly.vertices poly_) (p : Pose ℚ) (ε : ℝ) : Type where
+    (poly : GoodPoly ι) (poly_ : Polyhedron ι (Fin 3 → ℚ))
+    (happrox : κApproxPoly poly.vertices poly_.toReal) (p : Pose ℚ) (ε : ℝ) : Type where
   j : ι
   p_in_4 : p ∈ fourInterval ℚ
   w : ℝ²
   w_unit : ‖w‖ = 1
-  exceeds : Gℚ p.toReal ε (poly_.v j) w > maxHℚ p.toReal poly_ ε w
+  exceeds : Gℚ p.toReal ε (poly_.toReal.v j) w > maxHℚ p.toReal poly_.toReal ε w
 
 private lemma abs_le_abs_add_of_norm_sub_le {a b C : ℝ} (h : ‖a - b‖ ≤ C) : |a| ≤ |b| + C := by
   linarith [abs_sub_abs_le_abs_sub a b, (Real.norm_eq_abs _).symm ▸ h]
@@ -131,8 +131,8 @@ private lemma H_le_Hℚ {pbar : Pose ℝ} {ε : ℝ} (hε : 0 ≤ ε)
 -/
 theorem rational_global {ι : Type} [Fintype ι] [Nonempty ι]
     (p : Pose ℚ) (ε : ℝ) (hε : 0 ≤ ε)
-    (poly : GoodPoly ι) (poly_ : Polyhedron ι ℝ³)
-    (happrox : κApproxPoly poly.vertices poly_)
+    (poly : GoodPoly ι) (poly_ : Polyhedron ι (Fin 3 → ℚ))
+    (happrox : κApproxPoly poly.vertices poly_.toReal)
     (_poly_pointsym : PointSym poly.hull)
     (pc : RationalGlobalTheoremPrecondition poly poly_ happrox p ε) :
     ¬ ∃ q ∈ Metric.closedBall p.toReal ε, RupertPose q poly.hull := by
@@ -143,13 +143,13 @@ theorem rational_global {ι : Type} [Fintype ι] [Nonempty ι]
   let i := happrox.bijection.symm j
   let S_real := poly.vertices.v i
   have hS_in : S_real ∈ Set.range poly.vertices.v := ⟨i, rfl⟩
-  have hS_approx : ‖S_real - poly_.v j‖ ≤ κ := by
-    show ‖poly.vertices.v (happrox.bijection.symm j) - poly_.v j‖ ≤ κ
+  have hS_approx : ‖S_real - poly_.toReal.v j‖ ≤ κ := by
+    show ‖poly.vertices.v (happrox.bijection.symm j) - poly_.toReal.v j‖ ≤ κ
     have := happrox.approx (happrox.bijection.symm j)
     rwa [Equiv.apply_symm_apply] at this
   have hS_norm : ‖S_real‖ ≤ 1 := poly.vertex_radius_le_one i
   -- Step 2: Show maxH_real ≤ maxHℚ
-  have h_maxH_le : GlobalTheorem.maxH pbar poly ε pc.w ≤ maxHℚ pbar poly_ ε pc.w := by
+  have h_maxH_le : GlobalTheorem.maxH pbar poly ε pc.w ≤ maxHℚ pbar poly_.toReal ε pc.w := by
     unfold GlobalTheorem.maxH maxHℚ
     apply Finset.max'_le
     simp only [Function.comp, Finset.mem_image, Finset.mem_univ, true_and]
@@ -157,12 +157,12 @@ theorem rational_global {ι : Type} [Fintype ι] [Nonempty ι]
     -- Map vertex k to approximate vertex
     let k' := happrox.bijection k
     have hk_norm : ‖poly.vertices.v k‖ ≤ 1 := poly.vertex_radius_le_one k
-    have hk_approx : ‖poly.vertices.v k - poly_.v k'‖ ≤ κ := happrox.approx k
+    have hk_approx : ‖poly.vertices.v k - poly_.toReal.v k'‖ ≤ κ := happrox.approx k
     calc GlobalTheorem.H pbar ε pc.w (poly.vertices.v k)
-      _ ≤ Hℚ pbar ε pc.w (poly_.v k') :=
+      _ ≤ Hℚ pbar ε pc.w (poly_.toReal.v k') :=
           H_le_Hℚ hε hk_norm hk_approx pc.w_unit hp4
       _ ≤ _ := by
-          show (Hℚ pbar ε pc.w ∘ poly_.v) k' ≤ _
+          show (Hℚ pbar ε pc.w ∘ poly_.toReal.v) k' ≤ _
           exact Finset.le_max' _ _ (Finset.mem_image_of_mem _ (Finset.mem_univ k'))
   -- Step 3: Build the precondition and apply global_theorem
   exact GlobalTheorem.global_theorem pbar ε hε poly _poly_pointsym {

--- a/Noperthedron/RationalApprox/RationalGlobal.lean
+++ b/Noperthedron/RationalApprox/RationalGlobal.lean
@@ -30,7 +30,7 @@ A measure of how far all of the outer-shadow vertices can "reach" along w.
 -/
 noncomputable
 def maxHℚ {ι : Type} [Fintype ι] [ne : Nonempty ι]
-    (p : Pose ℝ) (poly : Polyhedron ι) (ε : ℝ) (w : ℝ²) : ℝ :=
+    (p : Pose ℝ) (poly : Polyhedron ι ℝ³) (ε : ℝ) (w : ℝ²) : ℝ :=
   Finset.image (Hℚ p ε w ∘ poly.v) Finset.univ  |>.max' <| by
     simp only [Finset.image_nonempty]
     exact Finset.univ_nonempty_iff.mpr ne
@@ -42,7 +42,7 @@ the direction we're projecting ℝ² → ℝ to find that S "sticks out too far"
 other outer-shadow vertices P (which the calculation of H iterates over) in the polygon that lies in ℝ².
 -/
 structure RationalGlobalTheoremPrecondition {ι : Type} [Fintype ι] [Nonempty ι]
-    (poly : GoodPoly ι) (poly_ : Polyhedron ι)
+    (poly : GoodPoly ι) (poly_ : Polyhedron ι ℝ³)
     (happrox : κApproxPoly poly.vertices poly_) (p : Pose ℚ) (ε : ℝ) : Type where
   j : ι
   p_in_4 : p ∈ fourInterval ℚ
@@ -131,7 +131,7 @@ private lemma H_le_Hℚ {pbar : Pose ℝ} {ε : ℝ} (hε : 0 ≤ ε)
 -/
 theorem rational_global {ι : Type} [Fintype ι] [Nonempty ι]
     (p : Pose ℚ) (ε : ℝ) (hε : 0 ≤ ε)
-    (poly : GoodPoly ι) (poly_ : Polyhedron ι)
+    (poly : GoodPoly ι) (poly_ : Polyhedron ι ℝ³)
     (happrox : κApproxPoly poly.vertices poly_)
     (_poly_pointsym : PointSym poly.hull)
     (pc : RationalGlobalTheoremPrecondition poly poly_ happrox p ε) :

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -39,7 +39,7 @@ If we have indices `Pi` for a triangle in `poly`, yield the corresponding
 triangle in `poly_` which κ-approximates it.
 -/
 def transportTri {ι : Type} [Fintype ι]
-    {A : Polyhedron ι} {B : Polyhedron ι}
+    {A : Polyhedron ι ℝ³} {B : Polyhedron ι ℝ³}
     (Pi : Fin 3 → ι)
     (hpoly : κApproxPoly A B) : Triangle :=
   fun i => B.v (hpoly.bijection (Pi i))
@@ -56,7 +56,7 @@ def BoundRℚ (r ε : ℝ) (p : Pose ℝ) (Q_ : Triangle) (sl : LowerSqrt) : Pro
 [SY25] Theorem 48 "The Rational Local Theorem"
 -/
 theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
-    (poly : GoodPoly ι) (poly_ : Polyhedron ι)
+    (poly : GoodPoly ι) (poly_ : Polyhedron ι ℝ³)
     (hpoly : κApproxPoly poly.vertices poly_)
     (Pi Qi : Fin 3 → ι)
     (cong_tri : Triangle.Congruent (poly.vertices.v ∘ Pi) (poly.vertices.v ∘ Qi))

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -19,8 +19,8 @@ def Aεℚ (X : ℝ³) (P_ : Triangle) (ε : ℝ) : Prop :=
 
 noncomputable
 def Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℝ) (su : UpperSqrt) : ℝ :=
-   (⟪p.rotM₂ℚ v₁, p.rotM₂ℚ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (su.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
-   / ((su.norm (p.rotM₂ℚ v₁) + √2 * ε + 3 * κ) * (su.norm (p.rotM₂ℚ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
+   (⟪p.rotM₂ℚℝ v₁, p.rotM₂ℚℝ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (su.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
+   / ((su.norm (p.rotM₂ℚℝ v₁) + √2 * ε + 3 * κ) * (su.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
 
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
@@ -46,11 +46,11 @@ def transportTri {ι : Type} [Fintype ι]
 
 /-- The condition on δ -/
 def BoundDeltaℚ (δ : ℝ) (p : Pose ℝ) (P_ Q_ : Triangle) (su : UpperSqrt) : Prop :=
-  ∀ i : Fin 3, δ ≥ su.norm (p.rotR (p.rotM₁ℚ (P_ i)) - p.rotM₂ℚ (Q_ i))/2 + 3 * κ
+  ∀ i : Fin 3, δ ≥ su.norm (p.rotR (p.rotM₁ℚℝ (P_ i)) - p.rotM₂ℚℝ (Q_ i))/2 + 3 * κ
 
 /-- The condition on r -/
 def BoundRℚ (r ε : ℝ) (p : Pose ℝ) (Q_ : Triangle) (sl : LowerSqrt) : Prop :=
-  ∀ i : Fin 3, sl.norm (p.rotM₂ℚ (Q_ i)) > r + √2 * ε + 3 * κ
+  ∀ i : Fin 3, sl.norm (p.rotM₂ℚℝ (Q_ i)) > r + √2 * ε + 3 * κ
 
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"
@@ -65,8 +65,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (su : UpperSqrt) (sl : LowerSqrt)
     (hr₁ : BoundRℚ r ε p_.toReal (transportTri Qi hpoly) sl)
     (hδ : BoundDeltaℚ δ p_.toReal (transportTri Pi hpoly) (transportTri Qi hpoly) su)
-    (ae₁ : (transportTri Pi hpoly).Aεℚ p_.toReal.vecX₁ℚ ε)
-    (ae₂ : (transportTri Qi hpoly).Aεℚ p_.toReal.vecX₂ℚ ε)
+    (ae₁ : (transportTri Pi hpoly).Aεℚ p_.toReal.vecX₁ℚℝ ε)
+    (ae₂ : (transportTri Qi hpoly).Aεℚ p_.toReal.vecX₂ℚℝ ε)
     (span₁ : (transportTri Pi hpoly).κSpanning (p_.θ₁ : ℝ) (p_.φ₁ : ℝ) ε)
     (span₂ : (transportTri Qi hpoly).κSpanning (p_.θ₂ : ℝ) (p_.φ₂ : ℝ) ε)
     (be : (transportTri Qi hpoly).Bεℚ Qi
@@ -104,40 +104,40 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
   have ae₁' : P.Aε p_.vecX₁ ε := by
     obtain ⟨σ, hσ₁, hσ₂⟩ := ae₁
     refine ⟨σ, hσ₁, fun i => ?_⟩
-    have hX : ‖⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫‖ ≤ 3 * κ :=
+    have hX : ‖⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₁) (φ := φ₁) (hPnorm i) (hPapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₁ ↑φ₁, P i⟫ > √2 * ε
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
-    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
+    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
       rw [abs_mul, habs, one_mul]; exact hX
     rw [abs_le] at hdiff
-    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₁ ↑φ₁, P i⟫ ⟪vecXℚ ↑θ₁ ↑φ₁, P_ i⟫]
+    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₁ ↑φ₁, P i⟫ ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫]
   have ae₂' : Q.Aε p_.vecX₂ ε := by
     obtain ⟨σ, hσ₁, hσ₂⟩ := ae₂
     refine ⟨σ, hσ₁, fun i => ?_⟩
-    have hX : ‖⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫‖ ≤ 3 * κ :=
+    have hX : ‖⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ > √2 * ε
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
-    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by
+    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by
       rw [abs_mul, habs, one_mul]; exact hX
     rw [abs_le] at hdiff
-    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ ⟪vecXℚ ↑θ₂ ↑φ₂, Q_ i⟫]
+    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫]
   -- Bridge: BoundRℚ → BoundR
   have hr₁' : Local.BoundR r ε p_ Q := by
     intro i
-    have hsl : sl.norm ((rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) ≤ ‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
-      show sl.f _ ≤ _; calc sl.f (‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2)
-        _ ≤ √(‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2) := sl.bound _ (sq_nonneg _)
-        _ = ‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := Real.sqrt_sq (norm_nonneg _)
-    have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ - ‖(rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖)| ≤ 3 * κ :=
+    have hsl : sl.norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) ≤ ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
+      show sl.f _ ≤ _; calc sl.f (‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2)
+        _ ≤ √(‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2) := sl.bound _ (sq_nonneg _)
+        _ = ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := Real.sqrt_sq (norm_nonneg _)
+    have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ - ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖)| ≤ 3 * κ :=
       bounds_kappa3_MQ (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     show ‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ > r + √2 * ε
-    have hr₁i : sl.norm ((rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) > r + √2 * ε + 3 * κ := hr₁ i
+    have hr₁i : sl.norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) > r + √2 * ε + 3 * κ := hr₁ i
     rw [abs_le] at hMQ
     linarith [hMQ.1]
   -- Bridge: BoundDeltaℚ → BoundDelta
@@ -145,46 +145,46 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     intro i
     have := hδ i
     -- su.norm ≥ ‖·‖
-    have hsu : ‖p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i)‖ ≤
-        su.norm (p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i)) := by
+    have hsu : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
+        su.norm (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) := by
       exact UpperSqrt_norm_le su _
     -- ‖real - rational‖ ≤ 6κ
-    have hM₁diff : ‖rotM (↑θ₁ : ℝ) ↑φ₁ - rotMℚ ↑θ₁ ↑φ₁‖ ≤ κ :=
+    have hM₁diff : ‖rotM (↑θ₁ : ℝ) ↑φ₁ - rotMℚℝ ↑θ₁ ↑φ₁‖ ≤ κ :=
       M_difference_norm_bounded _ _ θ₁.property φ₁.property
-    have hM₁ℚnorm : ‖rotMℚ (↑θ₁ : ℝ) ↑φ₁‖ ≤ 1 + κ :=
+    have hM₁ℚnorm : ‖rotMℚℝ (↑θ₁ : ℝ) ↑φ₁‖ ≤ 1 + κ :=
       Mℚ_norm_bounded θ₁.property φ₁.property
-    have hM₂diff : ‖rotM (↑θ₂ : ℝ) ↑φ₂ - rotMℚ ↑θ₂ ↑φ₂‖ ≤ κ :=
+    have hM₂diff : ‖rotM (↑θ₂ : ℝ) ↑φ₂ - rotMℚℝ ↑θ₂ ↑φ₂‖ ≤ κ :=
       M_difference_norm_bounded _ _ θ₂.property φ₂.property
-    have hM₂ℚnorm : ‖rotMℚ (↑θ₂ : ℝ) ↑φ₂‖ ≤ 1 + κ :=
+    have hM₂ℚnorm : ‖rotMℚℝ (↑θ₂ : ℝ) ↑φ₂‖ ≤ 1 + κ :=
       Mℚ_norm_bounded θ₂.property φ₂.property
-    have h₁ : ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)‖ ≤ 2 * κ + κ ^ 2 :=
+    have h₁ : ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)‖ ≤ 2 * κ + κ ^ 2 :=
       clm_approx_apply_sub hM₁diff hM₁ℚnorm (hPnorm i) (hPapprox i)
-    have h₂ : ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ ≤ 2 * κ + κ ^ 2 :=
+    have h₂ : ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ≤ 2 * κ + κ ^ 2 :=
       clm_approx_apply_sub hM₂diff hM₂ℚnorm (hQnorm i) (hQapprox i)
     have hdiff : ‖(p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)) -
-        (p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i))‖ ≤ 4 * κ + 2 * κ ^ 2 := by
+        (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i))‖ ≤ 4 * κ + 2 * κ ^ 2 := by
       show ‖(rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i)) -
-            (rotR p_.α ((rotMℚ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i))‖ ≤ _
+            (rotR p_.α ((rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i))‖ ≤ _
       have hrw : rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i) -
-            (rotR p_.α ((rotMℚ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) =
-            rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)) -
-            ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)) := by
+            (rotR p_.α ((rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) =
+            rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) -
+            ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) := by
         simp [map_sub]; abel
       rw [hrw]
-      calc ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)) -
-              ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i))‖
-        _ ≤ ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i))‖ +
-            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := norm_sub_le _ _
-        _ = ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚ ↑θ₁ ↑φ₁) (P_ i)‖ +
-            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
+      calc ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) -
+              ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i))‖
+        _ ≤ ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i))‖ +
+            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := norm_sub_le _ _
+        _ = ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)‖ +
+            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
           rw [Bounding.rotR_preserves_norm]
         _ ≤ (2 * κ + κ ^ 2) + (2 * κ + κ ^ 2) := add_le_add h₁ h₂
         _ = 4 * κ + 2 * κ ^ 2 := by ring
     show δ ≥ ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ / 2
     have hnorm_le : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
-        ‖p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i)‖ + (4 * κ + 2 * κ ^ 2) := by
+        ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + (4 * κ + 2 * κ ^ 2) := by
       linarith [norm_le_insert' (p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i))
-        (p_.rotR (p_.rotM₁ℚ (P_ i)) - p_.rotM₂ℚ (Q_ i))]
+        (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i))]
     have h6k : 4 * κ + 2 * κ ^ 2 ≤ 6 * κ := by unfold κ; norm_num
     linarith [hsu]
   -- Bridge: Bεℚ → Bε
@@ -202,24 +202,24 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
     have hsu_ge : su.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le su _
     -- Denominator positivity (su.norm ≥ ‖·‖ ≥ 0, and √2*ε + 3κ > 0)
-    have hden_pos : 0 < (su.norm (p_.rotM₂ℚ (Q_ i)) + √2 * ε + 3 * κ) *
-        (su.norm (p_.rotM₂ℚ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ) := by
-      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚ (Q_ i))) (UpperSqrt_norm_le su _)
-      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚ (Q_ i - v_))) (UpperSqrt_norm_le su _)
+    have hden_pos : 0 < (su.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+        (su.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ) := by
+      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le su _)
+      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le su _)
       positivity
     -- Extract positivity of Bεℚ numerator
-    have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+    have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
         2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
       have hδ_pos : 0 < δ := by
         have := hδ 0
         linarith [le_trans (norm_nonneg _)
-          (UpperSqrt_norm_le su (p_.rotR (p_.rotM₁ℚ (P_ 0)) - p_.rotM₂ℚ (Q_ 0)))]
+          (UpperSqrt_norm_le su (p_.rotR (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)))]
       have h0 : 0 < (δ + √5 * ε) / r := by positivity
       exact (div_pos_iff_of_pos_right hden_pos).mp (h0.trans hbe)
     -- su.norm ≥ ‖·‖ means numBεℚ ≤ numAℚ (subtracted term is bigger with su.norm)
-    have hAℚ_num_pos : 0 < ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ -
+    have hAℚ_num_pos : 0 < ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ -
         2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
-      show 0 < ⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+      show 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
           2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)
       have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
           2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
@@ -238,7 +238,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
       _ ≤ κ + κ := add_le_add (hQapprox i) hvapprox
       _ = 2 * κ := by ring
     have h_inner_10 : |⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ -
-        ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫| ≤ 10 * κ :=
+        ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫| ≤ 10 * κ :=
       inner_product_bound_10kappa (θ := θ₂) (φ := φ₂) (hQnorm i) hQv_norm (hQapprox i) hQv_approx
     have h_norm_QR : ‖Q i - poly.vertices.v k‖ ≤ ‖Q_ i - v_‖ + 2 * κ :=
       calc ‖Q i - poly.vertices.v k‖
@@ -246,7 +246,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
         _ ≤ ‖Q_ i - v_‖ + 2 * κ := by grw [hQv_approx]
     have hA_nonneg : 0 ≤ ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ -
         2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) := by
-      have h_inner_le : ⟪(rotMℚ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ ≤
+      have h_inner_le : ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ ≤
           ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ :=
         sub_le_of_abs_sub_le_left h_inner_10
       have h_eps_term : 2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) ≤
@@ -263,14 +263,14 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hBεℚ_le : Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε su ≤
         bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su := by
       -- Express both sides using p_.rotM₂ℚ (which is def. equal to rotMℚ ↑θ₂ ↑φ₂)
-      show (⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+      show (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
             2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε)) /
-          ((su.norm (p_.rotM₂ℚ (Q_ i)) + √2 * ε + 3 * κ) *
-            (su.norm (p_.rotM₂ℚ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ)) ≤
-          (⟪p_.rotM₂ℚ (Q_ i), p_.rotM₂ℚ (Q_ i - v_)⟫ - 10 * κ -
+          ((su.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+            (su.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ)) ≤
+          (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
             2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)) /
-          ((su.norm (p_.rotM₂ℚ (Q_ i)) + √2 * ε + 3 * κ) *
-            (su.norm (p_.rotM₂ℚ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
+          ((su.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+            (su.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
       apply div_le_div_of_nonneg_right _ (le_of_lt hden_pos)
       have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
           2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by

--- a/Noperthedron/SolutionTable/Global.lean
+++ b/Noperthedron/SolutionTable/Global.lean
@@ -24,7 +24,7 @@ theorem valid_global_imp_no_rupert (_tab : Table) (row : Row)
       (Interval.toReal_center_getParam row.interval p).symm
     refine Pose.mk.injEq .. |>.mpr ⟨h .θ₁, h .θ₂, h .φ₁, h .φ₂, h .α⟩
   have hrg := RationalApprox.GlobalTheorem.rational_global
-                 pℚ r hr exactPoly pythonPoly
+                 pℚ r hr exactPoly pythonPolyQ
                  KappaApprox.exact_κApprox_python exactPoly_point_symmetric
   have center_eq : ∀ p : Param, ((row.interval.center p : ℚ) : ℝ) =
       ((row.interval.min.getParam p : ℝ) + (row.interval.max.getParam p : ℝ)) / 2 := by
@@ -41,7 +41,7 @@ theorem valid_global_imp_no_rupert (_tab : Table) (row : Row)
   have hα : (row.α : ℝ) = pbar.α := by
     rw [show (row.α : ℝ) = ((row.interval.center .α : ℚ) : ℝ) from rfl, center_eq]; rfl
   have pc : RationalApprox.GlobalTheorem.RationalGlobalTheoremPrecondition
-             exactPoly pythonPoly KappaApprox.exact_κApprox_python pℚ r := {
+             exactPoly pythonPolyQ KappaApprox.exact_κApprox_python pℚ r := {
     j := row.S_index
     p_in_4 := hrow.center_in_fourQ
     w := WithLp.toLp 2 (fun i : Fin 2 => ((row.w i : ℝ)))

--- a/Noperthedron/Vertices/Exact.lean
+++ b/Noperthedron/Vertices/Exact.lean
@@ -156,7 +156,7 @@ theorem exactVertex_radius_one : Polyhedron.radius ⟨exactVertex⟩ = 1 := by
     exact exactVertex_norm_le_one j
 
 noncomputable
-def exactPolyhedron : Polyhedron VertexIndex := {
+def exactPolyhedron : Polyhedron VertexIndex ℝ³ := {
   v := exactVertex
 }
 

--- a/Noperthedron/Vertices/Python.lean
+++ b/Noperthedron/Vertices/Python.lean
@@ -114,9 +114,5 @@ def pythonVertexCurried : Fin 2 → Fin 3 → Fin 15 → Fin 3 → ℚ := ![
 
 def pythonVertex (idx : VertexIndex) : Fin 3 → ℚ := pythonVertexCurried idx.ℓ idx.i idx.k
 
-/-- Cast a `Fin 3 → ℚ` to an `ℝ³` point. -/
-noncomputable def toR3 (v : Fin 3 → ℚ) : ℝ³ :=
-  WithLp.toLp 2 (fun i => (v i : ℝ))
-
 noncomputable
-def pythonPoly : Polyhedron VertexIndex := ⟨toR3 ∘ pythonVertex⟩
+def pythonPoly : Polyhedron VertexIndex ℝ³ := ⟨toR3 ∘ pythonVertex⟩

--- a/Noperthedron/Vertices/Python.lean
+++ b/Noperthedron/Vertices/Python.lean
@@ -118,4 +118,3 @@ def pythonPolyQ : Polyhedron VertexIndex (Fin 3 → ℚ) := ⟨pythonVertex⟩
 
 noncomputable
 def pythonPoly : Polyhedron VertexIndex ℝ³ := pythonPolyQ.toReal
-

--- a/Noperthedron/Vertices/Python.lean
+++ b/Noperthedron/Vertices/Python.lean
@@ -114,5 +114,8 @@ def pythonVertexCurried : Fin 2 → Fin 3 → Fin 15 → Fin 3 → ℚ := ![
 
 def pythonVertex (idx : VertexIndex) : Fin 3 → ℚ := pythonVertexCurried idx.ℓ idx.i idx.k
 
+def pythonPolyQ : Polyhedron VertexIndex (Fin 3 → ℚ) := ⟨pythonVertex⟩
+
 noncomputable
-def pythonPoly : Polyhedron VertexIndex ℝ³ := ⟨toR3 ∘ pythonVertex⟩
+def pythonPoly : Polyhedron VertexIndex ℝ³ := pythonPolyQ.toReal
+


### PR DESCRIPTION
Also, append an `ℝ` at the end of many RationalApprox defs, in anticipation of adding actually-rational versions of them.