### PR TITLE
finish proof of `valid_local_imp_no_rupert`, i.e. "solution_local"

### DIFF
--- a/Noperthedron.lean
+++ b/Noperthedron.lean
@@ -6,6 +6,7 @@ import Noperthedron.Bounding.OpNorm
 import Noperthedron.Bounding.OrthEquivRotz
 import Noperthedron.Bounding.RaRa
 import Noperthedron.Bounding.SmallConsecutiveRotations
+import Noperthedron.Checker.ApproxSqrt
 import Noperthedron.Checker.Global
 import Noperthedron.Checker.KappaApprox
 import Noperthedron.Checker.Local

--- a/Noperthedron/Checker/ApproxSqrt.lean
+++ b/Noperthedron/Checker/ApproxSqrt.lean
@@ -254,7 +254,7 @@ returns a result in the window provided `fuel ≥ k`.
 Note: maintaining the invariant `scaled < 10^22` is automatic because each
 "up" step is taken only when `scaled < 10^20`, which then yields
 `scaled * 100 < 10^22`. -/
-private lemma findShiftAux_up {x : ℚ} (hx : 0 < x) :
+private lemma findShiftAux_up {x : ℚ} :
     ∀ (k : ℕ) (a : ℤ),
       x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (22 : ℕ)) →
       ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * a) * (100 : ℚ) ^ k →
@@ -298,13 +298,13 @@ private lemma findShiftAux_up {x : ℚ} (hx : 0 < x) :
           linarith [this ▸ hlo]
         exact ih (a + 1) hnew_lt hnew_lo f (Nat.le_of_succ_le_succ hfuel)
     · -- scaled ≥ 10^20: combined with hhi, in window.
-      push_neg at hcase
+      push Not at hcase
       have hw : InWindow x a := ⟨hcase, hhi⟩
       rw [findShiftAux_of_inWindow x a fuel hw]
       exact hw
 
 /-- **Down-search convergence**: symmetric to `findShiftAux_up`. -/
-private lemma findShiftAux_down {x : ℚ} (hx : 0 < x) :
+private lemma findShiftAux_down {x : ℚ} :
     ∀ (k : ℕ) (a : ℤ),
       ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * a) →
       x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ k →
@@ -328,7 +328,7 @@ private lemma findShiftAux_down {x : ℚ} (hx : 0 < x) :
         unfold findShiftAux
         simp only
         have hnotlo : ¬ (x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (20 : ℕ))) := by
-          push_neg
+          push Not
           calc ((10 : ℚ) ^ (20 : ℕ)) ≤ ((10 : ℚ) ^ (22 : ℕ)) := by norm_num
             _ ≤ x * (10 : ℚ) ^ (2 * a) := hcase
         rw [if_neg hnotlo, if_pos hcase]
@@ -357,7 +357,7 @@ private lemma findShiftAux_down {x : ℚ} (hx : 0 < x) :
           exact lt_of_mul_lt_mul_right h1 (by positivity)
         exact ih (a - 1) hnew_lo hnew_hi f (Nat.le_of_succ_le_succ hfuel)
     · -- scaled < 10^22: combined with hlo, in window.
-      push_neg at hcase
+      push Not at hcase
       have hw : InWindow x a := ⟨hlo, hcase⟩
       rw [findShiftAux_of_inWindow x a fuel hw]
       exact hw
@@ -449,9 +449,9 @@ private lemma findShift_inWindow {x : ℚ} (hx : 0 < x) :
     have hfuel : k ≤ N + D + 100 := by rw [hk]; omega
     have hhi0 : x * (10 : ℚ) ^ (2 * (0 : ℤ)) < ((10 : ℚ) ^ (22 : ℕ)) := by
       simp only [mul_zero, zpow_zero, mul_one]; exact hcase
-    exact findShiftAux_up hx k 0 hhi0 hkbound (N + D + 100) hfuel
+    exact findShiftAux_up k 0 hhi0 hkbound (N + D + 100) hfuel
   · -- Down-search. x ≥ 10^22. Use k = N.
-    push_neg at hcase
+    push Not at hcase
     set k : ℕ := N with hk
     have hkbound : x * (10 : ℚ) ^ (2 * (0 : ℤ)) < ((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ k := by
       simp only [mul_zero, zpow_zero, mul_one]
@@ -472,7 +472,7 @@ private lemma findShift_inWindow {x : ℚ} (hx : 0 < x) :
       calc ((10 : ℚ) ^ (20 : ℕ)) ≤ ((10 : ℚ) ^ (22 : ℕ)) := by norm_num
         _ ≤ x := hcase
     have hfuel : k ≤ N + D + 100 := by rw [hk]; omega
-    exact findShiftAux_down hx k 0 hlo0 hkbound (N + D + 100) hfuel
+    exact findShiftAux_down k 0 hlo0 hkbound (N + D + 100) hfuel
 
 private lemma sqrtℚLow_pos_of_pos {y : ℚ} (hy : 0 < y) : 0 < sqrtℚLow y := by
   unfold sqrtℚLow

--- a/Noperthedron/Checker/ApproxSqrt.lean
+++ b/Noperthedron/Checker/ApproxSqrt.lean
@@ -1,0 +1,152 @@
+import Mathlib.Data.Real.Sqrt
+
+import Noperthedron.RationalApprox.Basic
+
+/-!
+# Rational square-root approximations (§7.2.2 of [SY25])
+
+We define computable upper and lower rational square-root functions,
+following Definition 47 and §7.2.2 of SY25.
+
+For all `x : ℚ` with `0 ≤ x`:
+
+  `sqrtℚLow x ≤ √(x : ℝ) ≤ sqrtℚUp x`,
+
+and both functions return `0` on negative input (matching the convention used
+by `Real.sqrt`).
+
+## Construction
+
+* `x = 0` ↦ both return `0`.
+* `x > 0`: find the unique `a ∈ ℤ` such that `x · 10^(2a) ∈ [10^20, 10^22)`,
+  let `b := ⌊√(x · 10^(2a))⌋`, and set
+    `sqrtℚLow x := b / 10^a`,
+    `sqrtℚUp  x := 1 / sqrtℚLow (1 / x)`.
+  This guarantees ten decimal digits of accuracy.
+
+The construction is implemented as follows:
+* `findShift` locates `a` by fuel-bounded iteration starting at `0`.
+* `b` is obtained by `Nat.sqrt` applied to natural-number division of
+  the (positive) numerator and denominator of `x · 10^(2a)`. This works
+  because for any rational `r > 0`, `Nat.sqrt (r.num.toNat / r.den) = ⌊√r⌋`:
+  the largest integer with square `≤ r` equals the largest with square
+  `≤ ⌊r⌋`, since the squares in question are themselves integers.
+-/
+
+namespace RationalApprox
+
+open scoped BigOperators
+
+/-! ## Choosing the scale -/
+
+/-- Auxiliary fuel-bounded search for an integer `a` such that
+`x · 10^(2a) ∈ [10^20, 10^22)`. With `0 < x` and enough fuel, the unique
+such `a` is returned. -/
+private def findShiftAux (x : ℚ) : ℤ → ℕ → ℤ
+  | a, 0          => a
+  | a, fuel + 1 =>
+      let scaled := x * (10 : ℚ) ^ (2 * a)
+      if scaled < ((10 : ℚ) ^ (20 : ℕ)) then
+        findShiftAux x (a + 1) fuel
+      else if ((10 : ℚ) ^ (22 : ℕ)) ≤ scaled then
+        findShiftAux x (a - 1) fuel
+      else
+        a
+/-- The unique integer `a` with `x · 10^(2a) ∈ [10^20, 10^22)`, for `x > 0`.
+
+A fuel of `1024` is far beyond what is needed for any rational arising in the
+proof: each step changes `a` by `1`, and `|a| ≲ digits(x.num) + digits(x.den)`. -/
+def findShift (x : ℚ) : ℤ :=
+  findShiftAux x 0 1024
+
+/-! ## The square-root functions -/
+
+/-- **Lower rational square-root** (`√⁻`): returns `0` on `x ≤ 0`; otherwise
+returns a rational `r` with `r ≤ √x`. -/
+def sqrtℚLow (x : ℚ) : ℚ :=
+  if x ≤ 0 then 0
+  else
+    let a      := findShift x
+    let scaled := x * (10 : ℚ) ^ (2 * a)
+    -- For `0 < scaled` we have `0 < scaled.num`, so `.toNat` is well-defined.
+    -- `b = ⌊√scaled⌋ = Nat.sqrt (scaled.num.toNat / scaled.den)`.
+    let m : ℕ  := scaled.num.toNat / scaled.den
+    let b : ℕ  := Nat.sqrt m
+    (b : ℚ) * (10 : ℚ) ^ (-a)
+
+/-- **Upper rational square-root** (`√⁺`): returns `0` on `x ≤ 0`; otherwise
+returns a rational `r` with `√x ≤ r`, defined as `1 / √⁻ (1/x)`. -/
+def sqrtℚUp (x : ℚ) : ℚ :=
+  if x ≤ 0 then 0
+  else 1 / sqrtℚLow (1 / x)
+
+/-! ## Norms induced on rational vectors
+
+The paper uses, for `Z ∈ ℚⁿ`:
+  `‖Z‖₊ := √⁺ ‖Z‖²`,  `‖Z‖₋ := √⁻ ‖Z‖²`.
+-/
+
+/-- Squared Euclidean norm of a rational vector, taking values in `ℚ`. -/
+def normSqℚ {n : ℕ} (v : Fin n → ℚ) : ℚ :=
+  ∑ i, v i * v i
+
+/-- Lower-rational Euclidean norm: `‖v‖₋ ≤ ‖v‖`. -/
+def normLowℚ {n : ℕ} (v : Fin n → ℚ) : ℚ :=
+  sqrtℚLow (normSqℚ v)
+
+/-- Upper-rational Euclidean norm: `‖v‖ ≤ ‖v‖₊`. -/
+def normUpℚ {n : ℕ} (v : Fin n → ℚ) : ℚ :=
+  sqrtℚUp (normSqℚ v)
+
+/-- `sqrtℚLow` is non-negative. -/
+theorem sqrtℚLow_nonneg (x : ℚ) : 0 ≤ sqrtℚLow x := by
+  sorry
+
+/-- `sqrtℚUp` is non-negative. -/
+theorem sqrtℚUp_nonneg (x : ℚ) : 0 ≤ sqrtℚUp x := by
+  sorry
+
+/-- `√⁻ x ≤ √x` for `x ≥ 0` (Definition 47). -/
+theorem sqrtℚLow_le_sqrt {x : ℚ} (hx : 0 ≤ x) :
+    ((sqrtℚLow x : ℚ) : ℝ) ≤ Real.sqrt ((x : ℚ) : ℝ) := by
+  sorry
+
+/-- `√x ≤ √⁺ x` for `x ≥ 0` (Definition 47). -/
+theorem sqrt_le_sqrtℚUp {x : ℚ} (hx : 0 ≤ x) :
+    Real.sqrt ((x : ℚ) : ℝ) ≤ ((sqrtℚUp x : ℚ) : ℝ) := by
+  sorry
+
+/-- For a rational vector, the lower-norm bounds the true Euclidean norm. -/
+theorem normLowℚ_le_norm {n : ℕ} (v : Fin n → ℚ) :
+    ((normLowℚ v : ℚ) : ℝ) ≤ Real.sqrt ((normSqℚ v : ℚ) : ℝ) :=
+  sorry -- sqrtℚLow_le_sqrt (by positivity)
+
+/-- For a rational vector, the true Euclidean norm bounds the upper-norm. -/
+theorem norm_le_normUpℚ {n : ℕ} (v : Fin n → ℚ) :
+    Real.sqrt ((normSqℚ v : ℚ) : ℝ) ≤ ((normUpℚ v : ℚ) : ℝ) :=
+  sorry --sqrt_le_sqrtℚUp (by positivity)
+
+end RationalApprox
+
+/-
+/-! ## Sanity checks -/
+section Examples
+open RationalApprox
+
+-- `√2 ≈ 1.41421356237…`. We expect `sqrtℚLow 2` slightly below and
+-- `sqrtℚUp 2` slightly above.
+#eval sqrtℚLow 2          -- 14142135623 / 10000000000
+#eval sqrtℚUp 2
+
+-- `√(1/2) ≈ 0.70710678118…`.
+#eval sqrtℚLow (1/2)
+#eval sqrtℚUp  (1/2)
+
+-- `√100 = 10`; the lower rational sqrt should match exactly,
+-- though `b = 10^11` because of the chosen scale.
+#eval sqrtℚLow 100
+#eval sqrtℚUp  100
+
+end Examples
+-/
+

--- a/Noperthedron/Checker/ApproxSqrt.lean
+++ b/Noperthedron/Checker/ApproxSqrt.lean
@@ -602,25 +602,32 @@ def sqrtApprox : Approx where
 
 end RationalApprox
 
-/-
 /-! ## Sanity checks -/
 section Examples
 open RationalApprox
 
--- `√2 ≈ 1.41421356237…`. We expect `sqrtℚLow 2` slightly below and
--- `sqrtℚUp 2` slightly above.
-#eval sqrtℚLow 2          -- 14142135623 / 10000000000
+/-- info: 14142135623 / 10000000000 -/
+#guard_msgs in
+#eval sqrtℚLow 2
+
+/-- info: 50000000000 / 35355339059 -/
+#guard_msgs in
 #eval sqrtℚUp 2
 
--- `√(1/2) ≈ 0.70710678118…`.
+/-- info: 35355339059 / 50000000000 -/
+#guard_msgs in
 #eval sqrtℚLow (1/2)
+
+/-- info: 10000000000 / 14142135623 -/
+#guard_msgs in
 #eval sqrtℚUp  (1/2)
 
--- `√100 = 10`; the lower rational sqrt should match exactly,
--- though `b = 10^11` because of the chosen scale.
+/-- info: 10 -/
+#guard_msgs in
 #eval sqrtℚLow 100
+
+/-- info: 10 -/
+#guard_msgs in
 #eval sqrtℚUp  100
 
 end Examples
--/
-

--- a/Noperthedron/Checker/ApproxSqrt.lean
+++ b/Noperthedron/Checker/ApproxSqrt.lean
@@ -593,10 +593,18 @@ def lowerSqrt : LowerSqrt where
 def sqrtApprox : Approx where
   upper_sqrt_two := 1.42
   upper_sqrt_two_gt_sqrt_two := by
-    sorry
+    show ((1.42 : ℚ) : ℝ) > Real.sqrt 2
+    have h : Real.sqrt 2 < (1.42 : ℝ) :=
+      (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+    push_cast
+    linarith
   upper_sqrt_five := 2.24
   upper_sqrt_five_gt_sqrt_five := by
-    sorry
+    show ((2.24 : ℚ) : ℝ) > Real.sqrt 5
+    have h : Real.sqrt 5 < (2.24 : ℝ) :=
+      (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+    push_cast
+    linarith
   lower_sqrt := lowerSqrt
   upper_sqrt := upperSqrt
 

--- a/Noperthedron/Checker/ApproxSqrt.lean
+++ b/Noperthedron/Checker/ApproxSqrt.lean
@@ -582,6 +582,24 @@ theorem norm_le_normUpℚ {n : ℕ} (v : Fin n → ℚ) :
     Real.sqrt ((normSqℚ v : ℚ) : ℝ) ≤ ((normUpℚ v : ℚ) : ℝ) :=
   sqrt_le_sqrtℚUp (normSqℚ_nonneg v)
 
+def upperSqrt : UpperSqrt where
+  f := sqrtℚUp
+  bound _ := sqrt_le_sqrtℚUp
+
+def lowerSqrt : LowerSqrt where
+  f := sqrtℚLow
+  bound _ := sqrtℚLow_le_sqrt
+
+def sqrtApprox : Approx where
+  upper_sqrt_two := 1.42
+  upper_sqrt_two_gt_sqrt_two := by
+    sorry
+  upper_sqrt_five := 2.24
+  upper_sqrt_five_gt_sqrt_five := by
+    sorry
+  lower_sqrt := lowerSqrt
+  upper_sqrt := upperSqrt
+
 end RationalApprox
 
 /-

--- a/Noperthedron/Checker/ApproxSqrt.lean
+++ b/Noperthedron/Checker/ApproxSqrt.lean
@@ -54,10 +54,11 @@ private def findShiftAux (x : ℚ) : ℤ → ℕ → ℤ
         a
 /-- The unique integer `a` with `x · 10^(2a) ∈ [10^20, 10^22)`, for `x > 0`.
 
-A fuel of `1024` is far beyond what is needed for any rational arising in the
-proof: each step changes `a` by `1`, and `|a| ≲ digits(x.num) + digits(x.den)`. -/
+The fuel grows with the magnitude of the input, so the search converges for
+any `0 < x`: we have `|a*| ≲ digits(x.num) + digits(x.den)`, where the search
+moves by `±1` per step. -/
 def findShift (x : ℚ) : ℤ :=
-  findShiftAux x 0 1024
+  findShiftAux x 0 (Nat.log 10 x.num.natAbs + Nat.log 10 x.den + 100)
 
 /-! ## The square-root functions -/
 
@@ -100,31 +101,486 @@ def normUpℚ {n : ℕ} (v : Fin n → ℚ) : ℚ :=
 
 /-- `sqrtℚLow` is non-negative. -/
 theorem sqrtℚLow_nonneg (x : ℚ) : 0 ≤ sqrtℚLow x := by
-  sorry
+  unfold sqrtℚLow
+  split_ifs with h
+  · exact le_refl 0
+  · positivity
 
 /-- `sqrtℚUp` is non-negative. -/
 theorem sqrtℚUp_nonneg (x : ℚ) : 0 ≤ sqrtℚUp x := by
-  sorry
+  unfold sqrtℚUp
+  split_ifs with h
+  · exact le_refl 0
+  · exact div_nonneg zero_le_one (sqrtℚLow_nonneg _)
+
+/-- Squared lower bound: `(sqrtℚLow x)^2 ≤ x` (cast to ℝ) for `0 ≤ x`. -/
+private lemma sqrtℚLow_sq_le (x : ℚ) (hx : 0 ≤ x) :
+    ((sqrtℚLow x : ℚ) : ℝ) ^ 2 ≤ ((x : ℚ) : ℝ) := by
+  unfold sqrtℚLow
+  split_ifs with h
+  · -- x ≤ 0, so sqrtℚLow x = 0; combined with 0 ≤ x means x = 0.
+    have hx0 : x = 0 := le_antisymm h hx
+    simp [hx0]
+  · -- 0 < x
+    have h : 0 < x := lt_of_le_of_ne hx (fun heq => h (by simp [← heq]))
+    set a := findShift x with ha
+    set scaled : ℚ := x * (10 : ℚ) ^ (2 * a) with hscaled
+    set m : ℕ := scaled.num.toNat / scaled.den with hm
+    set b : ℕ := Nat.sqrt m with hb
+    -- Goal: ((b : ℚ) * (10 : ℚ)^(-a))^2 ≤ x in ℝ.
+    have h10pos : (0 : ℝ) < (10 : ℝ) ^ (2 * a) := by positivity
+    have hscaled_pos : 0 < scaled := by
+      simp [hscaled]; exact mul_pos h (by positivity)
+    have hscaled_num_pos : 0 < scaled.num := Rat.num_pos.mpr hscaled_pos
+    have hscaled_den_pos : (0 : ℤ) < scaled.den := by exact_mod_cast scaled.pos
+    -- (m : ℝ) ≤ (scaled : ℝ)
+    have hm_le_scaled : (m : ℝ) ≤ (scaled : ℝ) := by
+      have h1 : m * scaled.den ≤ scaled.num.toNat := Nat.div_mul_le_self _ _
+      have htoNat : (scaled.num.toNat : ℤ) = scaled.num :=
+        Int.toNat_of_nonneg (le_of_lt hscaled_num_pos)
+      have h2 : (m : ℤ) * (scaled.den : ℤ) ≤ scaled.num := by
+        have := h1
+        have h3 : ((m * scaled.den : ℕ) : ℤ) ≤ ((scaled.num.toNat : ℕ) : ℤ) := by
+          exact_mod_cast h1
+        rw [Nat.cast_mul, Int.toNat_of_nonneg (le_of_lt hscaled_num_pos)] at h3
+        exact h3
+      have h4 : (m : ℝ) * (scaled.den : ℝ) ≤ (scaled.num : ℝ) := by exact_mod_cast h2
+      have hden_pos_R : (0 : ℝ) < (scaled.den : ℝ) := by exact_mod_cast hscaled_den_pos
+      have : (m : ℝ) ≤ (scaled.num : ℝ) / (scaled.den : ℝ) :=
+        (le_div_iff₀ hden_pos_R).mpr h4
+      have hcast : ((scaled : ℚ) : ℝ) = (scaled.num : ℝ) / (scaled.den : ℝ) := by
+        rw [Rat.cast_def]
+      rw [hcast]
+      exact this
+    -- (b : ℝ)^2 ≤ (m : ℝ)
+    have hbb_le_m : (b : ℝ) ^ 2 ≤ (m : ℝ) := by
+      have : b * b ≤ m := Nat.sqrt_le m
+      have : (b * b : ℕ) ≤ (m : ℕ) := this
+      have hRR : ((b * b : ℕ) : ℝ) ≤ ((m : ℕ) : ℝ) := by exact_mod_cast this
+      simpa [pow_two, Nat.cast_mul] using hRR
+    -- Combine: (b : ℝ)^2 ≤ (scaled : ℝ)
+    have hbb_le_scaled : (b : ℝ) ^ 2 ≤ ((scaled : ℚ) : ℝ) := le_trans hbb_le_m hm_le_scaled
+    -- ((b : ℝ) * 10^(-a))^2 = (b : ℝ)^2 * 10^(-2a)
+    -- And (scaled : ℝ) * 10^(-2a) = (x : ℝ).
+    have h10a_pos : (0 : ℝ) < (10 : ℝ) ^ ((-2 * a : ℤ)) := by positivity
+    have hscaled_cast : ((scaled : ℚ) : ℝ) = (x : ℝ) * (10 : ℝ) ^ (2 * a) := by
+      show (((x * (10 : ℚ) ^ (2 * a)) : ℚ) : ℝ) = _
+      push_cast
+      rfl
+    -- multiply both sides of hbb_le_scaled by 10^(-2a) > 0
+    have hmul : (b : ℝ) ^ 2 * (10 : ℝ) ^ ((-2 * a : ℤ)) ≤
+        ((scaled : ℚ) : ℝ) * (10 : ℝ) ^ ((-2 * a : ℤ)) :=
+      mul_le_mul_of_nonneg_right hbb_le_scaled (le_of_lt h10a_pos)
+    have h10ne : (10 : ℝ) ≠ 0 := by norm_num
+    have hRHS : ((scaled : ℚ) : ℝ) * (10 : ℝ) ^ ((-2 * a : ℤ)) = (x : ℝ) := by
+      rw [hscaled_cast, mul_assoc, ← zpow_add₀ h10ne]
+      have : (2 * a : ℤ) + (-2 * a : ℤ) = 0 := by ring
+      rw [this]
+      simp
+    -- LHS rewriting
+    have hLHS_eq : (((b : ℚ) * (10 : ℚ) ^ (-a) : ℚ) : ℝ) ^ 2 =
+        (b : ℝ) ^ 2 * (10 : ℝ) ^ ((-2 * a : ℤ)) := by
+      push_cast
+      rw [mul_pow]
+      have : ((10 : ℝ) ^ (-a)) ^ 2 = (10 : ℝ) ^ ((-2 * a : ℤ)) := by
+        rw [← zpow_natCast _ 2, ← zpow_mul]
+        congr 1
+        push_cast
+        ring
+      rw [this]
+    rw [hLHS_eq, ← hRHS]
+    exact hmul
 
 /-- `√⁻ x ≤ √x` for `x ≥ 0` (Definition 47). -/
 theorem sqrtℚLow_le_sqrt {x : ℚ} (hx : 0 ≤ x) :
     ((sqrtℚLow x : ℚ) : ℝ) ≤ Real.sqrt ((x : ℚ) : ℝ) := by
-  sorry
+  apply Real.le_sqrt_of_sq_le
+  exact sqrtℚLow_sq_le x hx
+
+/-! ### Correctness of `findShiftAux`
+
+For `0 < x`, with sufficient fuel, `findShiftAux x a fuel` returns an integer
+`a'` such that `x * 10^(2a') ∈ [10^20, 10^22)`. The proof builds up:
+1. If already in `[10^20, 10^22)`, the function returns `a`.
+2. Up-search converges: starting strictly below, multiplying by `100` each
+   step we cross into the window (and never overshoot, since the window has
+   multiplicative width `100`).
+3. Down-search converges: symmetric.
+4. The fuel bound `Nat.log 10 num + Nat.log 10 den + 100` always suffices.
+-/
+
+/-- The "in window" predicate for the scale search. -/
+private def InWindow (x : ℚ) (a : ℤ) : Prop :=
+  ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * a) ∧
+    x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (22 : ℕ))
+
+/-- If we are already in the target window, `findShiftAux` returns the current `a`. -/
+private lemma findShiftAux_of_inWindow (x : ℚ) (a : ℤ) (fuel : ℕ)
+    (hw : InWindow x a) : findShiftAux x a fuel = a := by
+  cases fuel with
+  | zero => rfl
+  | succ n =>
+    obtain ⟨hlo, hhi⟩ := hw
+    unfold findShiftAux
+    simp only
+    have h1 : ¬ (x * (10 : ℚ) ^ (2 * a) < (10 : ℚ) ^ (20 : ℕ)) := not_lt.mpr hlo
+    have h2 : ¬ ((10 : ℚ) ^ (22 : ℕ) ≤ x * (10 : ℚ) ^ (2 * a)) := not_le.mpr hhi
+    rw [if_neg h1, if_neg h2]
+
+/-- Stepping `a` up by 1 multiplies the scaled value by 100. -/
+private lemma scaled_step_up (x : ℚ) (a : ℤ) :
+    x * (10 : ℚ) ^ (2 * (a + 1)) = x * (10 : ℚ) ^ (2 * a) * 100 := by
+  have h10ne : (10 : ℚ) ≠ 0 := by norm_num
+  have hrw : (10 : ℚ) ^ (2 * (a + 1)) = (10 : ℚ) ^ (2 * a) * (10 : ℚ) ^ 2 := by
+    have heq : (2 * (a + 1) : ℤ) = 2 * a + 2 := by ring
+    rw [heq, zpow_add₀ h10ne]
+    rfl
+  rw [hrw]; ring
+
+/-- Stepping `a` down by 1 divides the scaled value by 100. -/
+private lemma scaled_step_down (x : ℚ) (a : ℤ) :
+    x * (10 : ℚ) ^ (2 * (a - 1)) * 100 = x * (10 : ℚ) ^ (2 * a) := by
+  have h10ne : (10 : ℚ) ≠ 0 := by norm_num
+  have hrw : (10 : ℚ) ^ (2 * a) = (10 : ℚ) ^ (2 * (a - 1)) * (10 : ℚ) ^ 2 := by
+    have heq : (2 * a : ℤ) = 2 * (a - 1) + 2 := by ring
+    rw [heq, zpow_add₀ h10ne]
+    rfl
+  rw [hrw]; ring
+
+/-- **Up-search convergence**: if `0 < x`, currently `scaled := x * 10^(2a) < 10^22`,
+and `scaled * 100^k ≥ 10^20` for some `k : ℕ`, then `findShiftAux x a fuel`
+returns a result in the window provided `fuel ≥ k`.
+
+Note: maintaining the invariant `scaled < 10^22` is automatic because each
+"up" step is taken only when `scaled < 10^20`, which then yields
+`scaled * 100 < 10^22`. -/
+private lemma findShiftAux_up {x : ℚ} (hx : 0 < x) :
+    ∀ (k : ℕ) (a : ℤ),
+      x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (22 : ℕ)) →
+      ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * a) * (100 : ℚ) ^ k →
+      ∀ fuel, k ≤ fuel → InWindow x (findShiftAux x a fuel) := by
+  intro k
+  induction k with
+  | zero =>
+    intro a hhi hlo fuel _
+    -- scaled * 100^0 = scaled, so 10^20 ≤ scaled < 10^22 means in window.
+    have hlo' : ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * a) := by
+      simpa using hlo
+    have hw : InWindow x a := ⟨hlo', hhi⟩
+    rw [findShiftAux_of_inWindow x a fuel hw]
+    exact hw
+  | succ j ih =>
+    intro a hhi hlo fuel hfuel
+    by_cases hcase : x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (20 : ℕ))
+    · -- scaled too low: step up. Apply IH at a+1 with k=j.
+      cases fuel with
+      | zero => omega
+      | succ f =>
+        unfold findShiftAux
+        simp only
+        rw [if_pos hcase]
+        -- New scaled = old scaled * 100; need new < 10^22.
+        have hnew_eq : x * (10 : ℚ) ^ (2 * (a + 1)) = x * (10 : ℚ) ^ (2 * a) * 100 :=
+          scaled_step_up x a
+        have hnew_lt : x * (10 : ℚ) ^ (2 * (a + 1)) < ((10 : ℚ) ^ (22 : ℕ)) := by
+          rw [hnew_eq]
+          have hpos : (0 : ℚ) < 100 := by norm_num
+          have h1 : x * (10 : ℚ) ^ (2 * a) * 100 < ((10 : ℚ) ^ (20 : ℕ)) * 100 := by
+            exact mul_lt_mul_of_pos_right hcase hpos
+          have h2 : ((10 : ℚ) ^ (20 : ℕ)) * 100 = (10 : ℚ) ^ (22 : ℕ) := by norm_num
+          linarith
+        -- New 100^j bound:
+        -- old: 10^20 ≤ x * 10^(2a) * 100^(j+1) = (x * 10^(2(a+1))) * 100^j
+        have hnew_lo : ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * (a + 1)) * (100 : ℚ) ^ j := by
+          have : x * (10 : ℚ) ^ (2 * a) * (100 : ℚ) ^ (j + 1) =
+                 x * (10 : ℚ) ^ (2 * (a + 1)) * (100 : ℚ) ^ j := by
+            rw [hnew_eq, pow_succ]; ring
+          linarith [this ▸ hlo]
+        exact ih (a + 1) hnew_lt hnew_lo f (Nat.le_of_succ_le_succ hfuel)
+    · -- scaled ≥ 10^20: combined with hhi, in window.
+      push_neg at hcase
+      have hw : InWindow x a := ⟨hcase, hhi⟩
+      rw [findShiftAux_of_inWindow x a fuel hw]
+      exact hw
+
+/-- **Down-search convergence**: symmetric to `findShiftAux_up`. -/
+private lemma findShiftAux_down {x : ℚ} (hx : 0 < x) :
+    ∀ (k : ℕ) (a : ℤ),
+      ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * a) →
+      x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ k →
+      ∀ fuel, k ≤ fuel → InWindow x (findShiftAux x a fuel) := by
+  intro k
+  induction k with
+  | zero =>
+    intro a hlo hhi fuel _
+    have hhi' : x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (22 : ℕ)) := by
+      simpa using hhi
+    have hw : InWindow x a := ⟨hlo, hhi'⟩
+    rw [findShiftAux_of_inWindow x a fuel hw]
+    exact hw
+  | succ j ih =>
+    intro a hlo hhi fuel hfuel
+    by_cases hcase : ((10 : ℚ) ^ (22 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * a)
+    · -- scaled too high: step down. New scaled = old / 100.
+      cases fuel with
+      | zero => omega
+      | succ f =>
+        unfold findShiftAux
+        simp only
+        have hnotlo : ¬ (x * (10 : ℚ) ^ (2 * a) < ((10 : ℚ) ^ (20 : ℕ))) := by
+          push_neg
+          calc ((10 : ℚ) ^ (20 : ℕ)) ≤ ((10 : ℚ) ^ (22 : ℕ)) := by norm_num
+            _ ≤ x * (10 : ℚ) ^ (2 * a) := hcase
+        rw [if_neg hnotlo, if_pos hcase]
+        -- Recurse at a-1. New scaled = old scaled / 100.
+        have hnew_eq : x * (10 : ℚ) ^ (2 * (a - 1)) * 100 = x * (10 : ℚ) ^ (2 * a) :=
+          scaled_step_down x a
+        -- 10^20 ≤ new_scaled? old ≥ 10^22 ≥ 10^20*100, so new ≥ 10^20.
+        have hnew_lo : ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * (a - 1)) := by
+          have h1 : ((10 : ℚ) ^ (22 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * (a - 1)) * 100 := by
+            rw [hnew_eq]; exact hcase
+          have h22eq : ((10 : ℚ) ^ (22 : ℕ)) = ((10 : ℚ) ^ (20 : ℕ)) * 100 := by norm_num
+          have h2 : ((10 : ℚ) ^ (20 : ℕ)) * 100 ≤ x * (10 : ℚ) ^ (2 * (a - 1)) * 100 := by
+            rw [← h22eq]; exact h1
+          have hpos : (0 : ℚ) < 100 := by norm_num
+          exact le_of_mul_le_mul_right h2 hpos
+        -- new_scaled < 10^22 * 100^j:
+        -- old / 100 < 10^22 * 100^(j+1) / 100 = 10^22 * 100^j (for j ≥ 0).
+        have hnew_hi : x * (10 : ℚ) ^ (2 * (a - 1)) < ((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ j := by
+          have h1 : x * (10 : ℚ) ^ (2 * (a - 1)) * 100 < ((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ (j + 1) := by
+            rw [hnew_eq]; exact hhi
+          have h2 : ((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ (j + 1) =
+                    (((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ j) * 100 := by
+            rw [pow_succ]; ring
+          rw [h2] at h1
+          have hpos : (0 : ℚ) < 100 := by norm_num
+          exact lt_of_mul_lt_mul_right h1 (by positivity)
+        exact ih (a - 1) hnew_lo hnew_hi f (Nat.le_of_succ_le_succ hfuel)
+    · -- scaled < 10^22: combined with hlo, in window.
+      push_neg at hcase
+      have hw : InWindow x a := ⟨hlo, hcase⟩
+      rw [findShiftAux_of_inWindow x a fuel hw]
+      exact hw
+
+/-- `Nat.log 10 n` provides an upper bound: `n < 10^(Nat.log 10 n + 1)`. -/
+private lemma nat_lt_ten_pow_log_succ (n : ℕ) :
+    (n : ℚ) < (10 : ℚ) ^ (Nat.log 10 n + 1) := by
+  have h := Nat.lt_pow_succ_log_self (by norm_num : 1 < 10) n
+  have hcast : (n : ℚ) < ((10 ^ (Nat.log 10 n + 1) : ℕ) : ℚ) := by exact_mod_cast h
+  rw [Nat.cast_pow] at hcast
+  exact_mod_cast hcast
+
+/-- Useful: `0 < x.num.natAbs` for `0 < x`. -/
+private lemma num_natAbs_pos {x : ℚ} (hx : 0 < x) : 0 < x.num.natAbs :=
+  Int.natAbs_pos.mpr (ne_of_gt (Rat.num_pos.mpr hx))
+
+/-- For `0 < x`, `x ≥ 1 / x.den` since `x.num ≥ 1`. -/
+private lemma rat_ge_one_div_den {x : ℚ} (hx : 0 < x) :
+    (1 : ℚ) / (x.den : ℚ) ≤ x := by
+  have hd_pos : (0 : ℚ) < (x.den : ℚ) := by exact_mod_cast x.pos
+  have hnum_pos : 0 < x.num := Rat.num_pos.mpr hx
+  have hnum_ge_one : (1 : ℚ) ≤ (x.num : ℚ) := by exact_mod_cast hnum_pos
+  rw [div_le_iff₀ hd_pos]
+  -- 1 * den ≤ x * den, i.e., den ≤ x * den = num
+  have : x * (x.den : ℚ) = (x.num : ℚ) := by
+    rw [Rat.mul_den_eq_num]
+  rw [this]
+  linarith
+
+/-- For `0 < x`, `x ≤ x.num.natAbs` since `x.den ≥ 1`. -/
+private lemma rat_le_num {x : ℚ} (hx : 0 < x) :
+    x ≤ (x.num.natAbs : ℚ) := by
+  have hd_pos : (0 : ℚ) < (x.den : ℚ) := by exact_mod_cast x.pos
+  have hd_ge : (1 : ℚ) ≤ (x.den : ℚ) := by exact_mod_cast x.pos
+  have hnum_pos : 0 < x.num := Rat.num_pos.mpr hx
+  have hnum_natAbs : (x.num.natAbs : ℚ) = (x.num : ℚ) := by
+    rw [Nat.cast_natAbs, abs_of_pos hnum_pos]
+  rw [hnum_natAbs]
+  -- x ≤ num: since x * den = num and den ≥ 1, x ≤ x * den = num.
+  have hxd : x * (x.den : ℚ) = (x.num : ℚ) := by
+    rw [Rat.mul_den_eq_num]
+  have hpos : 0 ≤ x := le_of_lt hx
+  nlinarith [hpos, hd_ge, hxd]
+
+/-- `(100:ℚ)^k = (10:ℚ)^(2k)`. -/
+private lemma pow_hundred_eq (k : ℕ) : (100 : ℚ) ^ k = (10 : ℚ) ^ (2 * k) := by
+  rw [show (100 : ℚ) = 10 ^ 2 from by norm_num, ← pow_mul, mul_comm]
+
+/-- For `0 < x`, `findShiftAux x 0 fuel` is in window when fuel is large enough. -/
+private lemma findShift_inWindow {x : ℚ} (hx : 0 < x) :
+    InWindow x (findShift x) := by
+  unfold findShift
+  set N := Nat.log 10 x.num.natAbs with hN
+  set D := Nat.log 10 x.den with hD
+  -- Case split: is x < 10^22 or not?
+  by_cases hcase : x < ((10 : ℚ) ^ (22 : ℕ))
+  · -- Up-search. Use k = D + 11. Then 2k = 2D + 22.
+    set k : ℕ := D + 11 with hk
+    have hkbound : ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * (0 : ℤ)) * (100 : ℚ) ^ k := by
+      simp only [mul_zero, zpow_zero, mul_one]
+      -- x * 100^k ≥ (1/den) * 10^(2k) ≥ (1/10^(D+1)) * 10^(2D+22) = 10^(D+21) ≥ 10^20.
+      rw [pow_hundred_eq]
+      have hx_lb : (1 : ℚ) / (x.den : ℚ) ≤ x := rat_ge_one_div_den hx
+      have hden_lt : (x.den : ℚ) < (10 : ℚ) ^ (D + 1) := nat_lt_ten_pow_log_succ x.den
+      have hden_pos : (0 : ℚ) < (x.den : ℚ) := by exact_mod_cast x.pos
+      have h10pos : (0 : ℚ) < (10 : ℚ) ^ (D + 1) := by positivity
+      have hinv : (1 : ℚ) / (10 : ℚ) ^ (D + 1) ≤ 1 / (x.den : ℚ) :=
+        le_of_lt (one_div_lt_one_div_of_lt hden_pos hden_lt)
+      have hxd : (1 : ℚ) / (10 : ℚ) ^ (D + 1) ≤ x := le_trans hinv hx_lb
+      have h10ne : (10 : ℚ) ≠ 0 := by norm_num
+      -- Now 10^20 ≤ 1/10^(D+1) * 10^(2k):
+      have h2k : 2 * k = 2 * D + 22 := by rw [hk]; ring
+      have hsplit : (10 : ℚ) ^ (2 * k) = (10 : ℚ) ^ (D + 1) * (10 : ℚ) ^ (D + 21) := by
+        rw [← pow_add]
+        congr 1
+        omega
+      have h_eq : (1 : ℚ) / (10 : ℚ) ^ (D + 1) * (10 : ℚ) ^ (2 * k) = (10 : ℚ) ^ (D + 21) := by
+        rw [hsplit]
+        field_simp
+      have hge_20 : ((10 : ℚ) ^ (20 : ℕ)) ≤ (10 : ℚ) ^ (D + 21) := by
+        apply pow_le_pow_right₀ (by norm_num : (1:ℚ) ≤ 10)
+        omega
+      have hpos2k : (0 : ℚ) < (10 : ℚ) ^ (2 * k) := by positivity
+      calc ((10 : ℚ) ^ (20 : ℕ))
+          ≤ (10 : ℚ) ^ (D + 21) := hge_20
+        _ = (1 : ℚ) / (10 : ℚ) ^ (D + 1) * (10 : ℚ) ^ (2 * k) := h_eq.symm
+        _ ≤ x * (10 : ℚ) ^ (2 * k) :=
+            mul_le_mul_of_nonneg_right hxd (le_of_lt hpos2k)
+    have hfuel : k ≤ N + D + 100 := by rw [hk]; omega
+    have hhi0 : x * (10 : ℚ) ^ (2 * (0 : ℤ)) < ((10 : ℚ) ^ (22 : ℕ)) := by
+      simp only [mul_zero, zpow_zero, mul_one]; exact hcase
+    exact findShiftAux_up hx k 0 hhi0 hkbound (N + D + 100) hfuel
+  · -- Down-search. x ≥ 10^22. Use k = N.
+    push_neg at hcase
+    set k : ℕ := N with hk
+    have hkbound : x * (10 : ℚ) ^ (2 * (0 : ℤ)) < ((10 : ℚ) ^ (22 : ℕ)) * (100 : ℚ) ^ k := by
+      simp only [mul_zero, zpow_zero, mul_one]
+      rw [pow_hundred_eq]
+      -- Need x < 10^22 * 10^(2k) = 10^(22 + 2k).
+      have hx_le_num : x ≤ (x.num.natAbs : ℚ) := rat_le_num hx
+      have hnum_lt : (x.num.natAbs : ℚ) < (10 : ℚ) ^ (N + 1) := nat_lt_ten_pow_log_succ x.num.natAbs
+      have hexp : ((10 : ℚ) ^ (22 : ℕ)) * (10 : ℚ) ^ (2 * k) = (10 : ℚ) ^ (22 + 2 * k) := by
+        rw [← pow_add]
+      rw [hexp]
+      calc x ≤ (x.num.natAbs : ℚ) := hx_le_num
+        _ < (10 : ℚ) ^ (N + 1) := hnum_lt
+        _ ≤ (10 : ℚ) ^ (22 + 2 * k) := by
+            apply pow_le_pow_right₀ (by norm_num : (1:ℚ) ≤ 10)
+            rw [hk]; omega
+    have hlo0 : ((10 : ℚ) ^ (20 : ℕ)) ≤ x * (10 : ℚ) ^ (2 * (0 : ℤ)) := by
+      simp only [mul_zero, zpow_zero, mul_one]
+      calc ((10 : ℚ) ^ (20 : ℕ)) ≤ ((10 : ℚ) ^ (22 : ℕ)) := by norm_num
+        _ ≤ x := hcase
+    have hfuel : k ≤ N + D + 100 := by rw [hk]; omega
+    exact findShiftAux_down hx k 0 hlo0 hkbound (N + D + 100) hfuel
+
+private lemma sqrtℚLow_pos_of_pos {y : ℚ} (hy : 0 < y) : 0 < sqrtℚLow y := by
+  unfold sqrtℚLow
+  have hy_nle : ¬ (y ≤ 0) := not_le.mpr hy
+  rw [if_neg hy_nle]
+  set a := findShift y with ha
+  set scaled : ℚ := y * (10 : ℚ) ^ (2 * a) with hscaled
+  set m : ℕ := scaled.num.toNat / scaled.den with hm
+  set b : ℕ := Nat.sqrt m with hb
+  -- Goal: 0 < (b : ℚ) * 10^(-a)
+  -- We need 0 < b. By in-window, scaled ≥ 10^20, so m ≥ 1.
+  have hwin : InWindow y a := findShift_inWindow hy
+  obtain ⟨hlo, _⟩ := hwin
+  -- scaled ≥ 10^20 ≥ 1
+  have hscaled_ge_one : (1 : ℚ) ≤ scaled := by
+    rw [hscaled]
+    calc (1 : ℚ) ≤ (10 : ℚ) ^ (20 : ℕ) := by norm_num
+      _ ≤ y * (10 : ℚ) ^ (2 * a) := hlo
+  have hscaled_pos : 0 < scaled := lt_of_lt_of_le zero_lt_one hscaled_ge_one
+  -- num ≥ den. Since 1 ≤ scaled = num/den (with den > 0), we have num ≥ den.
+  have hden_pos : 0 < scaled.den := scaled.pos
+  have hnum_pos : 0 < scaled.num := Rat.num_pos.mpr hscaled_pos
+  have hnum_ge_den : (scaled.den : ℤ) ≤ scaled.num := by
+    have hx_eq : scaled = (scaled.num : ℚ) / (scaled.den : ℚ) := (Rat.num_div_den scaled).symm
+    have hd_pos : (0 : ℚ) < (scaled.den : ℚ) := by exact_mod_cast hden_pos
+    have h1 : (1 : ℚ) * (scaled.den : ℚ) ≤ (scaled.num : ℚ) := by
+      have := hscaled_ge_one
+      rw [hx_eq] at this
+      rw [le_div_iff₀ hd_pos] at this
+      exact this
+    rw [one_mul] at h1
+    exact_mod_cast h1
+  -- m = num.toNat / den ≥ 1
+  have hm_ge_one : 1 ≤ m := by
+    rw [hm]
+    apply Nat.one_le_div_iff hden_pos |>.mpr
+    have : (scaled.den : ℤ) ≤ (scaled.num.toNat : ℤ) := by
+      rw [Int.toNat_of_nonneg (le_of_lt hnum_pos)]
+      exact hnum_ge_den
+    exact_mod_cast this
+  -- b = Nat.sqrt m ≥ Nat.sqrt 1 = 1
+  have hb_ge_one : 1 ≤ b := by
+    rw [hb]
+    have : Nat.sqrt 1 ≤ Nat.sqrt m := Nat.sqrt_le_sqrt hm_ge_one
+    simpa using this
+  have hb_pos : (0 : ℚ) < (b : ℚ) := by exact_mod_cast (Nat.lt_of_lt_of_le Nat.zero_lt_one hb_ge_one)
+  have h10a_pos : (0 : ℚ) < (10 : ℚ) ^ (-a) := by positivity
+  exact mul_pos hb_pos h10a_pos
 
 /-- `√x ≤ √⁺ x` for `x ≥ 0` (Definition 47). -/
 theorem sqrt_le_sqrtℚUp {x : ℚ} (hx : 0 ≤ x) :
     Real.sqrt ((x : ℚ) : ℝ) ≤ ((sqrtℚUp x : ℚ) : ℝ) := by
-  sorry
+  unfold sqrtℚUp
+  split_ifs with hx0
+  · -- x ≤ 0 and 0 ≤ x → x = 0; sqrt 0 = 0.
+    have : x = 0 := le_antisymm hx0 hx
+    simp [this]
+  · -- 0 < x
+    have hx0' : 0 < x := lt_of_le_of_ne hx (fun heq => hx0 (by simp [← heq]))
+    set y : ℚ := 1 / x with hy_def
+    have hy_pos : 0 < y := by rw [hy_def]; exact one_div_pos.mpr hx0'
+    have hy_nonneg : 0 ≤ y := le_of_lt hy_pos
+    have hLow_pos_Q : 0 < sqrtℚLow y := sqrtℚLow_pos_of_pos hy_pos
+    have hLow_pos_R : (0 : ℝ) < ((sqrtℚLow y : ℚ) : ℝ) := by exact_mod_cast hLow_pos_Q
+    have hsq : ((sqrtℚLow y : ℚ) : ℝ) ^ 2 ≤ ((y : ℚ) : ℝ) := sqrtℚLow_sq_le y hy_nonneg
+    -- Real-cast of x is positive
+    have hx_R_pos : (0 : ℝ) < ((x : ℚ) : ℝ) := by exact_mod_cast hx0'
+    have hy_R : ((y : ℚ) : ℝ) = 1 / ((x : ℚ) : ℝ) := by
+      rw [hy_def]; push_cast; ring
+    -- (1 / sqrtℚLow y : ℚ) cast to ℝ is 1 / ((sqrtℚLow y : ℚ) : ℝ)
+    have hcast : (((1 / sqrtℚLow y : ℚ) : ℝ)) = 1 / ((sqrtℚLow y : ℚ) : ℝ) := by
+      push_cast; ring
+    rw [hcast]
+    -- Goal: √x ≤ 1 / sqrtℚLow y
+    rw [le_div_iff₀ hLow_pos_R]
+    -- Goal: √x * sqrtℚLow y ≤ 1
+    -- (sqrtℚLow y)^2 ≤ y = 1/x. Multiply by x > 0: (sqrtℚLow y)^2 * x ≤ 1.
+    have hsq' : ((sqrtℚLow y : ℚ) : ℝ) ^ 2 ≤ 1 / ((x : ℚ) : ℝ) := by rw [← hy_R]; exact hsq
+    have hsq_x : ((sqrtℚLow y : ℚ) : ℝ) ^ 2 * ((x : ℚ) : ℝ) ≤ 1 := by
+      have := mul_le_mul_of_nonneg_right hsq' (le_of_lt hx_R_pos)
+      rw [div_mul_cancel₀ _ (ne_of_gt hx_R_pos)] at this
+      exact this
+    -- So (sqrtℚLow y * √x)^2 ≤ 1.
+    have hprod_nn : 0 ≤ Real.sqrt ((x : ℚ) : ℝ) * ((sqrtℚLow y : ℚ) : ℝ) :=
+      mul_nonneg (Real.sqrt_nonneg _) (le_of_lt hLow_pos_R)
+    have h_sq_eq : (Real.sqrt ((x : ℚ) : ℝ) * ((sqrtℚLow y : ℚ) : ℝ)) ^ 2 =
+        ((sqrtℚLow y : ℚ) : ℝ) ^ 2 * ((x : ℚ) : ℝ) := by
+      rw [mul_pow, Real.sq_sqrt (le_of_lt hx_R_pos)]
+      ring
+    have hprod_sq_le : (Real.sqrt ((x : ℚ) : ℝ) * ((sqrtℚLow y : ℚ) : ℝ)) ^ 2 ≤ 1 := by
+      rw [h_sq_eq]; exact hsq_x
+    -- From a² ≤ 1 and a ≥ 0, conclude a ≤ 1.
+    nlinarith [hprod_nn, hprod_sq_le]
+
+/-- The squared norm is non-negative. -/
+private lemma normSqℚ_nonneg {n : ℕ} (v : Fin n → ℚ) : 0 ≤ normSqℚ v := by
+  unfold normSqℚ
+  exact Finset.sum_nonneg (fun i _ => mul_self_nonneg (v i))
 
 /-- For a rational vector, the lower-norm bounds the true Euclidean norm. -/
 theorem normLowℚ_le_norm {n : ℕ} (v : Fin n → ℚ) :
     ((normLowℚ v : ℚ) : ℝ) ≤ Real.sqrt ((normSqℚ v : ℚ) : ℝ) :=
-  sorry -- sqrtℚLow_le_sqrt (by positivity)
+  sqrtℚLow_le_sqrt (normSqℚ_nonneg v)
 
 /-- For a rational vector, the true Euclidean norm bounds the upper-norm. -/
 theorem norm_le_normUpℚ {n : ℕ} (v : Fin n → ℚ) :
     Real.sqrt ((normSqℚ v : ℚ) : ℝ) ≤ ((normUpℚ v : ℚ) : ℝ) :=
-  sorry --sqrt_le_sqrtℚUp (by positivity)
+  sqrt_le_sqrtℚUp (normSqℚ_nonneg v)
 
 end RationalApprox
 

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -45,11 +45,9 @@ abbrev Row.M₂_ (r : Row) : Matrix (Fin 2) (Fin 3) ℚ :=
 abbrev Row.rotRℚ (r : Row) : Matrix (Fin 2) (Fin 2) ℚ :=
   RationalApprox.rotRℚ_mat r.α
 
-abbrev Row.X₁ (r : Row) : Matrix (Fin 3) (Fin 1) ℚ :=
-  RationalApprox.vecXℚ_mat r.θ₁ r.φ₁
+abbrev Row.X₁ (r : Row) : Fin 3 → ℚ := RationalApprox.vecXℚ r.θ₁ r.φ₁
 
-abbrev Row.X₂ (r : Row) : Matrix (Fin 3) (Fin 1) ℚ :=
-  RationalApprox.vecXℚ_mat r.θ₂ r.φ₂
+abbrev Row.X₂ (r : Row) : Fin 3 → ℚ := RationalApprox.vecXℚ r.θ₂ r.φ₂
 
 abbrev rot90 : Matrix (Fin 2) (Fin 2) ℚ :=
   !![0, -1; 1, 0]
@@ -66,11 +64,10 @@ structure Row.ValidLocal (row : Row) : Prop where
   center_in_fourQ : row.interval.centerPose ∈ fourInterval ℚ
   exists_symmetry : ∃ s : TriangleSymmetry,
     s.applicable row.Qi ∧ ∀ i, row.Pi i = s.apply (row.Qi i)
-  X₁_inner_gt : ∀ i, sqrt_twoℚ * row.epsilon + 3 * κQ <
-                     (row.X₁.transpose *ᵥ (pythonVertex (row.Pi i))) 0
-  X₂_inner_gt : ∀ i, sqrt_twoℚ * row.epsilon + 3 * κQ <
-                     (-1) ^ row.sigma_Q.val *
-                       (row.X₂.transpose *ᵥ (pythonVertex (row.Qi i))) 0
+  X₁_inner_gt : Local.TriangleQ.Aεℚσ
+                  row.X₁ (pythonVertex ∘ row.Pi) row.epsilon 0 RationalApprox.sqrtApprox
+  X₂_inner_gt : Local.TriangleQ.Aεℚσ
+                  row.X₂ (pythonVertex ∘ row.Qi) row.epsilon row.sigma_Q.val RationalApprox.sqrtApprox
   P_spanning : ∀ i : Fin 3,
     2 * row.epsilon * (sqrt_twoℚ + row.epsilon) + 6 * κQ <
     (rot90 *ᵥ (row.M₁_ *ᵥ (pythonVertex (row.Pi i)))) ⬝ᵥ

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -63,7 +63,7 @@ abbrev Row.δ (row : Row) (i : Fin 3) : ℚ :=
     (Finset.image
       (RationalApprox.LocalTheorem.BoundDeltaℚi row.interval.centerPose
          (pythonVertex ∘ row.Pi) (pythonVertex ∘ row.Qi) sqrtApprox) Finset.univ)
-    (by sorry)
+    (Finset.image_nonempty.mpr ⟨0, Finset.mem_univ 0⟩)
 
 /-- Assertion that a row constitutes a valid application of the rational global theorem. -/
 @[mk_iff]

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -84,6 +84,7 @@ structure Row.ValidLocal (row : Row) : Prop where
     2 * row.epsilon * (sqrt_twoℚ + row.epsilon) + 6 * κQ <
     (rot90 *ᵥ (row.M₂_ *ᵥ (pythonVertex (row.Qi i)))) ⬝ᵥ
       (row.M₂_ *ᵥ (pythonVertex ((row.Qi (i + 1)))))
+  rpos : 0 < row.r
   r_valid : RationalApprox.LocalTheorem.BoundRℚ
               row.r row.epsilon row.interval.centerPose (pythonVertex ∘ row.Qi) sqrtApprox
   Bεℚ : Local.TriangleQ.Bεℚ
@@ -123,7 +124,7 @@ def testLocalRow : Row := {
   Q1_index := VertexIndex.ofFin90 ⟨79, by lia⟩,
   Q2_index := VertexIndex.ofFin90 ⟨80, by lia⟩,
   Q3_index := VertexIndex.ofFin90 ⟨87, by lia⟩,
-  r' := 0, sigma_Q := ⟨1, by simp [Finset.mem_Icc]⟩
+  r' := 955, sigma_Q := ⟨1, by simp [Finset.mem_Icc]⟩
 }
 
 /-- info: true -/

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -70,6 +70,7 @@ abbrev Row.δ (row : Row) : ℚ :=
 structure Row.ValidLocal (row : Row) : Prop where
   nodeType_eq : row.nodeType = 2
   center_in_fourQ : row.interval.centerPose ∈ fourInterval ℚ
+  epsilon_pos : 0 < row.epsilon
   exists_symmetry : ∃ s : TriangleSymmetry,
     s.applicable row.Qi ∧ ∀ i, row.Pi i = s.apply (row.Qi i)
   X₁_inner_gt : Local.TriangleQ.Aεℚσ

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -58,7 +58,7 @@ abbrev Row.r (row : Row) : ℚ :=
 open scoped Matrix
 open RationalApprox (sqrtApprox)
 
-abbrev Row.δ (row : Row) (i : Fin 3) : ℚ :=
+abbrev Row.δ (row : Row) : ℚ :=
   Finset.max'
     (Finset.image
       (RationalApprox.LocalTheorem.BoundDeltaℚi row.interval.centerPose
@@ -84,6 +84,8 @@ structure Row.ValidLocal (row : Row) : Prop where
     2 * row.epsilon * (sqrt_twoℚ + row.epsilon) + 6 * κQ <
     (rot90 *ᵥ (row.M₂_ *ᵥ (pythonVertex (row.Qi i)))) ⬝ᵥ
       (row.M₂_ *ᵥ (pythonVertex ((row.Qi (i + 1)))))
+  r_valid : RationalApprox.LocalTheorem.BoundRℚ
+              row.r row.epsilon row.interval.centerPose (pythonVertex ∘ row.Qi) sqrtApprox
   -- ...
 
 instance (row : Row) : Decidable (Row.ValidLocal row) :=

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -1,7 +1,9 @@
 import Mathlib.Data.Finset.Max
 
+import Noperthedron.Checker.ApproxSqrt
 import Noperthedron.Local.Congruent
 import Noperthedron.RationalApprox.Basic
+import Noperthedron.RationalApprox.RationalLocal
 import Noperthedron.SolutionTable.Defs
 import Noperthedron.Vertices.Exact
 import Noperthedron.Vertices.Python

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -86,7 +86,9 @@ structure Row.ValidLocal (row : Row) : Prop where
       (row.M₂_ *ᵥ (pythonVertex ((row.Qi (i + 1)))))
   r_valid : RationalApprox.LocalTheorem.BoundRℚ
               row.r row.epsilon row.interval.centerPose (pythonVertex ∘ row.Qi) sqrtApprox
-  -- ...
+  Bεℚ : Local.TriangleQ.Bεℚ
+    (pythonVertex ∘ row.Qi) row.Qi pythonVertex row.interval.centerPose
+    row.epsilon row.δ row.r sqrtApprox
 
 instance (row : Row) : Decidable (Row.ValidLocal row) :=
   decidable_of_iff _ (Row.validLocal_iff row).symm
@@ -156,4 +158,3 @@ def testLocalRowReflection : Row := {
 /-- info: true -/
 #guard_msgs in
 #eval testLocalRowReflection.ValidLocal
-

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -56,6 +56,14 @@ abbrev Row.r (row : Row) : ℚ :=
   row.r' / 1000
 
 open scoped Matrix
+open RationalApprox (sqrtApprox)
+
+abbrev Row.δ (row : Row) (i : Fin 3) : ℚ :=
+  Finset.max'
+    (Finset.image
+      (RationalApprox.LocalTheorem.BoundDeltaℚi row.interval.centerPose
+         (pythonVertex ∘ row.Pi) (pythonVertex ∘ row.Qi) sqrtApprox) Finset.univ)
+    (by sorry)
 
 /-- Assertion that a row constitutes a valid application of the rational global theorem. -/
 @[mk_iff]
@@ -65,9 +73,9 @@ structure Row.ValidLocal (row : Row) : Prop where
   exists_symmetry : ∃ s : TriangleSymmetry,
     s.applicable row.Qi ∧ ∀ i, row.Pi i = s.apply (row.Qi i)
   X₁_inner_gt : Local.TriangleQ.Aεℚσ
-                  row.X₁ (pythonVertex ∘ row.Pi) row.epsilon 0 RationalApprox.sqrtApprox
+                  row.X₁ (pythonVertex ∘ row.Pi) row.epsilon 0 sqrtApprox
   X₂_inner_gt : Local.TriangleQ.Aεℚσ
-                  row.X₂ (pythonVertex ∘ row.Qi) row.epsilon row.sigma_Q.val RationalApprox.sqrtApprox
+                  row.X₂ (pythonVertex ∘ row.Qi) row.epsilon row.sigma_Q.val sqrtApprox
   P_spanning : ∀ i : Fin 3,
     2 * row.epsilon * (sqrt_twoℚ + row.epsilon) + 6 * κQ <
     (rot90 *ᵥ (row.M₁_ *ᵥ (pythonVertex (row.Pi i)))) ⬝ᵥ

--- a/Noperthedron/Local.lean
+++ b/Noperthedron/Local.lean
@@ -53,7 +53,7 @@ theorem inCirc {δ ε θ₁ θ₁_ θ₂ θ₂_ φ₁ φ₁_ φ₂ φ₂_ α α_
 Condition A_ε from [SY25] Theorem 36
 -/
 def Triangle.Aε (X : ℝ³) (P : Triangle) (ε : ℝ) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪X, P i⟫ > √2 * ε
+  ∃ σ ∈ ({0, 1} : Set ℕ), ∀ i : Fin 3, (-1)^σ * ⟪X, P i⟫ > √2 * ε
 
 noncomputable
 def Triangle.Bε.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℝ) : ℝ :=
@@ -142,9 +142,8 @@ theorem local_theorem {ι : Type} [Fintype ι] [Nonempty ι]
     simp [P_, Q_, K]
     rw [smul_smul, hL]
     congr 1
-    rw [←zpow_add₀ (show (-1:ℝ) ≠ 0 by norm_num)]
-    ring_nf
-    rw [zpow_add₀ (show (-1:ℝ) ≠ 0 by norm_num), mul_comm σQ, zpow_mul]
+    rw [← pow_add, show σQ + (σP + σQ) = σP + 2 * σQ by ring,
+        pow_add, pow_mul]
     norm_num
   have h₁ : Y ∈ Spanp P_ ∧ Z ∈ Spanp P_ := by
     constructor
@@ -269,8 +268,8 @@ theorem local_theorem {ι : Type} [Fintype ι] [Nonempty ι]
       LinearIsometry.coe_toContinuousLinearMap, inner_smul_left, real_inner_smul_right, RCLike.conj_to_real]
     rw [hL i, L.inner_map_map]
     have h_exp : (-1 : ℝ)^(σP + σQ) * (-1 : ℝ)^σP = (-1 : ℝ)^σQ := by
-      rw [← zpow_add₀ (by norm_num : (-1 : ℝ) ≠ 0), show σP + σQ + σP = 2 * σP + σQ by ring,
-          zpow_add₀ (by norm_num), zpow_mul]; norm_num
+      rw [← pow_add, show σP + σQ + σP = 2 * σP + σQ by ring,
+          pow_add, pow_mul]; norm_num
     rw [←mul_assoc, h_exp]
   have h_YP : ⟪Y, P_ i⟫ = (-1 : ℝ)^σP * ⟪Y, P i⟫ := by simp only [P_, real_inner_smul_right]
   rw [h_ZP, h_YP]
@@ -278,7 +277,7 @@ theorem local_theorem {ι : Type} [Fintype ι] [Nonempty ι]
   have hZQ_sign : 0 < (-1 : ℝ)^σQ * ⟪vecX p.θ₂ p.φ₂, Q i⟫ := by simp only [Q_, real_inner_smul_right] at hZQ_pos; exact hZQ_pos
   have hYP_sign : 0 < (-1 : ℝ)^σP * ⟪Y, P i⟫ := by rw [← h_YP]; exact hYP_pos
   calc (-1 : ℝ)^σQ * ⟪vecX p.θ₂ p.φ₂, Q i⟫ = |(-1 : ℝ)^σQ * ⟪vecX p.θ₂ p.φ₂, Q i⟫| := (abs_of_pos hZQ_sign).symm
-    _ = |⟪vecX p.θ₂ p.φ₂, Q i⟫| := by rw [abs_mul, abs_neg_one_zpow, one_mul]
+    _ = |⟪vecX p.θ₂ p.φ₂, Q i⟫| := by rw [abs_mul, abs_neg_one_pow, one_mul]
     _ < |⟪Y, P i⟫| := sq_lt_sq.mp h_inner_sq
-    _ = |(-1 : ℝ)^σP * ⟪Y, P i⟫| := by rw [abs_mul, abs_neg_one_zpow, one_mul]
+    _ = |(-1 : ℝ)^σP * ⟪Y, P i⟫| := by rw [abs_mul, abs_neg_one_pow, one_mul]
     _ = (-1 : ℝ)^σP * ⟪Y, P i⟫ := abs_of_pos hYP_sign

--- a/Noperthedron/Local/EpsSpanning.lean
+++ b/Noperthedron/Local/EpsSpanning.lean
@@ -29,7 +29,7 @@ structure Triangle.Spanning (P : Triangle) (θ φ ε : ℝ) : Prop where
   pos : 0 < ε
   lt : ∀ i : Fin 3, 2 * ε * (√2 + ε) < ⟪rotR (π / 2) (rotM θ φ (P i)), rotM θ φ (P (i + 1))⟫
 
-lemma spanning_neg {P : Triangle} {θ φ ε : ℝ} (e : ℤ) (h : P.Spanning θ φ ε) :
+lemma spanning_neg {P : Triangle} {θ φ ε : ℝ} (e : ℕ) (h : P.Spanning θ φ ε) :
     Triangle.Spanning (fun i ↦ (-1:ℝ)^e • P i) θ φ ε := by
   obtain ⟨pos, lt⟩ := h
   refine ⟨pos, ?_⟩
@@ -38,8 +38,8 @@ lemma spanning_neg {P : Triangle} {θ φ ε : ℝ} (e : ℤ) (h : P.Spanning θ 
   simp only [map_smul]
   rw [real_inner_smul_right, real_inner_smul_left, ←mul_assoc ((-1:ℝ)^e)]
   have h₁ : (-1:ℝ) ^ e * (-1:ℝ) ^ e = 1 := by
-    rw [←zpow_add₀ (show (-1:ℝ) ≠ 0 by norm_num), ←mul_two, mul_comm]
-    rw [zpow_mul]
+    rw [←pow_add, ←mul_two, mul_comm]
+    rw [pow_mul]
     norm_num
   rw [h₁, one_mul]
   exact lt

--- a/Noperthedron/RationalApprox/Basic.lean
+++ b/Noperthedron/RationalApprox/Basic.lean
@@ -195,3 +195,19 @@ structure LowerSqrt where
 noncomputable
 def LowerSqrt.norm {n : ℕ} (s : LowerSqrt) (v : Euc(n)) : ℝ :=
   s.f (‖v‖^2)
+
+structure Approx where
+  lower_sqrt : LowerSqrt
+  upper_sqrt : UpperSqrt
+  upper_sqrt_two : ℚ
+  upper_sqrt_two_gt_sqrt_two : upper_sqrt_two > √2
+  upper_sqrt_five : ℚ
+  upper_sqrt_five_gt_sqrt_five : upper_sqrt_five > √5
+
+noncomputable
+def Approx.upper_norm {n : ℕ} (approx : Approx) (v : Euc(n)) : ℝ :=
+  approx.upper_sqrt.f (‖v‖^2)
+
+noncomputable
+def Approx.lower_norm {n : ℕ} (approx : Approx) (v : Euc(n)) : ℝ :=
+  approx.lower_sqrt.f (‖v‖^2)

--- a/Noperthedron/RationalApprox/Basic.lean
+++ b/Noperthedron/RationalApprox/Basic.lean
@@ -179,22 +179,16 @@ def _root_.Pose.vecX₂ℚℝ (p : Pose ℝ) : ℝ³ := vecXℚℝ (p.θ₂) (p.
 end
 
 structure UpperSqrt where
-  f : ℝ → ℝ
-  rational : ∀ (x : ℚ), 0 ≤ x → ∃ q : ℚ, f x = q
-  bound : ∀ (x : ℝ), 0 ≤ x → √x ≤ f x
+  f : ℚ → ℚ
+  bound : ∀ (x : ℚ), 0 ≤ x → √x ≤ f x
 
-noncomputable
-def UpperSqrt.norm {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ℝ :=
-  s.f (‖v‖^2)
+def UpperSqrt.norm {n : ℕ} (s : UpperSqrt) (v : Fin n → ℚ) : ℚ := s.f (v ⬝ᵥ v)
 
 structure LowerSqrt where
-  f : ℝ → ℝ
-  rational : ∀ (x : ℚ), 0 ≤ x → ∃ q : ℚ, f x = q
-  bound : ∀ (x : ℝ), 0 ≤ x → f x ≤ √x
+  f : ℚ → ℚ
+  bound : ∀ (x : ℚ), 0 ≤ x → f x ≤ √x
 
-noncomputable
-def LowerSqrt.norm {n : ℕ} (s : LowerSqrt) (v : Euc(n)) : ℝ :=
-  s.f (‖v‖^2)
+def LowerSqrt.norm {n : ℕ} (s : LowerSqrt) (v : Fin n → ℚ) : ℚ := s.f (v ⬝ᵥ v)
 
 structure Approx where
   lower_sqrt : LowerSqrt
@@ -204,10 +198,8 @@ structure Approx where
   upper_sqrt_five : ℚ
   upper_sqrt_five_gt_sqrt_five : upper_sqrt_five > √5
 
-noncomputable
-def Approx.upper_norm {n : ℕ} (approx : Approx) (v : Euc(n)) : ℝ :=
-  approx.upper_sqrt.f (‖v‖^2)
+def Approx.upper_norm {n : ℕ} (approx : Approx) (v : Fin n → ℚ) : ℚ :=
+  approx.upper_sqrt.f (v ⬝ᵥ v)
 
-noncomputable
-def Approx.lower_norm {n : ℕ} (approx : Approx) (v : Euc(n)) : ℝ :=
-  approx.lower_sqrt.f (‖v‖^2)
+def Approx.lower_norm {n : ℕ} (approx : Approx) (v : Fin n → ℚ) : ℚ :=
+  approx.lower_sqrt.f (v ⬝ᵥ v)

--- a/Noperthedron/RationalApprox/BoundsKappa4.lean
+++ b/Noperthedron/RationalApprox/BoundsKappa4.lean
@@ -19,16 +19,51 @@ def bounds_kappa4_A := (⟪rotM θ φ P, rotM θ φ (P - Q)⟫ - 2 * ε * ‖P -
   ((‖rotM θ φ P‖ + √2 * ε) * (‖rotM θ φ (P - Q)‖ + 2 * √2 * ε))
 
 noncomputable
-def bounds_kappa4_Aℚ (s : UpperSqrt) :=
-  (⟪rotMℚℝ θ φ P_, rotMℚℝ θ φ (P_ - Q_)⟫ - 10 * κ - 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)) /
-  ((s.norm (rotMℚℝ θ φ P_) + √2 * ε + 3 * κ) * (s.norm (rotMℚℝ θ φ (P_ - Q_)) + 2 * √2 * ε + 6 * κ))
+def bounds_kappa4_Aℚ (P_ Q_ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℝ) (s : UpperSqrt) : ℝ :=
+  (((p.rotM₂ℚ P_ ⬝ᵥ p.rotM₂ℚ (P_ - Q_) : ℚ) : ℝ) - 10 * κ -
+      2 * ε * (‖toR3 (P_ - Q_)‖ + 2 * κ) * (√2 + ε)) /
+  ((↑(s.norm (p.rotM₂ℚ P_)) + √2 * ε + 3 * κ) *
+    (↑(s.norm (p.rotM₂ℚ (P_ - Q_))) + 2 * √2 * ε + 6 * κ))
 
-/-- An `UpperSqrt` overestimates the Euclidean norm. -/
-lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Euc(n)) : ‖v‖ ≤ s.norm v := by
+/-- The squared norm of a `Fin n → ℚ` cast to `ℝ` equals `((v ⬝ᵥ v : ℚ) : ℝ)`. -/
+private lemma toLp_norm_sq_eq_dotProduct {n : ℕ} (v : Fin n → ℚ) :
+    ‖WithLp.toLp 2 (fun i => (v i : ℝ))‖ ^ 2 = ((v ⬝ᵥ v : ℚ) : ℝ) := by
+  have h_inner_self : @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin n))
+        (WithLp.toLp 2 (fun i => (v i : ℝ))) = ((v ⬝ᵥ v : ℚ) : ℝ) := by
+    have h := EuclideanSpace.inner_eq_star_dotProduct
+      (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin n))
+      (WithLp.toLp 2 (fun i => (v i : ℝ)))
+    simp only [star_trivial] at h
+    refine h.trans ?_
+    push_cast [dotProduct]; rfl
+  rw [← h_inner_self]; exact (real_inner_self_eq_norm_sq _).symm
+
+/-- An `UpperSqrt` overestimates the Euclidean norm of a rational vector cast to `ℝ`. -/
+lemma UpperSqrt_norm_le {n : ℕ} (s : UpperSqrt) (v : Fin n → ℚ) :
+    ‖WithLp.toLp 2 (fun i => (v i : ℝ))‖ ≤ ↑(s.norm v) := by
   unfold UpperSqrt.norm
-  have h : (0 : ℝ) ≤ ‖v‖ ^ 2 := sq_nonneg _
-  calc ‖v‖ = √(‖v‖ ^ 2) := by rw [Real.sqrt_sq (norm_nonneg _)]
-    _ ≤ s.f (‖v‖ ^ 2) := s.bound _ h
+  have h_norm_sq := toLp_norm_sq_eq_dotProduct v
+  have h_dot_nn : (0 : ℝ) ≤ ((v ⬝ᵥ v : ℚ) : ℝ) := by
+    rw [← h_norm_sq]; exact sq_nonneg _
+  have h_dot_nn_ℚ : (0 : ℚ) ≤ v ⬝ᵥ v := by exact_mod_cast h_dot_nn
+  calc ‖WithLp.toLp 2 (fun i => (v i : ℝ))‖
+      = √(‖WithLp.toLp 2 (fun i => (v i : ℝ))‖ ^ 2) := by
+        rw [Real.sqrt_sq (norm_nonneg _)]
+    _ = √(((v ⬝ᵥ v : ℚ) : ℝ)) := by rw [h_norm_sq]
+    _ ≤ ↑(s.f (v ⬝ᵥ v)) := s.bound _ h_dot_nn_ℚ
+
+/-- A `LowerSqrt` underestimates the Euclidean norm of a rational vector cast to `ℝ`. -/
+lemma LowerSqrt_norm_ge {n : ℕ} (s : LowerSqrt) (v : Fin n → ℚ) :
+    ↑(s.norm v) ≤ ‖WithLp.toLp 2 (fun i => (v i : ℝ))‖ := by
+  unfold LowerSqrt.norm
+  have h_norm_sq := toLp_norm_sq_eq_dotProduct v
+  have h_dot_nn : (0 : ℝ) ≤ ((v ⬝ᵥ v : ℚ) : ℝ) := by
+    rw [← h_norm_sq]; exact sq_nonneg _
+  have h_dot_nn_ℚ : (0 : ℚ) ≤ v ⬝ᵥ v := by exact_mod_cast h_dot_nn
+  calc (↑(s.f (v ⬝ᵥ v)) : ℝ)
+      ≤ √(((v ⬝ᵥ v : ℚ) : ℝ)) := s.bound _ h_dot_nn_ℚ
+    _ = √(‖WithLp.toLp 2 (fun i => (v i : ℝ))‖ ^ 2) := by rw [h_norm_sq]
+    _ = ‖WithLp.toLp 2 (fun i => (v i : ℝ))‖ := Real.sqrt_sq (norm_nonneg _)
 
 /-- The inner product bound for `rotM`/`rotMℚ` when the second vector has norm ≤ 2.
 This generalises `bounds_kappa3_M` (which requires ‖Q‖ ≤ 1) to handle `P − Q`. -/
@@ -110,62 +145,127 @@ lemma norm_diff_bound_6kappa
     (clm_approx_apply_sub₂ hMdiff hMℚnorm hPQ_norm hPQ_approx).trans (by unfold κ; norm_num)
   linarith [norm_le_insert' ((rotM ↑θ ↑φ) (P - Q)) ((rotMℚℝ ↑θ ↑φ) (P_ - Q_))]
 
+/-- Bridge: `toR3` distributes over subtraction. -/
+private lemma toR3_sub (v w : Fin 3 → ℚ) : toR3 (v - w) = toR3 v - toR3 w := by
+  unfold toR3; ext i; simp
+
+/-- Bridge: cast of `Matrix.mulVec` over ℚ to ℝ. -/
+private lemma castℝ_mulVec_aux {m n : ℕ} (M : Matrix (Fin m) (Fin n) ℚ) (v : Fin n → ℚ) :
+    (fun i => ((M.mulVec v) i : ℝ)) =
+      (M.map (fun x => (x : ℝ))).mulVec (fun i => (v i : ℝ)) := by
+  ext i
+  simp only [Matrix.mulVec, dotProduct, Matrix.map_apply]
+  push_cast; rfl
+
+/-- Bridge: `rotMℚ_mat` over ℝ equals the cast of `rotMℚ_mat` over ℚ. -/
+private lemma rotMℚ_mat_castℝ_aux (θ φ : ℚ) :
+    (rotMℚ_mat (θ : ℝ) (φ : ℝ)) = (rotMℚ_mat θ φ).map (fun x => (x : ℝ)) := by
+  ext i j; fin_cases i <;> fin_cases j <;> simp [rotMℚ_mat, sinℚ_match, cosℚ_match]
+
+/-- Bridge: `toR2` of `p.rotM₂ℚ v` equals `p.rotM₂ℚℝ (toR3 v)`. -/
+private lemma toR2_rotM₂ℚ_aux (p : Pose ℚ) (v : Fin 3 → ℚ) :
+    toR2 (p.rotM₂ℚ v) = rotMℚℝ (p.θ₂ : ℝ) (p.φ₂ : ℝ) (toR3 v) := by
+  show toR2 ((rotMℚ p.θ₂ p.φ₂) v) = rotMℚℝ (p.θ₂ : ℝ) (p.φ₂ : ℝ) (toR3 v)
+  unfold rotMℚ rotMℚℝ toR2 toR3
+  rw [Matrix.toLin'_apply]
+  show WithLp.toLp 2 (fun i : Fin 2 => (((rotMℚ_mat p.θ₂ p.φ₂).mulVec v) i : ℝ)) =
+       (rotMℚ_mat (p.θ₂ : ℝ) (p.φ₂ : ℝ)).toEuclideanLin.toContinuousLinearMap
+         (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+  rw [castℝ_mulVec_aux, ← rotMℚ_mat_castℝ_aux]
+  show WithLp.toLp 2 ((rotMℚ_mat (p.θ₂ : ℝ) (p.φ₂ : ℝ)).mulVec _) =
+       (rotMℚ_mat (p.θ₂ : ℝ) (p.φ₂ : ℝ)).toEuclideanLin
+         (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+  rw [Matrix.toLpLin_apply]
+
+/-- Bridge: real inner product of two `toR2` casts equals the rational dot product cast to ℝ. -/
+private lemma inner_toR2_aux (v w : Fin 2 → ℚ) :
+    @inner ℝ ℝ² _ (toR2 v) (toR2 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
+  unfold toR2
+  have h := EuclideanSpace.inner_eq_star_dotProduct
+    (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 2))
+    (WithLp.toLp 2 (fun i => (w i : ℝ)))
+  simp only [star_trivial] at h
+  rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
+       (WithLp.toLp 2 (fun i => (w i : ℝ))) =
+       (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
+  simp [dotProduct]
+
 /-- [SY25] Corollary 51 -/
-lemma bounds_kappa4 (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1) (Papprox : ‖P - P_‖ ≤ κ) (Qapprox : ‖Q - Q_‖ ≤ κ)
+lemma bounds_kappa4 (P Q : ℝ³) (P_ Q_ : Fin 3 → ℚ) (p : Pose ℚ)
+    (hθBound : (p.θ₂ : ℝ) ∈ Set.Icc (-4 : ℝ) 4)
+    (hφBound : (p.φ₂ : ℝ) ∈ Set.Icc (-4 : ℝ) 4)
+    (hP : ‖P‖ ≤ 1) (hQ : ‖Q‖ ≤ 1)
+    (Papprox : ‖P - toR3 P_‖ ≤ κ) (Qapprox : ‖Q - toR3 Q_‖ ≤ κ)
     (ε : ℝ) (hε : 0 < ε) (s : UpperSqrt)
-    (hA_nonneg : 0 ≤ ⟪rotM θ φ P, rotM θ φ (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)) :
-    bounds_kappa4_Aℚ P_ Q_ θ φ ε s ≤ bounds_kappa4_A P Q θ φ ε := by
+    (hA_nonneg : 0 ≤ ⟪rotM (p.θ₂ : ℝ) (p.φ₂ : ℝ) P,
+        rotM (p.θ₂ : ℝ) (p.φ₂ : ℝ) (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)) :
+    bounds_kappa4_Aℚ P_ Q_ p ε s ≤
+      bounds_kappa4_A P Q ⟨(p.θ₂ : ℝ), hθBound⟩ ⟨(p.φ₂ : ℝ), hφBound⟩ ε := by
+  set θ : Set.Icc (-4 : ℝ) 4 := ⟨(p.θ₂ : ℝ), hθBound⟩
+  set φ : Set.Icc (-4 : ℝ) 4 := ⟨(p.φ₂ : ℝ), hφBound⟩
+  -- Bridges: link rational dot/norm to real inner/norm.
+  have h_toR3_sub : toR3 (P_ - Q_) = toR3 P_ - toR3 Q_ := toR3_sub _ _
+  have h_inner_bridge : ((p.rotM₂ℚ P_ ⬝ᵥ p.rotM₂ℚ (P_ - Q_) : ℚ) : ℝ) =
+      ⟪(rotMℚℝ ↑θ ↑φ) (toR3 P_), (rotMℚℝ ↑θ ↑φ) (toR3 P_ - toR3 Q_)⟫ := by
+    rw [← toR2_rotM₂ℚ_aux, ← h_toR3_sub, ← toR2_rotM₂ℚ_aux, inner_toR2_aux]
+  have h_norm_bridge_P : ‖(rotMℚℝ ↑θ ↑φ) (toR3 P_)‖ ≤ ↑(s.norm (p.rotM₂ℚ P_)) := by
+    rw [← toR2_rotM₂ℚ_aux]
+    show ‖toR2 (p.rotM₂ℚ P_)‖ ≤ ↑(s.norm (p.rotM₂ℚ P_))
+    exact UpperSqrt_norm_le s _
+  have h_norm_bridge_PQ : ‖(rotMℚℝ ↑θ ↑φ) (toR3 P_ - toR3 Q_)‖ ≤
+      ↑(s.norm (p.rotM₂ℚ (P_ - Q_))) := by
+    rw [← h_toR3_sub, ← toR2_rotM₂ℚ_aux]
+    show ‖toR2 (p.rotM₂ℚ (P_ - Q_))‖ ≤ ↑(s.norm (p.rotM₂ℚ (P_ - Q_)))
+    exact UpperSqrt_norm_le s _
   -- Abbreviate the numerators and denominators
   set numA := ⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ - 2 * ε * ‖P - Q‖ * (√2 + ε)
-  set numAℚ := ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotMℚℝ ↑θ ↑φ) (P_ - Q_)⟫ - 10 * κ -
-    2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε)
+  set numAℚ := ((p.rotM₂ℚ P_ ⬝ᵥ p.rotM₂ℚ (P_ - Q_) : ℚ) : ℝ) - 10 * κ -
+    2 * ε * (‖toR3 (P_ - Q_)‖ + 2 * κ) * (√2 + ε)
   set denA := (‖(rotM ↑θ ↑φ) P‖ + √2 * ε) * (‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε)
-  set denAℚ := (s.norm ((rotMℚℝ ↑θ ↑φ) P_) + √2 * ε + 3 * κ) *
-    (s.norm ((rotMℚℝ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ)
-  -- The goal becomes numAℚ / denAℚ ≤ numA / denA after unfolding
+  set denAℚ := (↑(s.norm (p.rotM₂ℚ P_)) + √2 * ε + 3 * κ) *
+    (↑(s.norm (p.rotM₂ℚ (P_ - Q_))) + 2 * √2 * ε + 6 * κ)
   change numAℚ / denAℚ ≤ numA / denA
   -- Step 1: numAℚ ≤ numA
   have h_numAℚ_le : numAℚ ≤ numA := by
-    -- First, bound the inner product difference
     have hPQ_norm : ‖P - Q‖ ≤ 2 := by
       calc ‖P - Q‖ ≤ ‖P‖ + ‖Q‖ := norm_sub_le _ _
         _ ≤ 1 + 1 := add_le_add hP hQ
         _ = 2 := by ring
-    have hPQ_approx : ‖(P - Q) - (P_ - Q_)‖ ≤ 2 * κ := by
-      calc ‖(P - Q) - (P_ - Q_)‖ = ‖(P - P_) - (Q - Q_)‖ := by congr 1; abel
-        _ ≤ ‖P - P_‖ + ‖Q - Q_‖ := norm_sub_le _ _
+    have hPQ_approx : ‖(P - Q) - (toR3 P_ - toR3 Q_)‖ ≤ 2 * κ := by
+      calc ‖(P - Q) - (toR3 P_ - toR3 Q_)‖
+          = ‖(P - toR3 P_) - (Q - toR3 Q_)‖ := by congr 1; abel
+        _ ≤ ‖P - toR3 P_‖ + ‖Q - toR3 Q_‖ := norm_sub_le _ _
         _ ≤ κ + κ := add_le_add Papprox Qapprox
         _ = 2 * κ := by ring
-    have h_inner : |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ -
-        ⟪(rotMℚℝ ↑θ ↑φ) P_, (rotMℚℝ ↑θ ↑φ) (P_ - Q_)⟫| ≤ 10 * κ :=
+    have h_inner_real : |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ -
+        ⟪(rotMℚℝ ↑θ ↑φ) (toR3 P_), (rotMℚℝ ↑θ ↑φ) (toR3 P_ - toR3 Q_)⟫| ≤ 10 * κ :=
       inner_product_bound_10kappa hP hPQ_norm Papprox hPQ_approx
+    have h_inner :
+        |⟪(rotM ↑θ ↑φ) P, (rotM ↑θ ↑φ) (P - Q)⟫ -
+          ((p.rotM₂ℚ P_ ⬝ᵥ p.rotM₂ℚ (P_ - Q_) : ℚ) : ℝ)| ≤ 10 * κ := by
+      rw [h_inner_bridge]; exact h_inner_real
     replace h_inner := sub_le_of_abs_sub_le_left h_inner
-    have h_norm_PQ : ‖P - Q‖ ≤ ‖P_ - Q_‖ + 2 * κ := by
+    have h_norm_PQ : ‖P - Q‖ ≤ ‖toR3 (P_ - Q_)‖ + 2 * κ := by
+      rw [h_toR3_sub]
       calc ‖P - Q‖
-        _ ≤ ‖P_ - Q_‖ + ‖(P - Q) - (P_ - Q_)‖ := norm_le_insert' _ _
-        _ ≤ ‖P_ - Q_‖ + 2 * κ := by grw [hPQ_approx]
-    -- Now combine: numAℚ ≤ numA
-    -- numAℚ = inner_ℚ - 10κ - 2ε(‖P_-Q_‖ + 2κ)(√2 + ε)
-    -- numA  = inner - 2ε‖P-Q‖(√2 + ε)
-    -- We need: inner_ℚ - 10κ - 2ε(‖P_-Q_‖ + 2κ)(√2 + ε) ≤ inner - 2ε‖P-Q‖(√2 + ε)
-    -- i.e., inner_ℚ - 10κ ≤ inner + 2ε(√2 + ε)((‖P_-Q_‖ + 2κ) - ‖P-Q‖)
-    -- which follows from inner_ℚ - 10κ ≤ inner and (‖P_-Q_‖ + 2κ) - ‖P-Q‖ ≥ 0
-    have h_eps_term : 2 * ε * ‖P - Q‖ * (√2 + ε) ≤ 2 * ε * (‖P_ - Q_‖ + 2 * κ) * (√2 + ε) :=
+        _ ≤ ‖toR3 P_ - toR3 Q_‖ + ‖(P - Q) - (toR3 P_ - toR3 Q_)‖ := norm_le_insert' _ _
+        _ ≤ ‖toR3 P_ - toR3 Q_‖ + 2 * κ := by grw [hPQ_approx]
+    have h_eps_term : 2 * ε * ‖P - Q‖ * (√2 + ε) ≤
+        2 * ε * (‖toR3 (P_ - Q_)‖ + 2 * κ) * (√2 + ε) :=
       mul_le_mul_of_nonneg_right
         (mul_le_mul_of_nonneg_left h_norm_PQ (by linarith)) (by positivity)
     linarith [h_inner, h_eps_term]
   -- Step 2: denA ≤ denAℚ
   have h_denA_le : denA ≤ denAℚ := by
-    -- Factor 1: ‖rotM P‖ + √2ε ≤ s.norm(rotMℚ P_) + √2ε + 3κ
     have h_f1 : ‖(rotM ↑θ ↑φ) P‖ + √2 * ε ≤
-        s.norm ((rotMℚℝ ↑θ ↑φ) P_) + √2 * ε + 3 * κ := by
-      linarith [norm_diff_bound_3kappa hP Papprox (θ := θ) (φ := φ),
-        UpperSqrt_norm_le s ((rotMℚℝ ↑θ ↑φ) P_)]
-    -- Factor 2: ‖rotM (P-Q)‖ + 2√2ε ≤ s.norm(rotMℚ (P_-Q_)) + 2√2ε + 6κ
+        ↑(s.norm (p.rotM₂ℚ P_)) + √2 * ε + 3 * κ := by
+      have h1 : ‖(rotM ↑θ ↑φ) P‖ ≤ ‖(rotMℚℝ ↑θ ↑φ) (toR3 P_)‖ + 3 * κ :=
+        norm_diff_bound_3kappa hP Papprox (θ := θ) (φ := φ)
+      linarith [h1, h_norm_bridge_P]
     have h_f2 : ‖(rotM ↑θ ↑φ) (P - Q)‖ + 2 * √2 * ε ≤
-        s.norm ((rotMℚℝ ↑θ ↑φ) (P_ - Q_)) + 2 * √2 * ε + 6 * κ := by
-      linarith [norm_diff_bound_6kappa hP hQ Papprox Qapprox (θ := θ) (φ := φ),
-        UpperSqrt_norm_le s ((rotMℚℝ ↑θ ↑φ) (P_ - Q_))]
+        ↑(s.norm (p.rotM₂ℚ (P_ - Q_))) + 2 * √2 * ε + 6 * κ := by
+      have h2 : ‖(rotM ↑θ ↑φ) (P - Q)‖ ≤ ‖(rotMℚℝ ↑θ ↑φ) (toR3 P_ - toR3 Q_)‖ + 6 * κ :=
+        norm_diff_bound_6kappa hP hQ Papprox Qapprox (θ := θ) (φ := φ)
+      linarith [h2, h_norm_bridge_PQ]
     exact mul_le_mul h_f1 h_f2 (by positivity) (le_trans (by positivity) h_f1)
-  -- Step 3: Apply div_le_div₀
   exact div_le_div₀ hA_nonneg h_numAℚ_le (by positivity) h_denA_le

--- a/Noperthedron/RationalApprox/EpsKapSpanning.lean
+++ b/Noperthedron/RationalApprox/EpsKapSpanning.lean
@@ -181,3 +181,70 @@ theorem ek_spanning_imp_e_spanning (P P' : Triangle)
     grw [norm_sub_le_bound1 mv κ (by norm_num [κ]) hdbb hbs1 hanb]
     simp only [mv]
     norm_num [κ]
+
+/-! ### Bridges from rational matrix-form spanning condition to `κSpanning` -/
+
+private lemma toR2_rotMℚ_mat_mulVec (θ φ : ℚ) (v : Fin 3 → ℚ) :
+    toR2 (rotMℚ_mat θ φ *ᵥ v) = rotMℚℝ (θ : ℝ) (φ : ℝ) (toR3 v) := by
+  unfold toR2 toR3 rotMℚℝ
+  rw [show (rotMℚ_mat θ φ *ᵥ v) = (rotMℚ_mat θ φ).toLin' v from rfl]
+  rw [Matrix.toLin'_apply]
+  show WithLp.toLp 2 (fun i : Fin 2 => (((rotMℚ_mat θ φ).mulVec v) i : ℝ)) =
+       (rotMℚ_mat (θ : ℝ) (φ : ℝ)).toEuclideanLin.toContinuousLinearMap
+         (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+  have hcast : (rotMℚ_mat (θ : ℝ) (φ : ℝ)) = (rotMℚ_mat θ φ).map (fun x => (x : ℝ)) := by
+    ext i j; fin_cases i <;> fin_cases j <;> simp [rotMℚ_mat, sinℚ_match, cosℚ_match]
+  have hmap : (fun i : Fin 2 => (((rotMℚ_mat θ φ).mulVec v) i : ℝ)) =
+        ((rotMℚ_mat θ φ).map (fun x => (x : ℝ))).mulVec (fun i => (v i : ℝ)) := by
+    ext i
+    simp only [Matrix.mulVec, dotProduct, Matrix.map_apply]
+    push_cast; rfl
+  rw [hmap, ← hcast]
+  show WithLp.toLp 2 ((rotMℚ_mat (θ : ℝ) (φ : ℝ)).mulVec _) =
+       (rotMℚ_mat (θ : ℝ) (φ : ℝ)).toEuclideanLin
+         (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+  rw [Matrix.toLpLin_apply]
+
+private lemma inner_toR2' (v w : Fin 2 → ℚ) :
+    @inner ℝ ℝ² _ (toR2 v) (toR2 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
+  unfold toR2
+  have h := EuclideanSpace.inner_eq_star_dotProduct
+    (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 2))
+    (WithLp.toLp 2 (fun i => (w i : ℝ)))
+  simp only [star_trivial] at h
+  rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
+       (WithLp.toLp 2 (fun i => (w i : ℝ))) =
+       (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
+  simp [dotProduct]
+
+/-- Bridge: the rational `rot90 *ᵥ ...` spanning form casts to the real `κSpanning` form. -/
+lemma rot90_rotMℚ_inner_eq_real_inner (θ φ : ℚ) (v w : Fin 3 → ℚ) :
+    (((!![(0 : ℚ), -1; 1, 0] *ᵥ (rotMℚ_mat θ φ *ᵥ v)) ⬝ᵥ
+        (rotMℚ_mat θ φ *ᵥ w) : ℚ) : ℝ) =
+      ⟪rotR (π / 2) (rotMℚℝ (θ : ℝ) (φ : ℝ) (toR3 v)),
+        rotMℚℝ (θ : ℝ) (φ : ℝ) (toR3 w)⟫ := by
+  rw [← toR2_rotMℚ_mat_mulVec, ← toR2_rotMℚ_mat_mulVec]
+  rw [show rotR (π / 2) (toR2 (rotMℚ_mat θ φ *ᵥ v)) =
+        toR2 (!![(0 : ℚ), -1; 1, 0] *ᵥ (rotMℚ_mat θ φ *ᵥ v)) from ?_]
+  · exact (inner_toR2' _ _).symm
+  · -- rotR(π/2) applied to toR2 u = toR2 (rot90 *ᵥ u)
+    set u : Fin 2 → ℚ := rotMℚ_mat θ φ *ᵥ v
+    show (rotR_mat (π / 2)).toEuclideanLin.toContinuousLinearMap (toR2 u) =
+         toR2 (!![(0 : ℚ), -1; 1, 0] *ᵥ u)
+    unfold toR2
+    -- Compute LHS as a matrix mulVec
+    have hLHS : (rotR_mat (π / 2)).toEuclideanLin.toContinuousLinearMap
+        (WithLp.toLp 2 (fun i : Fin 2 => (u i : ℝ))) =
+        WithLp.toLp 2 ((rotR_mat (π / 2)).mulVec (fun i => (u i : ℝ))) := by
+      show (rotR_mat (π / 2)).toEuclideanLin
+            (WithLp.toLp 2 (fun i : Fin 2 => (u i : ℝ))) = _
+      rw [Matrix.toLpLin_apply]
+    rw [hLHS]
+    ext i
+    have hpi : Real.cos (π / 2) = 0 ∧ Real.sin (π / 2) = 1 :=
+      ⟨Real.cos_pi_div_two, Real.sin_pi_div_two⟩
+    fin_cases i
+    · show ((rotR_mat (π / 2)).mulVec (fun i => (u i : ℝ))) 0 = ((!![(0:ℚ),-1;1,0] *ᵥ u) 0 : ℝ)
+      simp [rotR_mat, hpi.1, hpi.2, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+    · show ((rotR_mat (π / 2)).mulVec (fun i => (u i : ℝ))) 1 = ((!![(0:ℚ),-1;1,0] *ᵥ u) 1 : ℝ)
+      simp [rotR_mat, hpi.1, hpi.2, Matrix.mulVec, dotProduct, Fin.sum_univ_two]

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -25,7 +25,7 @@ def TriangleQ.Aεℚ (X : ℝ³) (P_ : TriangleQ) (ε : ℚ) : Prop :=
 noncomputable
 def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (approx : RationalApprox.Approx) : ℝ :=
    (⟪p.rotM₂ℚℝ v₁, p.rotM₂ℚℝ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
-   / ((approx.upper_sqrt.norm (p.rotM₂ℚℝ v₁) + √2 * ε + 3 * κ) * (approx.upper_sqrt.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
+   / ((approx.upper_sqrt.norm (p.rotM₂ℚℝ v₁) + approx.upper_sqrt_two * ε + 3 * κ) * (approx.upper_sqrt.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
 
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
@@ -218,9 +218,11 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
     have hsu_ge : approx.upper_sqrt.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le approx.upper_sqrt _
-    -- Denominator positivity (su.norm ≥ ‖·‖ ≥ 0, and √2*ε + 3κ > 0)
-    have hden_pos : 0 < (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+    -- Denominator positivity (su.norm ≥ ‖·‖ ≥ 0, and upper_sqrt_two*ε + 3κ > 0)
+    have hden_pos : 0 < (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
         (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ) := by
+      have h_us2_nn : (0 : ℝ) ≤ approx.upper_sqrt_two :=
+        (Real.sqrt_nonneg 2).trans approx.upper_sqrt_two_gt_sqrt_two.le
       have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
       have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
       positivity
@@ -277,25 +279,29 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hbk4 : bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt ≤
         bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε :=
       bounds_kappa4 (Q i) (poly.vertices.v k) (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hεℝ approx.upper_sqrt hA_nonneg
-    -- Bεℚ.lhs ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ in numerator, denominators def. equal)
+    -- Bεℚ.lhs ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ shrinks numerator;
+    -- upper_sqrt_two ≥ √2 grows denominator)
     have hBεℚ_le : Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx ≤
         bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := by
-      -- Express both sides using p_.rotM₂ℚ (which is def. equal to rotMℚ ↑θ₂ ↑φ₂)
+      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
+      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
+      have h_us2 : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+        mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
+      have h_num_sub : 2 * (ε : ℝ) * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
+          2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+        apply mul_le_mul_of_nonneg_right (mul_le_mul_of_nonneg_left
+          (by linarith [hsu_ge]) (by linarith))
+        positivity
       show (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
             2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε)) /
-          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
             (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ)) ≤
           (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
             2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)) /
           ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
             (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
-      apply div_le_div_of_nonneg_right _ (le_of_lt hden_pos)
-      have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
-          2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
-        apply mul_le_mul_of_nonneg_right
-        · exact mul_le_mul_of_nonneg_left (by grw [hsu_ge]) (by linarith)
-        · positivity
-      grw [h_sub_le]
+      refine div_le_div₀ hAℚ_num_pos.le (by linarith) (by positivity) ?_
+      exact mul_le_mul_of_nonneg_right (by linarith) (by positivity)
     -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
     have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
     -- Combine

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -33,7 +33,7 @@ Condition B_ε^ℚ from [SY25] Theorem 48
 def Triangle.Bεℚ {ι : Type} [Fintype ι] (Q_ : Triangle) (Qi : Fin 3 → ι)
     (v_ : ι → Euc(3)) (p : Pose ℝ) (ε δ r : ℚ)  (approx : RationalApprox.Approx) : Prop :=
   ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
-    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε approx
+    (δ + approx.upper_sqrt_five * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε approx
 
 end Local
 
@@ -223,7 +223,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
         linarith [le_trans (norm_nonneg _)
            (UpperSqrt_norm_le approx.upper_sqrt (p_.rotR (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)))]
       have h0 : 0 < (δ + √5 * ε) / r := by positivity
-      exact (div_pos_iff_of_pos_right hden_pos).mp (h0.trans hbe)
+      refine (div_pos_iff_of_pos_right hden_pos).mp (h0.trans ?_)
+      sorry
     -- su.norm ≥ ‖·‖ means numBεℚ ≤ numAℚ (subtracted term is bigger with su.norm)
     have hAℚ_num_pos : 0 < ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ -
         2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -7,7 +7,7 @@ import Noperthedron.RationalApprox.BoundsKappa4
 open Local (Triangle)
 open scoped RealInnerProductSpace Real
 
-open RationalApprox (κ UpperSqrt)
+open RationalApprox (κ κℚ UpperSqrt)
 
 namespace Local
 
@@ -20,18 +20,19 @@ def TriangleQ.toReal (t : TriangleQ) : Triangle :=
 Condition A_ε^ℚ from [SY25] Theorem 48
 -/
 def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * RationalApprox.κℚ
+  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * κℚ
 
 noncomputable
-def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (approx : RationalApprox.Approx) : ℝ :=
-   (⟪p.rotM₂ℚℝ v₁, p.rotM₂ℚℝ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κ) * (approx.upper_sqrt_two + ε))
-   / ((approx.upper_sqrt.norm (p.rotM₂ℚℝ v₁) + approx.upper_sqrt_two * ε + 3 * κ) * (approx.upper_sqrt.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * approx.upper_sqrt_two * ε + 6 * κ))
+def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
+   (approx : RationalApprox.Approx) : ℝ :=
+   (p.rotM₂ℚ v₁ ⬝ᵥ p.rotM₂ℚ (v₁ - v₂) - 10 * κℚ - 2 * ε * (approx.upper_sqrt.norm (toR3 (v₁ - v₂)) + 2 * κℚ) * (approx.upper_sqrt_two + ε))
+   / ((approx.upper_sqrt.norm (toR2 (p.rotM₂ℚ v₁)) + approx.upper_sqrt_two * ε + 3 * κℚ) * (approx.upper_sqrt.norm (toR2 (p.rotM₂ℚ (v₁ - v₂))) + 2 * approx.upper_sqrt_two * ε + 6 * κℚ))
 
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
 -/
-def Triangle.Bεℚ {ι : Type} [Fintype ι] (Q_ : Triangle) (Qi : Fin 3 → ι)
-    (v_ : ι → Euc(3)) (p : Pose ℝ) (ε δ r : ℚ)  (approx : RationalApprox.Approx) : Prop :=
+def Triangle.Bεℚ {ι : Type} [Fintype ι] (Q_ : TriangleQ) (Qi : Fin 3 → ι)
+    (v_ : ι → Fin 3 → ℚ) (p : Pose ℚ) (ε δ r : ℚ)  (approx : RationalApprox.Approx) : Prop :=
   ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
     (δ + approx.upper_sqrt_five * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε approx
 
@@ -76,8 +77,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.vecX₂ℚ ε approx)
     (span₁ : (hpoly.transportTri Pi).toReal.κSpanning (p_.θ₁ : ℝ) (p_.φ₁ : ℝ) ε)
     (span₂ : (hpoly.transportTri Qi).toReal.κSpanning (p_.θ₂ : ℝ) (p_.φ₂ : ℝ) ε)
-    (be : (hpoly.transportTri Qi).toReal.Bεℚ Qi
-          (fun k => poly_.toReal.v (hpoly.bijection k)) p_.toReal ε δ r approx)
+    (be : Local.Triangle.Bεℚ (hpoly.transportTri Qi) Qi
+          (fun k => poly_.v (hpoly.bijection k)) p_ ε δ r approx)
     : ¬∃ p ∈ Metric.closedBall p_.toReal ε, RupertPose p poly.hull := by
   have hεℝ : 0 < (ε : ℝ) := span₁.pos
   -- Keep a handle on the rational pose before shadowing.
@@ -129,6 +130,66 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
          (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
     simp [dotProduct]
   have h_κℚ : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
+  -- Cast helpers to bridge between the rational `Fin n → ℚ` world and the real one.
+  have h_castℝ_mulVec : ∀ {m n : ℕ} (M : Matrix (Fin m) (Fin n) ℚ) (v : Fin n → ℚ),
+      (fun i => ((M.mulVec v) i : ℝ)) =
+        (M.map (fun x => (x : ℝ))).mulVec (fun i => (v i : ℝ)) := by
+    intro m n M v
+    ext i
+    simp only [Matrix.mulVec, dotProduct, Matrix.map_apply]
+    push_cast; rfl
+  have h_rotMℚ_mat_castℝ : ∀ (θ φ : ℚ),
+      (rotMℚ_mat (θ : ℝ) (φ : ℝ)) = (rotMℚ_mat θ φ).map (fun x => (x : ℝ)) := by
+    intro θ φ
+    ext i j; fin_cases i <;> fin_cases j <;> simp [rotMℚ_mat, sinℚ_match, cosℚ_match]
+  -- Bridge: `toR3` is linear over subtraction.
+  have h_toR3_sub : ∀ (v w : Fin 3 → ℚ), toR3 (v - w) = toR3 v - toR3 w := by
+    intro v w
+    unfold toR3; ext i; simp
+  -- Bridge: `toR2` of the rational rotM₂ℚ application equals real rotM₂ℚℝ on `toR3`.
+  have h_toR2_rotM₂ℚ : ∀ (v : Fin 3 → ℚ),
+      toR2 (p_ℚ.rotM₂ℚ v) = p_.rotM₂ℚℝ (toR3 v) := by
+    intro v
+    show toR2 ((rotMℚ p_ℚ.θ₂ p_ℚ.φ₂) v) = rotMℚℝ (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ) (toR3 v)
+    unfold rotMℚ rotMℚℝ toR2 toR3
+    rw [Matrix.toLin'_apply]
+    show WithLp.toLp 2 (fun i : Fin 2 => (((rotMℚ_mat p_ℚ.θ₂ p_ℚ.φ₂).mulVec v) i : ℝ)) =
+         (rotMℚ_mat (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)).toEuclideanLin.toContinuousLinearMap
+           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+    rw [h_castℝ_mulVec, ← h_rotMℚ_mat_castℝ]
+    show WithLp.toLp 2 ((rotMℚ_mat (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)).mulVec _) =
+         (rotMℚ_mat (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)).toEuclideanLin
+           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+    rw [Matrix.toLpLin_apply]
+  -- Bridge: `inner` on `toR2` casts to a rational dot product.
+  have h_inner_toR2 : ∀ (v w : Fin 2 → ℚ),
+      @inner ℝ ℝ² _ (toR2 v) (toR2 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
+    intro v w
+    unfold toR2
+    have h := EuclideanSpace.inner_eq_star_dotProduct
+      (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 2))
+      (WithLp.toLp 2 (fun i => (w i : ℝ)))
+    simp only [star_trivial] at h
+    rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
+         (WithLp.toLp 2 (fun i => (w i : ℝ))) =
+         (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
+    simp [dotProduct]
+  -- Main bridge: rewrite `Bεℚ.lhs` in terms of explicit real-form expressions.
+  have h_Bεℚ_lhs_bridge : ∀ (v₁ v₂ : Fin 3 → ℚ),
+      Local.Triangle.Bεℚ.lhs v₁ v₂ p_ℚ ε approx =
+      (⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ - 10 * κ -
+         2 * ε * (approx.upper_sqrt.norm (toR3 v₁ - toR3 v₂) + 2 * κ) *
+           (approx.upper_sqrt_two + ε)) /
+      ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (toR3 v₁)) + approx.upper_sqrt_two * ε + 3 * κ) *
+       (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)) +
+          2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
+    intro v₁ v₂
+    have h_inner_bridge : ((p_ℚ.rotM₂ℚ v₁ ⬝ᵥ p_ℚ.rotM₂ℚ (v₁ - v₂) : ℚ) : ℝ) =
+        ⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ := by
+      rw [← h_toR2_rotM₂ℚ v₁, ← h_toR3_sub, ← h_toR2_rotM₂ℚ (v₁ - v₂), h_inner_toR2]
+    unfold Local.Triangle.Bεℚ.lhs
+    rw [h_toR3_sub, h_toR2_rotM₂ℚ, h_toR2_rotM₂ℚ, h_toR3_sub, ← h_κℚ]
+    rw [h_inner_bridge]
   have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
     mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
   have ae₁' : P.Aε p_.vecX₁ ε := by
@@ -244,8 +305,20 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- Get the Bεℚ hypothesis
     have hbe := be i k hne_k
     show (δ + √5 * ε) / r < Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε
+    -- Identify the rational triangle/vertex underlying `Q_ i` and `v_`.
+    have hQ_eq : Q_ i = toR3 ((hpoly.transportTri Qi) i) := rfl
+    have hv_eq : v_ = toR3 (poly_.v (hpoly.bijection k)) := rfl
+    -- Use the bridge to rewrite `Bεℚ.lhs` into explicit real form.
+    have h_bridge_Qv :=
+      h_Bεℚ_lhs_bridge ((hpoly.transportTri Qi) i) (poly_.v (hpoly.bijection k))
+    rw [← hQ_eq, ← hv_eq] at h_bridge_Qv
     -- Bridge from approx.upper_sqrt_five to √5 (since upper_sqrt_five > √5)
-    have hbe' : (↑δ + √5 * ↑ε) / ↑r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx := by
+    have hbe' : (↑δ + √5 * ↑ε) / ↑r <
+        (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
+           2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
+        ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
+         (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
+      rw [← h_bridge_Qv]
       have hr_pos : (0 : ℝ) < r := by exact_mod_cast hr
       have hε_nonneg : (0 : ℝ) ≤ (ε : ℝ) := le_of_lt hεℝ
       have h_sqrt5_le : √5 ≤ (approx.upper_sqrt_five : ℝ) :=
@@ -319,9 +392,14 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hbk4 : bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt ≤
         bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε :=
       bounds_kappa4 (Q i) (poly.vertices.v k) (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hεℝ approx.upper_sqrt hA_nonneg
-    -- Bεℚ.lhs ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ shrinks numerator;
+    -- The explicit real form of `Bεℚ.lhs` ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ shrinks numerator;
     -- upper_sqrt_two ≥ √2 grows denominator)
-    have hBεℚ_le : Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx ≤
+    have hBεℚ_le :
+        (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
+            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
+          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
+            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) +
+              2 * approx.upper_sqrt_two * ε + 6 * κ)) ≤
         bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := by
       have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
       have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
@@ -340,7 +418,12 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
     have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
     -- Combine
-    calc (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx := hbe'
+    calc (δ + √5 * ε) / r
+        < (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
+            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
+          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
+            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) +
+              2 * approx.upper_sqrt_two * ε + 6 * κ)) := hbe'
       _ ≤ bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := hBεℚ_le
       _ ≤ bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := hbk4
       _ = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := hA_eq

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -16,11 +16,15 @@ def TriangleQ : Type := Fin 3 → Fin 3 → ℚ
 def TriangleQ.toReal (t : TriangleQ) : Triangle :=
   fun i => toR3 (t i)
 
+def TriangleQ.Aεℚσ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (σ : ℤ)
+    (approx : RationalApprox.Approx) : Prop :=
+  ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * κℚ
+
 /--
 Condition A_ε^ℚ from [SY25] Theorem 48
 -/
 def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * κℚ
+  ∃ σ ∈ ({-1, 1} : Set ℤ), TriangleQ.Aεℚσ X P_ ε σ approx
 
 def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
    (approx : RationalApprox.Approx) : ℚ :=

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -20,7 +20,7 @@ def TriangleQ.toReal (t : TriangleQ) : Triangle :=
 Condition A_ε^ℚ from [SY25] Theorem 48
 -/
 def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪toR3 X, P_.toReal i⟫ > approx.upper_sqrt_two * ε + 3 * κ
+  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * RationalApprox.κℚ
 
 noncomputable
 def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (approx : RationalApprox.Approx) : ℝ :=
@@ -80,6 +80,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
           (fun k => poly_.toReal.v (hpoly.bijection k)) p_.toReal ε δ r approx)
     : ¬∃ p ∈ Metric.closedBall p_.toReal ε, RupertPose p poly.hull := by
   have hεℝ : 0 < (ε : ℝ) := span₁.pos
+  -- Keep a handle on the rational pose before shadowing.
+  let p_ℚ : Pose ℚ := p_
   set p_ := p_.toReal
   have hp : (fourInterval ℝ).contains p_ := fourInterval_contains_toReal hp
   -- The rational `p_.θ₁` (cast to ℝ) is defeq to `p_.θ₁`, so the spanning hypotheses
@@ -114,6 +116,19 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     ext j
     unfold toR3 vecXℚ vecXℚℝ
     fin_cases j <;> simp [sinℚ_match, cosℚ_match]
+  have h_inner_toR3 : ∀ (v w : Fin 3 → ℚ),
+      @inner ℝ ℝ³ _ (toR3 v) (toR3 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
+    intro v w
+    unfold toR3
+    have h := EuclideanSpace.inner_eq_star_dotProduct
+      (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 3))
+      (WithLp.toLp 2 (fun i => (w i : ℝ)))
+    simp only [star_trivial] at h
+    rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
+         (WithLp.toLp 2 (fun i => (w i : ℝ))) =
+         (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
+    simp [dotProduct]
+  have h_κℚ : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
   have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
     mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
   have ae₁' : P.Aε p_.vecX₁ ε := by
@@ -122,9 +137,15 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hX : ‖⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₁) (φ := φ₁) (hPnorm i) (hPapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₁ ↑φ₁, P i⟫ > √2 * ε
-    have hσ₂i' := hσ₂ i
-    simp only [Pose.vecX₁ℚ, h_toR3_vecXℚ] at hσ₂i'
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂i'
+    have h_inner_eq : @inner ℝ ℝ³ _ (vecXℚℝ (↑θ₁ : ℝ) ↑φ₁) (P_ i) =
+        ((p_ℚ.vecX₁ℚ ⬝ᵥ (hpoly.transportTri Pi) i : ℚ) : ℝ) := by
+      show @inner ℝ ℝ³ _ (vecXℚℝ ↑p_ℚ.θ₁ ↑p_ℚ.φ₁) (P_ i) = _
+      rw [← h_toR3_vecXℚ]
+      exact h_inner_toR3 _ _
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := by
+      rw [h_inner_eq, ← h_κℚ,
+          show ((-1 : ℝ)) ^ σ = ((((-1 : ℚ)) ^ σ : ℚ) : ℝ) by push_cast; rfl]
+      exact_mod_cast hσ₂ i
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
@@ -137,9 +158,15 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hX : ‖⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ > √2 * ε
-    have hσ₂i' := hσ₂ i
-    simp only [Pose.vecX₂ℚ, h_toR3_vecXℚ] at hσ₂i'
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂i'
+    have h_inner_eq : @inner ℝ ℝ³ _ (vecXℚℝ (↑θ₂ : ℝ) ↑φ₂) (Q_ i) =
+        ((p_ℚ.vecX₂ℚ ⬝ᵥ (hpoly.transportTri Qi) i : ℚ) : ℝ) := by
+      show @inner ℝ ℝ³ _ (vecXℚℝ ↑p_ℚ.θ₂ ↑p_ℚ.φ₂) (Q_ i) = _
+      rw [← h_toR3_vecXℚ]
+      exact h_inner_toR3 _ _
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := by
+      rw [h_inner_eq, ← h_κℚ,
+          show ((-1 : ℝ)) ^ σ = ((((-1 : ℚ)) ^ σ : ℚ) : ℝ) by push_cast; rfl]
+      exact_mod_cast hσ₂ i
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -62,10 +62,12 @@ abbrev BoundDeltaℚi (p : Pose ℚ) (P_ Q_ : Local.TriangleQ) (approx : Approx)
 /-- The condition on δ -/
 def BoundDeltaℚ (δ : ℚ) (p : Pose ℚ) (P_ Q_ : Local.TriangleQ) (approx : Approx) : Prop :=
   ∀ i : Fin 3, δ ≥ BoundDeltaℚi p P_ Q_ approx i
+deriving Decidable
 
 /-- The condition on r -/
 def BoundRℚ (r ε : ℚ) (p : Pose ℚ) (Q_ : Local.TriangleQ) (approx : Approx) : Prop :=
   ∀ i : Fin 3, approx.lower_sqrt.norm (p.rotM₂ℚ (Q_ i)) > r + approx.upper_sqrt_two * ε + 3 * κℚ
+deriving Decidable
 
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -206,6 +206,15 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- Get the Bεℚ hypothesis
     have hbe := be i k hne_k
     show (δ + √5 * ε) / r < Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε
+    -- Bridge from approx.upper_sqrt_five to √5 (since upper_sqrt_five > √5)
+    have hbe' : (↑δ + √5 * ↑ε) / ↑r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx := by
+      have hr_pos : (0 : ℝ) < r := by exact_mod_cast hr
+      have hε_nonneg : (0 : ℝ) ≤ (ε : ℝ) := le_of_lt hεℝ
+      have h_sqrt5_le : √5 ≤ (approx.upper_sqrt_five : ℝ) :=
+        le_of_lt approx.upper_sqrt_five_gt_sqrt_five
+      have h_le : (↑δ + √5 * ↑ε) / ↑r ≤ (↑δ + ↑approx.upper_sqrt_five * ↑ε) / ↑r := by
+        gcongr
+      exact h_le.trans_lt hbe
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
     have hsu_ge : approx.upper_sqrt.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le approx.upper_sqrt _
@@ -224,7 +233,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
            (UpperSqrt_norm_le approx.upper_sqrt (p_.rotR (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)))]
       have h0 : 0 < (δ + √5 * ε) / r := by positivity
       refine (div_pos_iff_of_pos_right hden_pos).mp (h0.trans ?_)
-      sorry
+      exact hbe'
     -- su.norm ≥ ‖·‖ means numBεℚ ≤ numAℚ (subtracted term is bigger with su.norm)
     have hAℚ_num_pos : 0 < ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ -
         2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
@@ -290,7 +299,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
     have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
     -- Combine
-    calc (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx := hbe
+    calc (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx := hbe'
       _ ≤ bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := hBεℚ_le
       _ ≤ bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := hbk4
       _ = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := hA_eq

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -16,7 +16,7 @@ def TriangleQ : Type := Fin 3 → Fin 3 → ℚ
 def TriangleQ.toReal (t : TriangleQ) : Triangle :=
   fun i => toR3 (t i)
 
-def TriangleQ.Aεℚσ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (σ : ℤ)
+def TriangleQ.Aεℚσ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (σ : ℕ)
     (approx : RationalApprox.Approx) : Prop :=
   ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * κℚ
 
@@ -24,7 +24,7 @@ def TriangleQ.Aεℚσ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (σ : ℤ
 Condition A_ε^ℚ from [SY25] Theorem 48
 -/
 def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), TriangleQ.Aεℚσ X P_ ε σ approx
+  ∃ σ ∈ ({0, 1} : Set ℕ), TriangleQ.Aεℚσ X P_ ε σ approx
 
 def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
    (approx : RationalApprox.Approx) : ℚ :=
@@ -220,7 +220,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
           show ((-1 : ℝ)) ^ σ = ((((-1 : ℚ)) ^ σ : ℚ) : ℝ) by push_cast; rfl]
       exact_mod_cast hσ₂ i
     rw [Real.norm_eq_abs] at hX
-    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
+    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_pow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
       rw [abs_mul, habs, one_mul]; exact hX
     rw [abs_le] at hdiff
@@ -241,7 +241,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
           show ((-1 : ℝ)) ^ σ = ((((-1 : ℚ)) ^ σ : ℚ) : ℝ) by push_cast; rfl]
       exact_mod_cast hσ₂ i
     rw [Real.norm_eq_abs] at hX
-    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
+    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_pow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by
       rw [abs_mul, habs, one_mul]; exact hX
     rw [abs_le] at hdiff

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -19,6 +19,7 @@ def TriangleQ.toReal (t : TriangleQ) : Triangle :=
 def TriangleQ.Aεℚσ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (σ : ℕ)
     (approx : RationalApprox.Approx) : Prop :=
   ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * κℚ
+deriving Decidable
 
 /--
 Condition A_ε^ℚ from [SY25] Theorem 48

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -56,10 +56,12 @@ def κApproxPoly.transportTri {ι : Type} [Fintype ι]
 
 namespace LocalTheorem
 
+abbrev BoundDeltaℚi (p : Pose ℚ) (P_ Q_ : Local.TriangleQ) (approx : Approx) (i : Fin 3) : ℚ :=
+  approx.upper_sqrt.norm (p.rotRℚ (p.rotM₁ℚ (P_ i)) - p.rotM₂ℚ (Q_ i)) / 2 + 3 * κℚ
+
 /-- The condition on δ -/
 def BoundDeltaℚ (δ : ℚ) (p : Pose ℚ) (P_ Q_ : Local.TriangleQ) (approx : Approx) : Prop :=
-  ∀ i : Fin 3,
-    δ ≥ approx.upper_sqrt.norm (p.rotRℚ (p.rotM₁ℚ (P_ i)) - p.rotM₂ℚ (Q_ i)) / 2 + 3 * κℚ
+  ∀ i : Fin 3, δ ≥ BoundDeltaℚi p P_ Q_ approx i
 
 /-- The condition on r -/
 def BoundRℚ (r ε : ℚ) (p : Pose ℚ) (Q_ : Local.TriangleQ) (approx : Approx) : Prop :=

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -25,8 +25,8 @@ def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : R
 noncomputable
 def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
    (approx : RationalApprox.Approx) : ℝ :=
-   (p.rotM₂ℚ v₁ ⬝ᵥ p.rotM₂ℚ (v₁ - v₂) - 10 * κℚ - 2 * ε * (approx.upper_sqrt.norm (toR3 (v₁ - v₂)) + 2 * κℚ) * (approx.upper_sqrt_two + ε))
-   / ((approx.upper_sqrt.norm (toR2 (p.rotM₂ℚ v₁)) + approx.upper_sqrt_two * ε + 3 * κℚ) * (approx.upper_sqrt.norm (toR2 (p.rotM₂ℚ (v₁ - v₂))) + 2 * approx.upper_sqrt_two * ε + 6 * κℚ))
+   (p.rotM₂ℚ v₁ ⬝ᵥ p.rotM₂ℚ (v₁ - v₂) - 10 * κℚ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κℚ) * (approx.upper_sqrt_two + ε))
+   / ((approx.upper_sqrt.norm (p.rotM₂ℚ v₁) + approx.upper_sqrt_two * ε + 3 * κℚ) * (approx.upper_sqrt.norm (p.rotM₂ℚ (v₁ - v₂)) + 2 * approx.upper_sqrt_two * ε + 6 * κℚ))
 
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
@@ -53,12 +53,13 @@ def κApproxPoly.transportTri {ι : Type} [Fintype ι]
 namespace LocalTheorem
 
 /-- The condition on δ -/
-def BoundDeltaℚ (δ : ℝ) (p : Pose ℝ) (P_ Q_ : Triangle) (approx : Approx) : Prop :=
-  ∀ i : Fin 3, δ ≥ approx.upper_sqrt.norm (p.rotR (p.rotM₁ℚℝ (P_ i)) - p.rotM₂ℚℝ (Q_ i))/2 + 3 * κ
+def BoundDeltaℚ (δ : ℚ) (p : Pose ℚ) (P_ Q_ : Local.TriangleQ) (approx : Approx) : Prop :=
+  ∀ i : Fin 3,
+    δ ≥ approx.upper_sqrt.norm (p.rotRℚ (p.rotM₁ℚ (P_ i)) - p.rotM₂ℚ (Q_ i)) / 2 + 3 * κℚ
 
 /-- The condition on r -/
-def BoundRℚ (r ε : ℝ) (p : Pose ℝ) (Q_ : Triangle) (approx : Approx) : Prop :=
-  ∀ i : Fin 3, approx.lower_sqrt.norm (p.rotM₂ℚℝ (Q_ i)) > r + √2 * ε + 3 * κ
+def BoundRℚ (r ε : ℚ) (p : Pose ℚ) (Q_ : Local.TriangleQ) (approx : Approx) : Prop :=
+  ∀ i : Fin 3, (approx.lower_sqrt.norm (p.rotM₂ℚ (Q_ i)) : ℝ) > r + √2 * ε + 3 * κ
 
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"
@@ -71,8 +72,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (p_ : Pose ℚ) (hp : p_ ∈ fourInterval ℚ)
     (ε δ r : ℚ) (hε : 0 < ε) (hr : 0 < r)
     (approx : Approx)
-    (hr₁ : BoundRℚ r ε p_.toReal (hpoly.transportTri Qi).toReal approx)
-    (hδ : BoundDeltaℚ δ p_.toReal (hpoly.transportTri Pi).toReal (hpoly.transportTri Qi).toReal approx)
+    (hr₁ : BoundRℚ r ε p_ (hpoly.transportTri Qi) approx)
+    (hδ : BoundDeltaℚ δ p_ (hpoly.transportTri Pi) (hpoly.transportTri Qi) approx)
     (ae₁ : (hpoly.transportTri Pi).Aεℚ p_.vecX₁ℚ ε approx)
     (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.vecX₂ℚ ε approx)
     (span₁ : (hpoly.transportTri Pi).toReal.κSpanning (p_.θ₁ : ℝ) (p_.φ₁ : ℝ) ε)
@@ -174,21 +175,29 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
          (WithLp.toLp 2 (fun i => (w i : ℝ))) =
          (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
     simp [dotProduct]
+  -- Bridge: `‖toR3 v‖² = ((v ⬝ᵥ v : ℚ) : ℝ)` for `v : Fin 3 → ℚ`. Used to relate
+  -- `s.norm v` to `‖toR3 v‖`.
+  have h_upper_norm_toR3 : ∀ (v : Fin 3 → ℚ),
+      (approx.upper_sqrt.norm v : ℝ) ≥ ‖toR3 v‖ := fun v =>
+    UpperSqrt_norm_le approx.upper_sqrt v
+  have h_upper_norm_toR2 : ∀ (v : Fin 2 → ℚ),
+      (approx.upper_sqrt.norm v : ℝ) ≥ ‖toR2 v‖ := fun v =>
+    UpperSqrt_norm_le approx.upper_sqrt v
   -- Main bridge: rewrite `Bεℚ.lhs` in terms of explicit real-form expressions.
   have h_Bεℚ_lhs_bridge : ∀ (v₁ v₂ : Fin 3 → ℚ),
       Local.Triangle.Bεℚ.lhs v₁ v₂ p_ℚ ε approx =
       (⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ - 10 * κ -
-         2 * ε * (approx.upper_sqrt.norm (toR3 v₁ - toR3 v₂) + 2 * κ) *
+         2 * ε * ((approx.upper_sqrt.norm (v₁ - v₂) : ℝ) + 2 * κ) *
            (approx.upper_sqrt_two + ε)) /
-      ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (toR3 v₁)) + approx.upper_sqrt_two * ε + 3 * κ) *
-       (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)) +
+      (((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ v₁) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+       ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (v₁ - v₂)) : ℝ) +
           2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
     intro v₁ v₂
     have h_inner_bridge : ((p_ℚ.rotM₂ℚ v₁ ⬝ᵥ p_ℚ.rotM₂ℚ (v₁ - v₂) : ℚ) : ℝ) =
         ⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ := by
       rw [← h_toR2_rotM₂ℚ v₁, ← h_toR3_sub, ← h_toR2_rotM₂ℚ (v₁ - v₂), h_inner_toR2]
     unfold Local.Triangle.Bεℚ.lhs
-    rw [h_toR3_sub, h_toR2_rotM₂ℚ, h_toR2_rotM₂ℚ, h_toR3_sub, ← h_κℚ]
+    push_cast [← h_κℚ]
     rw [h_inner_bridge]
   have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
     mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
@@ -237,24 +246,86 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
   -- Bridge: BoundRℚ → BoundR
   have hr₁' : Local.BoundR r ε p_ Q := by
     intro i
-    have hsl : approx.lower_norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) ≤ ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
-      show approx.lower_sqrt.f _ ≤ _; calc approx.lower_sqrt.f (‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2)
-        _ ≤ √(‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2) := approx.lower_sqrt.bound _ (sq_nonneg _)
-        _ = ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := Real.sqrt_sq (norm_nonneg _)
+    -- Bridge: ‖(rotMℚℝ θ₂ φ₂) (Q_ i)‖ = ‖toR2 (p_ℚ.rotM₂ℚ (transportTri Qi i))‖
+    have hQ_eq : Q_ i = toR3 ((hpoly.transportTri Qi) i) := rfl
+    have h_toR2_eq : (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i) =
+        toR2 (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) := by
+      rw [hQ_eq]
+      exact (h_toR2_rotM₂ℚ _).symm
+    have hsl : (approx.lower_sqrt.norm (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) ≤
+        ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
+      rw [h_toR2_eq]
+      show (approx.lower_sqrt.norm _ : ℝ) ≤ ‖toR2 _‖
+      exact LowerSqrt_norm_ge approx.lower_sqrt _
     have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ - ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖)| ≤ 3 * κ :=
       bounds_kappa3_MQ (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     show ‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ > r + √2 * ε
-    have hr₁i : approx.lower_norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) > r + √2 * ε + 3 * κ := hr₁ i
+    have hr₁i : (approx.lower_sqrt.norm (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) >
+        r + √2 * ε + 3 * κ := hr₁ i
     rw [abs_le] at hMQ
     linarith [hMQ.1]
   -- Bridge: BoundDeltaℚ → BoundDelta
+  -- Helper bridges for `rotRℚ`, `rotM₁ℚ`, and `toR2` over subtraction.
+  have h_toR2_sub : ∀ (v w : Fin 2 → ℚ), toR2 (v - w) = toR2 v - toR2 w := by
+    intro v w; unfold toR2; ext i; simp
+  have h_toR2_rotM₁ℚ : ∀ (v : Fin 3 → ℚ),
+      toR2 (p_ℚ.rotM₁ℚ v) = p_.rotM₁ℚℝ (toR3 v) := by
+    intro v
+    show toR2 ((rotMℚ p_ℚ.θ₁ p_ℚ.φ₁) v) = rotMℚℝ (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ) (toR3 v)
+    unfold rotMℚ rotMℚℝ toR2 toR3
+    rw [Matrix.toLin'_apply]
+    show WithLp.toLp 2 (fun i : Fin 2 => (((rotMℚ_mat p_ℚ.θ₁ p_ℚ.φ₁).mulVec v) i : ℝ)) =
+         (rotMℚ_mat (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ)).toEuclideanLin.toContinuousLinearMap
+           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+    rw [h_castℝ_mulVec, ← h_rotMℚ_mat_castℝ]
+    show WithLp.toLp 2 ((rotMℚ_mat (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ)).mulVec _) =
+         (rotMℚ_mat (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ)).toEuclideanLin
+           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+    rw [Matrix.toLpLin_apply]
+  have h_rotRℚ_mat_castℝ : (rotRℚ_mat (p_ℚ.α : ℝ)) = (rotRℚ_mat p_ℚ.α).map (fun x => (x : ℝ)) := by
+    ext i j; fin_cases i <;> fin_cases j <;> simp [rotRℚ_mat, sinℚ_match, cosℚ_match]
+  -- Bridge: `toR2` of `p_ℚ.rotRℚ v` equals `p_.rotRℚℝ (toR2 v)`.
+  have h_toR2_rotRℚ : ∀ (v : Fin 2 → ℚ),
+      toR2 (p_ℚ.rotRℚ v) = p_.rotRℚℝ (toR2 v) := by
+    intro v
+    show toR2 ((rotRℚ p_ℚ.α) v) = (rotRℚℝ (p_ℚ.α : ℝ)) (toR2 v)
+    unfold rotRℚ rotRℚℝ toR2
+    rw [Matrix.toLin'_apply]
+    show WithLp.toLp 2 (fun i : Fin 2 => (((rotRℚ_mat p_ℚ.α).mulVec v) i : ℝ)) =
+         (rotRℚ_mat (p_ℚ.α : ℝ)).toEuclideanLin.toContinuousLinearMap
+           (WithLp.toLp 2 (fun i : Fin 2 => (v i : ℝ)))
+    rw [h_castℝ_mulVec, ← h_rotRℚ_mat_castℝ]
+    show WithLp.toLp 2 ((rotRℚ_mat (p_ℚ.α : ℝ)).mulVec _) =
+         (rotRℚ_mat (p_ℚ.α : ℝ)).toEuclideanLin
+           (WithLp.toLp 2 (fun i : Fin 2 => (v i : ℝ)))
+    rw [Matrix.toLpLin_apply]
   have hδ' : Local.BoundDelta δ p_ P Q := by
     intro i
-    have := hδ i
-    -- su.norm ≥ ‖·‖
-    have hsu : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
-        approx.upper_sqrt.norm (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) := by
+    have hδi := hδ i
+    -- su.norm ≥ ‖·‖ (rational form, then convert to real with toR2)
+    have h_eq_real :
+        toR2 (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
+              p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) =
+        p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i) := by
+      rw [h_toR2_sub, h_toR2_rotRℚ, h_toR2_rotM₁ℚ, h_toR2_rotM₂ℚ]; rfl
+    have hsu : ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
+        (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
+            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) := by
+      rw [← h_eq_real]
       exact UpperSqrt_norm_le approx.upper_sqrt _
+    -- ‖p_.rotR (rotM₁ℚℝ P_) - rotRℚℝ (rotM₁ℚℝ P_)‖ ≤ κ * (1 + κ)  (rotR vs rotRℚℝ discrepancy)
+    have h_rotR_norm_one : ‖p_.rotR‖ ≤ 1 := by
+      show ‖rotR p_.α‖ ≤ 1
+      rw [Bounding.rotR_norm_one]
+    have h_rotRdiff : ‖p_.rotR - p_.rotRℚℝ‖ ≤ κ := R_difference_norm_bounded p_.α hp.αBound
+    have hκ_nn : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+    have h_rotM₁ℚ_norm : ‖p_.rotM₁ℚℝ (P_ i)‖ ≤ (1 + κ) * (1 + κ) :=
+      approx_image_norm_le (Mℚ_norm_bounded θ₁.property φ₁.property) (hPnorm i) (hPapprox i)
+    have h_rotR_diff_apply : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))‖ ≤
+        κ * ((1 + κ) * (1 + κ)) := by
+      have := ContinuousLinearMap.le_opNorm (p_.rotR - p_.rotRℚℝ) (p_.rotM₁ℚℝ (P_ i))
+      simp only [ContinuousLinearMap.sub_apply] at this
+      exact this.trans (mul_le_mul h_rotRdiff h_rotM₁ℚ_norm (norm_nonneg _) (by linarith))
     -- ‖real - rational‖ ≤ 6κ
     have hM₁diff : ‖rotM (↑θ₁ : ℝ) ↑φ₁ - rotMℚℝ ↑θ₁ ↑φ₁‖ ≤ κ :=
       M_difference_norm_bounded _ _ θ₁.property φ₁.property
@@ -287,37 +358,67 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
           rw [Bounding.rotR_preserves_norm]
         _ ≤ (2 * κ + κ ^ 2) + (2 * κ + κ ^ 2) := add_le_add h₁ h₂
         _ = 4 * κ + 2 * κ ^ 2 := by ring
-    show δ ≥ ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ / 2
+    show (δ : ℝ) ≥ ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ / 2
     have hnorm_le : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
         ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + (4 * κ + 2 * κ ^ 2) := by
       linarith [norm_le_insert' (p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i))
         (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i))]
-    have h6k : 4 * κ + 2 * κ ^ 2 ≤ 6 * κ := by unfold κ; norm_num
-    linarith [hsu]
+    -- Bridge `p_.rotR` to `p_.rotRℚℝ` introducing extra κ-slack.
+    have h_rotR_to_rotRℚℝ : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
+        ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + κ * ((1 + κ) * (1 + κ)) := by
+      have h_diff_eq : p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i) =
+          (p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) +
+          (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))) := by abel
+      rw [h_diff_eq]
+      calc ‖(p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) +
+            (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)))‖
+        _ ≤ ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ +
+            ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))‖ := norm_add_le _ _
+        _ ≤ ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + κ * ((1 + κ) * (1 + κ)) := by
+            linarith [h_rotR_diff_apply]
+    have h_total_slack : κ * ((1 + κ) * (1 + κ)) + (4 * κ + 2 * κ ^ 2) ≤ 6 * κ := by
+      unfold κ; norm_num
+    -- Combine everything.
+    have h_chain : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
+        (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
+            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) + 6 * κ := by
+      linarith [hsu, hnorm_le, h_rotR_to_rotRℚℝ, h_total_slack]
+    -- Now use hδi: δ ≥ s.norm(...) / 2 + 3 * κℚ in ℚ
+    have hδiℝ : (δ : ℝ) ≥
+        (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
+            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) / 2 + 3 * κ := by
+      have h_κℚ_eq : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
+      have := hδi
+      have hcast : ((approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
+            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) / 2 + 3 * κℚ : ℚ) : ℝ) ≤ (δ : ℝ) := by
+        exact_mod_cast this
+      push_cast [h_κℚ_eq] at hcast
+      linarith
+    linarith [hδiℝ, h_chain]
   -- Bridge: Bεℚ → Bε
   have be' : Triangle.Bε Q Qi poly.vertices.v p_ ε δ r := by
     intro i k hne_k
     -- Map k to v_ in poly_
     let k' := hpoly.bijection k
+    let v_ℚ : Fin 3 → ℚ := poly_.v k'
     set v_ : ℝ³ := poly_.toReal.v k'
     have hvapprox : ‖poly.vertices.v k - v_‖ ≤ κ := hpoly.approx k
     have hvnorm : ‖poly.vertices.v k‖ ≤ 1 := poly.vertex_radius_le_one k
+    -- The rational forms of Q_ i and v_
+    let Q_ℚ : Fin 3 → ℚ := (hpoly.transportTri Qi) i
+    have hQ_eq : Q_ i = toR3 Q_ℚ := rfl
+    have hv_eq : v_ = toR3 v_ℚ := rfl
     -- Get the Bεℚ hypothesis
     have hbe := be i k hne_k
     show (δ + √5 * ε) / r < Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε
-    -- Identify the rational triangle/vertex underlying `Q_ i` and `v_`.
-    have hQ_eq : Q_ i = toR3 ((hpoly.transportTri Qi) i) := rfl
-    have hv_eq : v_ = toR3 (poly_.v (hpoly.bijection k)) := rfl
     -- Use the bridge to rewrite `Bεℚ.lhs` into explicit real form.
-    have h_bridge_Qv :=
-      h_Bεℚ_lhs_bridge ((hpoly.transportTri Qi) i) (poly_.v (hpoly.bijection k))
-    rw [← hQ_eq, ← hv_eq] at h_bridge_Qv
+    have h_bridge_Qv := h_Bεℚ_lhs_bridge Q_ℚ v_ℚ
     -- Bridge from approx.upper_sqrt_five to √5 (since upper_sqrt_five > √5)
     have hbe' : (↑δ + √5 * ↑ε) / ↑r <
-        (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-           2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
-        ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
-         (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
+        (⟪p_.rotM₂ℚℝ (toR3 Q_ℚ), p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ - 10 * κ -
+           2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
+        (((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+         ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
       rw [← h_bridge_Qv]
       have hr_pos : (0 : ℝ) < r := by exact_mod_cast hr
       have hε_nonneg : (0 : ℝ) ≤ (ε : ℝ) := le_of_lt hεℝ
@@ -328,103 +429,141 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
       exact h_le.trans_lt hbe
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
-    have hsu_ge : approx.upper_sqrt.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le approx.upper_sqrt _
+    -- Bridges relating real and rational norms via UpperSqrt_norm_le.
+    have h_toR3_sub_Qv : toR3 (Q_ℚ - v_ℚ) = toR3 Q_ℚ - toR3 v_ℚ := h_toR3_sub _ _
+    have h_norm_Qv_rat : ‖toR3 Q_ℚ - toR3 v_ℚ‖ ≤ (approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) := by
+      rw [← h_toR3_sub_Qv]; exact h_upper_norm_toR3 _
+    have h_norm_rotM₂_Q : ‖p_.rotM₂ℚℝ (toR3 Q_ℚ)‖ ≤
+        (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) := by
+      rw [← h_toR2_rotM₂ℚ]; exact h_upper_norm_toR2 _
+    have h_norm_rotM₂_Qv : ‖p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)‖ ≤
+        (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) := by
+      rw [← h_toR3_sub_Qv, ← h_toR2_rotM₂ℚ]; exact h_upper_norm_toR2 _
     have h_us2_nn : (0 : ℝ) ≤ approx.upper_sqrt_two :=
       (Real.sqrt_nonneg 2).trans approx.upper_sqrt_two_gt_sqrt_two.le
     have h_us2_le : (√2 : ℝ) ≤ approx.upper_sqrt_two := approx.upper_sqrt_two_gt_sqrt_two.le
-    have hsu_norm_nn : (0 : ℝ) ≤ approx.upper_sqrt.norm (Q_ i - v_) :=
-      (norm_nonneg _).trans hsu_ge
-    -- Denominator positivity (su.norm ≥ ‖·‖ ≥ 0, and upper_sqrt_two*ε + 3κ > 0)
-    have hden_pos : 0 < (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
-        (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * approx.upper_sqrt_two * ε + 6 * κ) := by
-      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
-      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
+    have hsu_norm_nn : (0 : ℝ) ≤ (approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) :=
+      (norm_nonneg _).trans h_norm_Qv_rat
+    -- Denominator positivity
+    have hden_pos : 0 < ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+        ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * approx.upper_sqrt_two * ε + 6 * κ) := by
+      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (toR3 Q_ℚ))) h_norm_rotM₂_Q
+      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ))) h_norm_rotM₂_Qv
       positivity
     -- Extract positivity of Bεℚ numerator
-    have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-        2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
+    have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚℝ (toR3 Q_ℚ), p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ - 10 * κ -
+        2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
       have hδ_pos : 0 < (δ : ℝ) := by
         have hδ₀ := hδ 0
-        linarith [le_trans (norm_nonneg _)
-           (UpperSqrt_norm_le approx.upper_sqrt (p_.rotR (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)))]
+        have h_eq_real_0 :
+            toR2 (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
+                  p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0)) =
+            p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0) := by
+          rw [h_toR2_sub, h_toR2_rotRℚ, h_toR2_rotM₁ℚ, h_toR2_rotM₂ℚ]; rfl
+        have hsu0 : ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)‖ ≤
+            (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
+                p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0)) : ℝ) := by
+          rw [← h_eq_real_0]
+          exact UpperSqrt_norm_le approx.upper_sqrt _
+        have h_κℚ_eq : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
+        have hδ₀_ℝ : (δ : ℝ) ≥
+            (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
+                p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0)) : ℝ) / 2 + 3 * κ := by
+          have hcast := (Rat.cast_le (K := ℝ)).mpr hδ₀
+          push_cast [h_κℚ_eq] at hcast
+          linarith
+        have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
+        linarith [le_trans (norm_nonneg
+          (p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0))) hsu0]
       have h0 : 0 < (δ + √5 * ε) / r := by positivity
       refine (div_pos_iff_of_pos_right hden_pos).mp (h0.trans ?_)
       exact hbe'
-    -- su.norm ≥ ‖·‖ and upper_sqrt_two ≥ √2 mean numBεℚ ≤ numAℚ
-    have h_num_sub : 2 * (ε : ℝ) * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
-        2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
-      apply mul_le_mul (mul_le_mul_of_nonneg_left (by linarith [hsu_ge]) (by linarith))
+    -- bounds_kappa4_Aℚ in real form
+    have h_num_sub : 2 * (ε : ℝ) * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) ≤
+        2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
+      apply mul_le_mul (mul_le_mul_of_nonneg_left (by linarith [h_norm_Qv_rat]) (by linarith))
         (by linarith) (by positivity) (by positivity)
-    have hAℚ_num_pos : 0 < ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ -
-        2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
-      show 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-          2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)
+    have hAℚ_num_pos : 0 < ⟪p_.rotM₂ℚℝ (toR3 Q_ℚ), p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ - 10 * κ -
+        2 * ε * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) := by
       linarith [hBεℚ_num_pos]
-    -- From inner_product_bound_10kappa: |innerA - innerAℚ| ≤ 10κ
+    -- Inner product 10κ-bound and the related real-norm bound for `Q i - v k`
     have hQv_norm : ‖Q i - poly.vertices.v k‖ ≤ 2 := calc
       ‖Q i - poly.vertices.v k‖ ≤ ‖Q i‖ + ‖poly.vertices.v k‖ := norm_sub_le _ _
       _ ≤ 1 + 1 := add_le_add (hQnorm i) hvnorm
       _ = 2 := by ring
-    have hQv_approx : ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖ ≤ 2 * κ := calc
-      ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖ = ‖(Q i - Q_ i) - (poly.vertices.v k - v_)‖ := by congr 1; abel
-      _ ≤ ‖Q i - Q_ i‖ + ‖poly.vertices.v k - v_‖ := norm_sub_le _ _
-      _ ≤ κ + κ := add_le_add (hQapprox i) hvapprox
-      _ = 2 * κ := by ring
-    have h_inner_10 : |⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ -
-        ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫| ≤ 10 * κ :=
-      inner_product_bound_10kappa (θ := θ₂) (φ := φ₂) (hQnorm i) hQv_norm (hQapprox i) hQv_approx
-    have h_norm_QR : ‖Q i - poly.vertices.v k‖ ≤ ‖Q_ i - v_‖ + 2 * κ :=
-      calc ‖Q i - poly.vertices.v k‖
-        _ ≤ ‖Q_ i - v_‖ + ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖ := norm_le_insert' _ _
-        _ ≤ ‖Q_ i - v_‖ + 2 * κ := by grw [hQv_approx]
-    have hA_nonneg : 0 ≤ ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ -
+    have hQv_approx : ‖(Q i - poly.vertices.v k) - (toR3 Q_ℚ - toR3 v_ℚ)‖ ≤ 2 * κ := by
+      rw [show toR3 Q_ℚ - toR3 v_ℚ = Q_ i - v_ from by rw [hQ_eq, hv_eq]]
+      calc ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖
+          = ‖(Q i - Q_ i) - (poly.vertices.v k - v_)‖ := by congr 1; abel
+        _ ≤ ‖Q i - Q_ i‖ + ‖poly.vertices.v k - v_‖ := norm_sub_le _ _
+        _ ≤ κ + κ := add_le_add (hQapprox i) hvapprox
+        _ = 2 * κ := by ring
+    -- Apply bounds_kappa4
+    have h_Q_approx : ‖Q i - toR3 Q_ℚ‖ ≤ κ := by rw [← hQ_eq]; exact hQapprox i
+    have h_v_approx : ‖poly.vertices.v k - toR3 v_ℚ‖ ≤ κ := by rw [← hv_eq]; exact hvapprox
+    have hA_nonneg : 0 ≤ ⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
+        (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ -
         2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) := by
-      have h_inner_le : ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ ≤
-          ⟪(rotM ↑θ₂ ↑φ₂) (Q i), (rotM ↑θ₂ ↑φ₂) (Q i - poly.vertices.v k)⟫ :=
+      have h_inner_10 : |⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
+            (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ -
+          ⟪p_.rotM₂ℚℝ (toR3 Q_ℚ),
+            p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫| ≤ 10 * κ :=
+        inner_product_bound_10kappa (θ := θ₂) (φ := φ₂) (hQnorm i) hQv_norm h_Q_approx hQv_approx
+      have h_inner_le : ⟪p_.rotM₂ℚℝ (toR3 Q_ℚ),
+            p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ - 10 * κ ≤
+          ⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
+            (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ :=
         sub_le_of_abs_sub_le_left h_inner_10
+      have h_norm_QR : ‖Q i - poly.vertices.v k‖ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ :=
+        calc ‖Q i - poly.vertices.v k‖
+          _ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ +
+              ‖(Q i - poly.vertices.v k) - (toR3 Q_ℚ - toR3 v_ℚ)‖ := norm_le_insert' _ _
+          _ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ := by grw [hQv_approx]
       have h_eps_term : 2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) ≤
-          2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
+          2 * ε * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) := by
         apply mul_le_mul_of_nonneg_right
         · exact mul_le_mul_of_nonneg_left h_norm_QR (by linarith)
         · positivity
       linarith [hAℚ_num_pos]
-    -- Apply bounds_kappa4 (note: P Q P_ Q_ θ φ are explicit in bounds_kappa4)
-    have hbk4 : bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt ≤
-        bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε :=
-      bounds_kappa4 (Q i) (poly.vertices.v k) (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hεℝ approx.upper_sqrt hA_nonneg
-    -- The explicit real form of `Bεℚ.lhs` ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ shrinks numerator;
-    -- upper_sqrt_two ≥ √2 grows denominator)
+    have hbk4 : bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt ≤
+        bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := by
+      change bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt ≤
+        bounds_kappa4_A (Q i) (poly.vertices.v k)
+          ⟨(p_ℚ.θ₂ : ℝ), hp.θ₂Bound⟩ ⟨(p_ℚ.φ₂ : ℝ), hp.φ₂Bound⟩ ε
+      exact bounds_kappa4 (Q i) (poly.vertices.v k) Q_ℚ v_ℚ p_ℚ
+        hp.θ₂Bound hp.φ₂Bound (hQnorm i) hvnorm h_Q_approx h_v_approx ε hεℝ
+        approx.upper_sqrt hA_nonneg
+    -- Bridge `Bεℚ.lhs` real form ≤ `bounds_kappa4_Aℚ`
     have hBεℚ_le :
-        (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
-          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
-            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) +
+        (⟪p_.rotM₂ℚℝ (toR3 Q_ℚ), p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ - 10 * κ -
+            2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
+          (((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+            ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) +
               2 * approx.upper_sqrt_two * ε + 6 * κ)) ≤
-        bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := by
-      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
-      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
+        bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt := by
+      show _ ≤ ((((p_ℚ.rotM₂ℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
+            2 * ε * (‖toR3 (Q_ℚ - v_ℚ)‖ + 2 * κ) * (√2 + ε)) /
+        (((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) + √2 * ε + 3 * κ) *
+         ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * √2 * ε + 6 * κ))
+      have h_inner_eq : ((p_ℚ.rotM₂ℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ) : ℚ) : ℝ) =
+          ⟪p_.rotM₂ℚℝ (toR3 Q_ℚ), p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ := by
+        rw [← h_toR2_rotM₂ℚ Q_ℚ, ← h_toR3_sub_Qv, ← h_toR2_rotM₂ℚ (Q_ℚ - v_ℚ), h_inner_toR2]
+      have h₁ : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) :=
+        le_trans (norm_nonneg _) h_norm_rotM₂_Q
+      have h₂ : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) :=
+        le_trans (norm_nonneg _) h_norm_rotM₂_Qv
       have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
         mul_le_mul_of_nonneg_right h_us2_le hεℝ.le
-      show (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
-          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
-            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * approx.upper_sqrt_two * ε + 6 * κ)) ≤
-          (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-            2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)) /
-          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
-            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
+      rw [h_inner_eq, h_toR3_sub_Qv]
       refine div_le_div₀ hAℚ_num_pos.le (by linarith [h_num_sub]) (by positivity) ?_
       gcongr
-    -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
-    have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
+    -- bounds_kappa4_A = Bε.lhs (definitionally)
+    have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε =
+        Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
     -- Combine
     calc (δ + √5 * ε) / r
-        < (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
-          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
-            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) +
-              2 * approx.upper_sqrt_two * ε + 6 * κ)) := hbe'
-      _ ≤ bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := hBεℚ_le
+        < _ := hbe'
+      _ ≤ bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt := hBεℚ_le
       _ ≤ bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := hbk4
       _ = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := hA_eq
   -- Apply local_theorem

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -22,9 +22,8 @@ Condition A_ε^ℚ from [SY25] Theorem 48
 def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
   ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * X ⬝ᵥ P_ i > approx.upper_sqrt_two * ε + 3 * κℚ
 
-noncomputable
 def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
-   (approx : RationalApprox.Approx) : ℝ :=
+   (approx : RationalApprox.Approx) : ℚ :=
    (p.rotM₂ℚ v₁ ⬝ᵥ p.rotM₂ℚ (v₁ - v₂) - 10 * κℚ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κℚ) * (approx.upper_sqrt_two + ε))
    / ((approx.upper_sqrt.norm (p.rotM₂ℚ v₁) + approx.upper_sqrt_two * ε + 3 * κℚ) * (approx.upper_sqrt.norm (p.rotM₂ℚ (v₁ - v₂)) + 2 * approx.upper_sqrt_two * ε + 6 * κℚ))
 
@@ -426,7 +425,10 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
         le_of_lt approx.upper_sqrt_five_gt_sqrt_five
       have h_le : (↑δ + √5 * ↑ε) / ↑r ≤ (↑δ + ↑approx.upper_sqrt_five * ↑ε) / ↑r := by
         gcongr
-      exact h_le.trans_lt hbe
+      have hbe_ℝ : ((δ + approx.upper_sqrt_five * ε) / r : ℝ) <
+          (Local.Triangle.Bεℚ.lhs Q_ℚ v_ℚ p_ℚ ε approx : ℝ) := by exact_mod_cast hbe
+      push_cast at hbe_ℝ
+      exact h_le.trans_lt hbe_ℝ
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
     -- Bridges relating real and rational norms via UpperSqrt_norm_le.

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -265,7 +265,12 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
       bounds_kappa3_MQ (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     show ‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ > r + √2 * ε
     have hr₁i : (approx.lower_sqrt.norm (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) >
-        r + √2 * ε + 3 * κ := hr₁ i
+        r + √2 * ε + 3 * κ := by
+      have h := hr₁ i
+      have hcast : ((approx.lower_sqrt.norm (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℚ) : ℝ) >
+          ((r + approx.upper_sqrt_two * ε + 3 * κℚ : ℚ) : ℝ) := by exact_mod_cast h
+      push_cast [h_κℚ] at hcast
+      linarith [h_us2_eps]
     rw [abs_le] at hMQ
     linarith [hMQ.1]
   -- Bridge: BoundDeltaℚ → BoundDelta

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -36,7 +36,7 @@ def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
 Condition B_ε^ℚ from [SY25] Theorem 48
 -/
 def Triangle.Bεℚ {ι : Type} [Fintype ι] (Q_ : TriangleQ) (Qi : Fin 3 → ι)
-    (v_ : ι → Fin 3 → ℚ) (p : Pose ℚ) (ε δ r : ℚ)  (approx : RationalApprox.Approx) : Prop :=
+    (v_ : ι → Fin 3 → ℚ) (p : Pose ℚ) (ε δ r : ℚ) (approx : RationalApprox.Approx) : Prop :=
   ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
     (δ + approx.upper_sqrt_five * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε approx
 
@@ -63,7 +63,7 @@ def BoundDeltaℚ (δ : ℚ) (p : Pose ℚ) (P_ Q_ : Local.TriangleQ) (approx : 
 
 /-- The condition on r -/
 def BoundRℚ (r ε : ℚ) (p : Pose ℚ) (Q_ : Local.TriangleQ) (approx : Approx) : Prop :=
-  ∀ i : Fin 3, (approx.lower_sqrt.norm (p.rotM₂ℚ (Q_ i)) : ℝ) > r + √2 * ε + 3 * κ
+  ∀ i : Fin 3, approx.lower_sqrt.norm (p.rotM₂ℚ (Q_ i)) > r + approx.upper_sqrt_two * ε + 3 * κℚ
 
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -56,6 +56,138 @@ def κApproxPoly.transportTri {ι : Type} [Fintype ι]
 
 namespace LocalTheorem
 
+/-! ### Universal bridge lemmas between the rational `Fin n → ℚ` and real `ℝⁿ` worlds. -/
+
+private lemma cast_κℚ : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
+
+private lemma toR3_sub (v w : Fin 3 → ℚ) : toR3 (v - w) = toR3 v - toR3 w := by
+  unfold toR3; ext i; simp
+
+private lemma toR2_sub (v w : Fin 2 → ℚ) : toR2 (v - w) = toR2 v - toR2 w := by
+  unfold toR2; ext i; simp
+
+private lemma toR3_vecXℚ (θ φ : ℚ) : toR3 (vecXℚ θ φ) = vecXℚℝ (↑θ : ℝ) ↑φ := by
+  ext j; unfold toR3 vecXℚ vecXℚℝ
+  fin_cases j <;> simp [sinℚ_match, cosℚ_match]
+
+private lemma inner_toR3 (v w : Fin 3 → ℚ) :
+    @inner ℝ ℝ³ _ (toR3 v) (toR3 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
+  unfold toR3
+  have h := EuclideanSpace.inner_eq_star_dotProduct
+    (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 3))
+    (WithLp.toLp 2 (fun i => (w i : ℝ)))
+  simp only [star_trivial] at h
+  rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
+       (WithLp.toLp 2 (fun i => (w i : ℝ))) =
+       (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
+  simp [dotProduct]
+
+private lemma inner_toR2 (v w : Fin 2 → ℚ) :
+    @inner ℝ ℝ² _ (toR2 v) (toR2 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
+  unfold toR2
+  have h := EuclideanSpace.inner_eq_star_dotProduct
+    (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 2))
+    (WithLp.toLp 2 (fun i => (w i : ℝ)))
+  simp only [star_trivial] at h
+  rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
+       (WithLp.toLp 2 (fun i => (w i : ℝ))) =
+       (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
+  simp [dotProduct]
+
+private lemma castℝ_mulVec {m n : ℕ} (M : Matrix (Fin m) (Fin n) ℚ) (v : Fin n → ℚ) :
+    (fun i => ((M.mulVec v) i : ℝ)) =
+      (M.map (fun x => (x : ℝ))).mulVec (fun i => (v i : ℝ)) := by
+  ext i
+  simp only [Matrix.mulVec, dotProduct, Matrix.map_apply]
+  push_cast; rfl
+
+private lemma rotMℚ_mat_castℝ (θ φ : ℚ) :
+    (rotMℚ_mat (θ : ℝ) (φ : ℝ)) = (rotMℚ_mat θ φ).map (fun x => (x : ℝ)) := by
+  ext i j; fin_cases i <;> fin_cases j <;> simp [rotMℚ_mat, sinℚ_match, cosℚ_match]
+
+private lemma rotRℚ_mat_castℝ (α : ℚ) :
+    (rotRℚ_mat (α : ℝ)) = (rotRℚ_mat α).map (fun x => (x : ℝ)) := by
+  ext i j; fin_cases i <;> fin_cases j <;> simp [rotRℚ_mat, sinℚ_match, cosℚ_match]
+
+private lemma toR2_rotMℚ (θ φ : ℚ) (v : Fin 3 → ℚ) :
+    toR2 (rotMℚ θ φ v) = rotMℚℝ (θ : ℝ) (φ : ℝ) (toR3 v) := by
+  unfold rotMℚ rotMℚℝ toR2 toR3
+  rw [Matrix.toLin'_apply]
+  show WithLp.toLp 2 (fun i : Fin 2 => (((rotMℚ_mat θ φ).mulVec v) i : ℝ)) =
+       (rotMℚ_mat (θ : ℝ) (φ : ℝ)).toEuclideanLin.toContinuousLinearMap
+         (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+  rw [castℝ_mulVec, ← rotMℚ_mat_castℝ]
+  show WithLp.toLp 2 ((rotMℚ_mat (θ : ℝ) (φ : ℝ)).mulVec _) =
+       (rotMℚ_mat (θ : ℝ) (φ : ℝ)).toEuclideanLin
+         (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
+  rw [Matrix.toLpLin_apply]
+
+private lemma toR2_rotRℚ (α : ℚ) (v : Fin 2 → ℚ) :
+    toR2 (rotRℚ α v) = rotRℚℝ (α : ℝ) (toR2 v) := by
+  unfold rotRℚ rotRℚℝ toR2
+  rw [Matrix.toLin'_apply]
+  show WithLp.toLp 2 (fun i : Fin 2 => (((rotRℚ_mat α).mulVec v) i : ℝ)) =
+       (rotRℚ_mat (α : ℝ)).toEuclideanLin.toContinuousLinearMap
+         (WithLp.toLp 2 (fun i : Fin 2 => (v i : ℝ)))
+  rw [castℝ_mulVec, ← rotRℚ_mat_castℝ]
+  show WithLp.toLp 2 ((rotRℚ_mat (α : ℝ)).mulVec _) =
+       (rotRℚ_mat (α : ℝ)).toEuclideanLin
+         (WithLp.toLp 2 (fun i : Fin 2 => (v i : ℝ)))
+  rw [Matrix.toLpLin_apply]
+
+private lemma toR2_pose_rotM₂ℚ (p : Pose ℚ) (v : Fin 3 → ℚ) :
+    toR2 (p.rotM₂ℚ v) = p.toReal.rotM₂ℚℝ (toR3 v) :=
+  toR2_rotMℚ p.θ₂ p.φ₂ v
+
+private lemma toR2_pose_rotM₁ℚ (p : Pose ℚ) (v : Fin 3 → ℚ) :
+    toR2 (p.rotM₁ℚ v) = p.toReal.rotM₁ℚℝ (toR3 v) :=
+  toR2_rotMℚ p.θ₁ p.φ₁ v
+
+private lemma toR2_pose_rotRℚ (p : Pose ℚ) (v : Fin 2 → ℚ) :
+    toR2 (p.rotRℚ v) = p.toReal.rotRℚℝ (toR2 v) :=
+  toR2_rotRℚ p.α v
+
+/--
+Helper used inside `rational_local`'s `Aε` bridge: rephrases the rational
+"angle" inequality on the real side, common to `ae₁'` and `ae₂'`.
+-/
+private lemma aε_bridge {θ φ : ℚ} {ε : ℚ} {approx : Approx}
+    (T : Local.TriangleQ) (R : Triangle)
+    (hθ : (θ : ℝ) ∈ Set.Icc (-4 : ℝ) 4) (hφ : (φ : ℝ) ∈ Set.Icc (-4 : ℝ) 4)
+    (hRnorm : ∀ i : Fin 3, ‖R i‖ ≤ 1)
+    (hRapprox : ∀ i : Fin 3, ‖R i - toR3 (T i)‖ ≤ κ)
+    (hAε : T.Aεℚ (vecXℚ θ φ) ε approx)
+    (hεℝ : 0 < (ε : ℝ)) :
+    R.Aε (vecX (θ : ℝ) (φ : ℝ)) ε := by
+  obtain ⟨σ, hσ₁, hσ₂⟩ := hAε
+  refine ⟨σ, hσ₁, fun i => ?_⟩
+  set θsub : Set.Icc (-4 : ℝ) 4 := ⟨(θ : ℝ), hθ⟩
+  set φsub : Set.Icc (-4 : ℝ) 4 := ⟨(φ : ℝ), hφ⟩
+  have hX : ‖⟪vecX (θsub : ℝ) (φsub : ℝ), R i⟫ -
+            ⟪vecXℚℝ (θsub : ℝ) (φsub : ℝ), toR3 (T i)⟫‖ ≤ 3 * κ :=
+    bounds_kappa3_X (θ := θsub) (φ := φsub) (hRnorm i) (hRapprox i)
+  have h_inner_eq :
+      @inner ℝ ℝ³ _ (vecXℚℝ (θ : ℝ) (φ : ℝ)) (toR3 (T i)) =
+        (((vecXℚ θ φ) ⬝ᵥ T i : ℚ) : ℝ) := by
+    rw [← toR3_vecXℚ]; exact inner_toR3 _ _
+  have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ (θ : ℝ) (φ : ℝ), toR3 (T i)⟫ >
+      approx.upper_sqrt_two * ε + 3 * κ := by
+    rw [h_inner_eq, ← cast_κℚ,
+        show ((-1 : ℝ)) ^ σ = ((((-1 : ℚ)) ^ σ : ℚ) : ℝ) by push_cast; rfl]
+    exact_mod_cast hσ₂ i
+  have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+    mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
+  rw [Real.norm_eq_abs] at hX
+  have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_pow σ
+  have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX (θ : ℝ) (φ : ℝ), R i⟫ -
+                                  ⟪vecXℚℝ (θ : ℝ) (φ : ℝ), toR3 (T i)⟫)| ≤ 3 * κ := by
+    rw [abs_mul, habs, one_mul]; exact hX
+  rw [abs_le] at hdiff
+  linarith [hdiff.1,
+    mul_sub ((-1 : ℝ) ^ σ) ⟪vecX (θ : ℝ) (φ : ℝ), R i⟫
+      ⟪vecXℚℝ (θ : ℝ) (φ : ℝ), toR3 (T i)⟫]
+
+
 abbrev BoundDeltaℚi (p : Pose ℚ) (P_ Q_ : Local.TriangleQ) (approx : Approx) (i : Fin 3) : ℚ :=
   approx.upper_sqrt.norm (p.rotRℚ (p.rotM₁ℚ (P_ i)) - p.rotM₂ℚ (Q_ i)) / 2 + 3 * κℚ
 
@@ -120,71 +252,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     ek_spanning_imp_e_spanning P P_ (fun i => hPapprox i) hPnorm hp.θ₁Bound hp.φ₁Bound span₁
   have span₂' : Q.Spanning p_.θ₂ p_.φ₂ ε :=
     ek_spanning_imp_e_spanning Q Q_ (fun i => hQapprox i) hQnorm hp.θ₂Bound hp.φ₂Bound span₂
-  -- Bridge: Aεℚ → Aε
-  have h_toR3_vecXℚ : ∀ θ φ : ℚ, toR3 (vecXℚ θ φ) = vecXℚℝ (↑θ : ℝ) ↑φ := by
-    intro θ φ
-    ext j
-    unfold toR3 vecXℚ vecXℚℝ
-    fin_cases j <;> simp [sinℚ_match, cosℚ_match]
-  have h_inner_toR3 : ∀ (v w : Fin 3 → ℚ),
-      @inner ℝ ℝ³ _ (toR3 v) (toR3 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
-    intro v w
-    unfold toR3
-    have h := EuclideanSpace.inner_eq_star_dotProduct
-      (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 3))
-      (WithLp.toLp 2 (fun i => (w i : ℝ)))
-    simp only [star_trivial] at h
-    rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
-         (WithLp.toLp 2 (fun i => (w i : ℝ))) =
-         (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
-    simp [dotProduct]
-  have h_κℚ : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
-  -- Cast helpers to bridge between the rational `Fin n → ℚ` world and the real one.
-  have h_castℝ_mulVec : ∀ {m n : ℕ} (M : Matrix (Fin m) (Fin n) ℚ) (v : Fin n → ℚ),
-      (fun i => ((M.mulVec v) i : ℝ)) =
-        (M.map (fun x => (x : ℝ))).mulVec (fun i => (v i : ℝ)) := by
-    intro m n M v
-    ext i
-    simp only [Matrix.mulVec, dotProduct, Matrix.map_apply]
-    push_cast; rfl
-  have h_rotMℚ_mat_castℝ : ∀ (θ φ : ℚ),
-      (rotMℚ_mat (θ : ℝ) (φ : ℝ)) = (rotMℚ_mat θ φ).map (fun x => (x : ℝ)) := by
-    intro θ φ
-    ext i j; fin_cases i <;> fin_cases j <;> simp [rotMℚ_mat, sinℚ_match, cosℚ_match]
-  -- Bridge: `toR3` is linear over subtraction.
-  have h_toR3_sub : ∀ (v w : Fin 3 → ℚ), toR3 (v - w) = toR3 v - toR3 w := by
-    intro v w
-    unfold toR3; ext i; simp
-  -- Bridge: `toR2` of the rational rotM₂ℚ application equals real rotM₂ℚℝ on `toR3`.
-  have h_toR2_rotM₂ℚ : ∀ (v : Fin 3 → ℚ),
-      toR2 (p_ℚ.rotM₂ℚ v) = p_.rotM₂ℚℝ (toR3 v) := by
-    intro v
-    show toR2 ((rotMℚ p_ℚ.θ₂ p_ℚ.φ₂) v) = rotMℚℝ (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ) (toR3 v)
-    unfold rotMℚ rotMℚℝ toR2 toR3
-    rw [Matrix.toLin'_apply]
-    show WithLp.toLp 2 (fun i : Fin 2 => (((rotMℚ_mat p_ℚ.θ₂ p_ℚ.φ₂).mulVec v) i : ℝ)) =
-         (rotMℚ_mat (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)).toEuclideanLin.toContinuousLinearMap
-           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
-    rw [h_castℝ_mulVec, ← h_rotMℚ_mat_castℝ]
-    show WithLp.toLp 2 ((rotMℚ_mat (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)).mulVec _) =
-         (rotMℚ_mat (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)).toEuclideanLin
-           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
-    rw [Matrix.toLpLin_apply]
-  -- Bridge: `inner` on `toR2` casts to a rational dot product.
-  have h_inner_toR2 : ∀ (v w : Fin 2 → ℚ),
-      @inner ℝ ℝ² _ (toR2 v) (toR2 w) = ((v ⬝ᵥ w : ℚ) : ℝ) := by
-    intro v w
-    unfold toR2
-    have h := EuclideanSpace.inner_eq_star_dotProduct
-      (WithLp.toLp 2 (fun i => (v i : ℝ)) : EuclideanSpace ℝ (Fin 2))
-      (WithLp.toLp 2 (fun i => (w i : ℝ)))
-    simp only [star_trivial] at h
-    rw [show @inner ℝ _ _ (WithLp.toLp 2 (fun i => (v i : ℝ)))
-         (WithLp.toLp 2 (fun i => (w i : ℝ))) =
-         (fun i => (w i : ℝ)) ⬝ᵥ (fun i => (v i : ℝ)) from h, dotProduct_comm]
-    simp [dotProduct]
-  -- Bridge: `‖toR3 v‖² = ((v ⬝ᵥ v : ℚ) : ℝ)` for `v : Fin 3 → ℚ`. Used to relate
-  -- `s.norm v` to `‖toR3 v‖`.
+  -- Universal bridges (above) provide the rational ↔ real cast facts we need.
   have h_upper_norm_toR3 : ∀ (v : Fin 3 → ℚ),
       (approx.upper_sqrt.norm v : ℝ) ≥ ‖toR3 v‖ := fun v =>
     UpperSqrt_norm_le approx.upper_sqrt v
@@ -201,117 +269,39 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
        ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (v₁ - v₂)) : ℝ) +
           2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
     intro v₁ v₂
-    have h_inner_bridge : ((p_ℚ.rotM₂ℚ v₁ ⬝ᵥ p_ℚ.rotM₂ℚ (v₁ - v₂) : ℚ) : ℝ) =
-        ⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ := by
-      rw [← h_toR2_rotM₂ℚ v₁, ← h_toR3_sub, ← h_toR2_rotM₂ℚ (v₁ - v₂), h_inner_toR2]
     unfold Local.Triangle.Bεℚ.lhs
-    push_cast [← h_κℚ]
-    rw [h_inner_bridge]
+    push_cast [← cast_κℚ]
+    rw [show ((p_ℚ.rotM₂ℚ v₁ ⬝ᵥ p_ℚ.rotM₂ℚ (v₁ - v₂) : ℚ) : ℝ) =
+        ⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ from by
+      rw [← toR3_sub, ← toR2_pose_rotM₂ℚ, ← toR2_pose_rotM₂ℚ, inner_toR2]]
   have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
     mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
-  have ae₁' : P.Aε p_.vecX₁ ε := by
-    obtain ⟨σ, hσ₁, hσ₂⟩ := ae₁
-    refine ⟨σ, hσ₁, fun i => ?_⟩
-    have hX : ‖⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫‖ ≤ 3 * κ :=
-      bounds_kappa3_X (θ := θ₁) (φ := φ₁) (hPnorm i) (hPapprox i)
-    change (-1) ^ σ * ⟪vecX ↑θ₁ ↑φ₁, P i⟫ > √2 * ε
-    have h_inner_eq : @inner ℝ ℝ³ _ (vecXℚℝ (↑θ₁ : ℝ) ↑φ₁) (P_ i) =
-        ((p_ℚ.vecX₁ℚ ⬝ᵥ (hpoly.transportTri Pi) i : ℚ) : ℝ) := by
-      show @inner ℝ ℝ³ _ (vecXℚℝ ↑p_ℚ.θ₁ ↑p_ℚ.φ₁) (P_ i) = _
-      rw [← h_toR3_vecXℚ]
-      exact h_inner_toR3 _ _
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := by
-      rw [h_inner_eq, ← h_κℚ,
-          show ((-1 : ℝ)) ^ σ = ((((-1 : ℚ)) ^ σ : ℚ) : ℝ) by push_cast; rfl]
-      exact_mod_cast hσ₂ i
-    rw [Real.norm_eq_abs] at hX
-    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_pow σ
-    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
-      rw [abs_mul, habs, one_mul]; exact hX
-    rw [abs_le] at hdiff
-    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₁ ↑φ₁, P i⟫ ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫]
-  have ae₂' : Q.Aε p_.vecX₂ ε := by
-    obtain ⟨σ, hσ₁, hσ₂⟩ := ae₂
-    refine ⟨σ, hσ₁, fun i => ?_⟩
-    have hX : ‖⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫‖ ≤ 3 * κ :=
-      bounds_kappa3_X (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
-    change (-1) ^ σ * ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ > √2 * ε
-    have h_inner_eq : @inner ℝ ℝ³ _ (vecXℚℝ (↑θ₂ : ℝ) ↑φ₂) (Q_ i) =
-        ((p_ℚ.vecX₂ℚ ⬝ᵥ (hpoly.transportTri Qi) i : ℚ) : ℝ) := by
-      show @inner ℝ ℝ³ _ (vecXℚℝ ↑p_ℚ.θ₂ ↑p_ℚ.φ₂) (Q_ i) = _
-      rw [← h_toR3_vecXℚ]
-      exact h_inner_toR3 _ _
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := by
-      rw [h_inner_eq, ← h_κℚ,
-          show ((-1 : ℝ)) ^ σ = ((((-1 : ℚ)) ^ σ : ℚ) : ℝ) by push_cast; rfl]
-      exact_mod_cast hσ₂ i
-    rw [Real.norm_eq_abs] at hX
-    have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_pow σ
-    have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by
-      rw [abs_mul, habs, one_mul]; exact hX
-    rw [abs_le] at hdiff
-    linarith [hdiff.1, mul_sub ((-1 : ℝ) ^ σ) ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫]
+  have ae₁' : P.Aε p_.vecX₁ ε :=
+    aε_bridge (T := hpoly.transportTri Pi) (R := P) hp.θ₁Bound hp.φ₁Bound
+      hPnorm hPapprox ae₁ hεℝ
+  have ae₂' : Q.Aε p_.vecX₂ ε :=
+    aε_bridge (T := hpoly.transportTri Qi) (R := Q) hp.θ₂Bound hp.φ₂Bound
+      hQnorm hQapprox ae₂ hεℝ
   -- Bridge: BoundRℚ → BoundR
   have hr₁' : Local.BoundR r ε p_ Q := by
     intro i
-    -- Bridge: ‖(rotMℚℝ θ₂ φ₂) (Q_ i)‖ = ‖toR2 (p_ℚ.rotM₂ℚ (transportTri Qi i))‖
-    have hQ_eq : Q_ i = toR3 ((hpoly.transportTri Qi) i) := rfl
     have h_toR2_eq : (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i) =
-        toR2 (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) := by
-      rw [hQ_eq]
-      exact (h_toR2_rotM₂ℚ _).symm
+        toR2 (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) :=
+      (toR2_pose_rotM₂ℚ _ _).symm
     have hsl : (approx.lower_sqrt.norm (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) ≤
         ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
-      rw [h_toR2_eq]
-      show (approx.lower_sqrt.norm _ : ℝ) ≤ ‖toR2 _‖
-      exact LowerSqrt_norm_ge approx.lower_sqrt _
+      rw [h_toR2_eq]; exact LowerSqrt_norm_ge approx.lower_sqrt _
     have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ - ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖)| ≤ 3 * κ :=
       bounds_kappa3_MQ (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     show ‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ > r + √2 * ε
     have hr₁i : (approx.lower_sqrt.norm (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) >
         r + √2 * ε + 3 * κ := by
-      have h := hr₁ i
       have hcast : ((approx.lower_sqrt.norm (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℚ) : ℝ) >
-          ((r + approx.upper_sqrt_two * ε + 3 * κℚ : ℚ) : ℝ) := by exact_mod_cast h
-      push_cast [h_κℚ] at hcast
+          ((r + approx.upper_sqrt_two * ε + 3 * κℚ : ℚ) : ℝ) := by exact_mod_cast hr₁ i
+      push_cast [cast_κℚ] at hcast
       linarith [h_us2_eps]
     rw [abs_le] at hMQ
     linarith [hMQ.1]
-  -- Bridge: BoundDeltaℚ → BoundDelta
-  -- Helper bridges for `rotRℚ`, `rotM₁ℚ`, and `toR2` over subtraction.
-  have h_toR2_sub : ∀ (v w : Fin 2 → ℚ), toR2 (v - w) = toR2 v - toR2 w := by
-    intro v w; unfold toR2; ext i; simp
-  have h_toR2_rotM₁ℚ : ∀ (v : Fin 3 → ℚ),
-      toR2 (p_ℚ.rotM₁ℚ v) = p_.rotM₁ℚℝ (toR3 v) := by
-    intro v
-    show toR2 ((rotMℚ p_ℚ.θ₁ p_ℚ.φ₁) v) = rotMℚℝ (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ) (toR3 v)
-    unfold rotMℚ rotMℚℝ toR2 toR3
-    rw [Matrix.toLin'_apply]
-    show WithLp.toLp 2 (fun i : Fin 2 => (((rotMℚ_mat p_ℚ.θ₁ p_ℚ.φ₁).mulVec v) i : ℝ)) =
-         (rotMℚ_mat (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ)).toEuclideanLin.toContinuousLinearMap
-           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
-    rw [h_castℝ_mulVec, ← h_rotMℚ_mat_castℝ]
-    show WithLp.toLp 2 ((rotMℚ_mat (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ)).mulVec _) =
-         (rotMℚ_mat (p_ℚ.θ₁ : ℝ) (p_ℚ.φ₁ : ℝ)).toEuclideanLin
-           (WithLp.toLp 2 (fun i : Fin 3 => (v i : ℝ)))
-    rw [Matrix.toLpLin_apply]
-  have h_rotRℚ_mat_castℝ : (rotRℚ_mat (p_ℚ.α : ℝ)) = (rotRℚ_mat p_ℚ.α).map (fun x => (x : ℝ)) := by
-    ext i j; fin_cases i <;> fin_cases j <;> simp [rotRℚ_mat, sinℚ_match, cosℚ_match]
-  -- Bridge: `toR2` of `p_ℚ.rotRℚ v` equals `p_.rotRℚℝ (toR2 v)`.
-  have h_toR2_rotRℚ : ∀ (v : Fin 2 → ℚ),
-      toR2 (p_ℚ.rotRℚ v) = p_.rotRℚℝ (toR2 v) := by
-    intro v
-    show toR2 ((rotRℚ p_ℚ.α) v) = (rotRℚℝ (p_ℚ.α : ℝ)) (toR2 v)
-    unfold rotRℚ rotRℚℝ toR2
-    rw [Matrix.toLin'_apply]
-    show WithLp.toLp 2 (fun i : Fin 2 => (((rotRℚ_mat p_ℚ.α).mulVec v) i : ℝ)) =
-         (rotRℚ_mat (p_ℚ.α : ℝ)).toEuclideanLin.toContinuousLinearMap
-           (WithLp.toLp 2 (fun i : Fin 2 => (v i : ℝ)))
-    rw [h_castℝ_mulVec, ← h_rotRℚ_mat_castℝ]
-    show WithLp.toLp 2 ((rotRℚ_mat (p_ℚ.α : ℝ)).mulVec _) =
-         (rotRℚ_mat (p_ℚ.α : ℝ)).toEuclideanLin
-           (WithLp.toLp 2 (fun i : Fin 2 => (v i : ℝ)))
-    rw [Matrix.toLpLin_apply]
   have hδ' : Local.BoundDelta δ p_ P Q := by
     intro i
     have hδi := hδ i
@@ -320,12 +310,11 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
         toR2 (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
               p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) =
         p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i) := by
-      rw [h_toR2_sub, h_toR2_rotRℚ, h_toR2_rotM₁ℚ, h_toR2_rotM₂ℚ]; rfl
+      rw [toR2_sub, toR2_pose_rotRℚ, toR2_pose_rotM₁ℚ, toR2_pose_rotM₂ℚ]; rfl
     have hsu : ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
         (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
             p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) := by
-      rw [← h_eq_real]
-      exact UpperSqrt_norm_le approx.upper_sqrt _
+      rw [← h_eq_real]; exact UpperSqrt_norm_le approx.upper_sqrt _
     -- ‖p_.rotR (rotM₁ℚℝ P_) - rotRℚℝ (rotM₁ℚℝ P_)‖ ≤ κ * (1 + κ)  (rotR vs rotRℚℝ discrepancy)
     have h_rotR_norm_one : ‖p_.rotR‖ ≤ 1 := by
       show ‖rotR p_.α‖ ≤ 1
@@ -400,12 +389,10 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hδiℝ : (δ : ℝ) ≥
         (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
             p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) / 2 + 3 * κ := by
-      have h_κℚ_eq : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
-      have := hδi
       have hcast : ((approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
             p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) / 2 + 3 * κℚ : ℚ) : ℝ) ≤ (δ : ℝ) := by
-        exact_mod_cast this
-      push_cast [h_κℚ_eq] at hcast
+        exact_mod_cast hδi
+      push_cast [cast_κℚ] at hcast
       linarith
     linarith [hδiℝ, h_chain]
   -- Bridge: Bεℚ → Bε
@@ -446,15 +433,15 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
     -- Bridges relating real and rational norms via UpperSqrt_norm_le.
-    have h_toR3_sub_Qv : toR3 (Q_ℚ - v_ℚ) = toR3 Q_ℚ - toR3 v_ℚ := h_toR3_sub _ _
+    have h_toR3_sub_Qv : toR3 (Q_ℚ - v_ℚ) = toR3 Q_ℚ - toR3 v_ℚ := toR3_sub _ _
     have h_norm_Qv_rat : ‖toR3 Q_ℚ - toR3 v_ℚ‖ ≤ (approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) := by
       rw [← h_toR3_sub_Qv]; exact h_upper_norm_toR3 _
     have h_norm_rotM₂_Q : ‖p_.rotM₂ℚℝ (toR3 Q_ℚ)‖ ≤
         (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) := by
-      rw [← h_toR2_rotM₂ℚ]; exact h_upper_norm_toR2 _
+      rw [← toR2_pose_rotM₂ℚ]; exact h_upper_norm_toR2 _
     have h_norm_rotM₂_Qv : ‖p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)‖ ≤
         (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) := by
-      rw [← h_toR3_sub_Qv, ← h_toR2_rotM₂ℚ]; exact h_upper_norm_toR2 _
+      rw [← h_toR3_sub_Qv, ← toR2_pose_rotM₂ℚ]; exact h_upper_norm_toR2 _
     have h_us2_nn : (0 : ℝ) ≤ approx.upper_sqrt_two :=
       (Real.sqrt_nonneg 2).trans approx.upper_sqrt_two_gt_sqrt_two.le
     have h_us2_le : (√2 : ℝ) ≤ approx.upper_sqrt_two := approx.upper_sqrt_two_gt_sqrt_two.le
@@ -470,27 +457,14 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚℝ (toR3 Q_ℚ), p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ - 10 * κ -
         2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
       have hδ_pos : 0 < (δ : ℝ) := by
-        have hδ₀ := hδ 0
-        have h_eq_real_0 :
-            toR2 (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
-                  p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0)) =
-            p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0) := by
-          rw [h_toR2_sub, h_toR2_rotRℚ, h_toR2_rotM₁ℚ, h_toR2_rotM₂ℚ]; rfl
-        have hsu0 : ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)‖ ≤
-            (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
-                p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0)) : ℝ) := by
-          rw [← h_eq_real_0]
-          exact UpperSqrt_norm_le approx.upper_sqrt _
-        have h_κℚ_eq : ((κℚ : ℚ) : ℝ) = κ := by unfold κℚ κ; norm_num
-        have hδ₀_ℝ : (δ : ℝ) ≥
-            (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
-                p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0)) : ℝ) / 2 + 3 * κ := by
-          have hcast := (Rat.cast_le (K := ℝ)).mpr hδ₀
-          push_cast [h_κℚ_eq] at hcast
-          linarith
+        -- δ ≥ s.norm/2 + 3 * κℚ in ℚ, and s.norm ≥ 0 (it bounds a real norm).
+        have hsu0 := UpperSqrt_norm_le approx.upper_sqrt
+          (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
+            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0))
+        have hcast := (Rat.cast_le (K := ℝ)).mpr (hδ 0)
+        push_cast [cast_κℚ] at hcast
         have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
-        linarith [le_trans (norm_nonneg
-          (p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0))) hsu0]
+        linarith [(norm_nonneg _).trans hsu0]
       have h0 : 0 < (δ + √5 * ε) / r := by positivity
       refine (div_pos_iff_of_pos_right hden_pos).mp (h0.trans ?_)
       exact hbe'
@@ -563,7 +537,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
          ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * √2 * ε + 6 * κ))
       have h_inner_eq : ((p_ℚ.rotM₂ℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ) : ℚ) : ℝ) =
           ⟪p_.rotM₂ℚℝ (toR3 Q_ℚ), p_.rotM₂ℚℝ (toR3 Q_ℚ - toR3 v_ℚ)⟫ := by
-        rw [← h_toR2_rotM₂ℚ Q_ℚ, ← h_toR3_sub_Qv, ← h_toR2_rotM₂ℚ (Q_ℚ - v_ℚ), h_inner_toR2]
+        rw [← toR2_pose_rotM₂ℚ p_ℚ Q_ℚ, ← h_toR3_sub_Qv,
+            ← toR2_pose_rotM₂ℚ p_ℚ (Q_ℚ - v_ℚ), inner_toR2]
       have h₁ : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ Q_ℚ) : ℝ) :=
         le_trans (norm_nonneg _) h_norm_rotM₂_Q
       have h₂ : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (Q_ℚ - v_ℚ)) : ℝ) :=

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -19,8 +19,8 @@ def TriangleQ.toReal (t : TriangleQ) : Triangle :=
 /--
 Condition A_ε^ℚ from [SY25] Theorem 48
 -/
-def TriangleQ.Aεℚ (X : ℝ³) (P_ : TriangleQ) (ε : ℚ) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪X, P_.toReal i⟫ > √2 * ε + 3 * κ
+def TriangleQ.Aεℚ (X : ℝ³) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
+  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪X, P_.toReal i⟫ > approx.upper_sqrt_two * ε + 3 * κ
 
 noncomputable
 def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (approx : RationalApprox.Approx) : ℝ :=
@@ -72,8 +72,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (approx : Approx)
     (hr₁ : BoundRℚ r ε p_.toReal (hpoly.transportTri Qi).toReal approx)
     (hδ : BoundDeltaℚ δ p_.toReal (hpoly.transportTri Pi).toReal (hpoly.transportTri Qi).toReal approx)
-    (ae₁ : (hpoly.transportTri Pi).Aεℚ p_.toReal.vecX₁ℚℝ ε)
-    (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.toReal.vecX₂ℚℝ ε)
+    (ae₁ : (hpoly.transportTri Pi).Aεℚ p_.toReal.vecX₁ℚℝ ε approx)
+    (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.toReal.vecX₂ℚℝ ε approx)
     (span₁ : (hpoly.transportTri Pi).toReal.κSpanning (p_.θ₁ : ℝ) (p_.φ₁ : ℝ) ε)
     (span₂ : (hpoly.transportTri Qi).toReal.κSpanning (p_.θ₂ : ℝ) (p_.φ₂ : ℝ) ε)
     (be : (hpoly.transportTri Qi).toReal.Bεℚ Qi
@@ -115,7 +115,9 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hX : ‖⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₁) (φ := φ₁) (hPnorm i) (hPapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₁ ↑φ₁, P i⟫ > √2 * ε
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂ i
+    have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+      mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
@@ -128,7 +130,9 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hX : ‖⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ > √2 * ε
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > √2 * ε + 3 * κ := hσ₂ i
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂ i
+    have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+      mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -24,8 +24,8 @@ def TriangleQ.Aεℚ (X : ℝ³) (P_ : TriangleQ) (ε : ℚ) : Prop :=
 
 noncomputable
 def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (approx : RationalApprox.Approx) : ℝ :=
-   (⟪p.rotM₂ℚℝ v₁, p.rotM₂ℚℝ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
-   / ((approx.upper_sqrt.norm (p.rotM₂ℚℝ v₁) + approx.upper_sqrt_two * ε + 3 * κ) * (approx.upper_sqrt.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
+   (⟪p.rotM₂ℚℝ v₁, p.rotM₂ℚℝ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κ) * (approx.upper_sqrt_two + ε))
+   / ((approx.upper_sqrt.norm (p.rotM₂ℚℝ v₁) + approx.upper_sqrt_two * ε + 3 * κ) * (approx.upper_sqrt.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * approx.upper_sqrt_two * ε + 6 * κ))
 
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
@@ -218,17 +218,20 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
     have hsu_ge : approx.upper_sqrt.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le approx.upper_sqrt _
+    have h_us2_nn : (0 : ℝ) ≤ approx.upper_sqrt_two :=
+      (Real.sqrt_nonneg 2).trans approx.upper_sqrt_two_gt_sqrt_two.le
+    have h_us2_le : (√2 : ℝ) ≤ approx.upper_sqrt_two := approx.upper_sqrt_two_gt_sqrt_two.le
+    have hsu_norm_nn : (0 : ℝ) ≤ approx.upper_sqrt.norm (Q_ i - v_) :=
+      (norm_nonneg _).trans hsu_ge
     -- Denominator positivity (su.norm ≥ ‖·‖ ≥ 0, and upper_sqrt_two*ε + 3κ > 0)
     have hden_pos : 0 < (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
-        (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ) := by
-      have h_us2_nn : (0 : ℝ) ≤ approx.upper_sqrt_two :=
-        (Real.sqrt_nonneg 2).trans approx.upper_sqrt_two_gt_sqrt_two.le
+        (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * approx.upper_sqrt_two * ε + 6 * κ) := by
       have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
       have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
       positivity
     -- Extract positivity of Bεℚ numerator
     have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-        2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+        2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
       have hδ_pos : 0 < (δ : ℝ) := by
         have hδ₀ := hδ 0
         linarith [le_trans (norm_nonneg _)
@@ -236,16 +239,15 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
       have h0 : 0 < (δ + √5 * ε) / r := by positivity
       refine (div_pos_iff_of_pos_right hden_pos).mp (h0.trans ?_)
       exact hbe'
-    -- su.norm ≥ ‖·‖ means numBεℚ ≤ numAℚ (subtracted term is bigger with su.norm)
+    -- su.norm ≥ ‖·‖ and upper_sqrt_two ≥ √2 mean numBεℚ ≤ numAℚ
+    have h_num_sub : 2 * (ε : ℝ) * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
+        2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
+      apply mul_le_mul (mul_le_mul_of_nonneg_left (by linarith [hsu_ge]) (by linarith))
+        (by linarith) (by positivity) (by positivity)
     have hAℚ_num_pos : 0 < ⟪(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i), (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i - v_)⟫ - 10 * κ -
         2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) := by
       show 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
           2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)
-      have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
-          2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
-        apply mul_le_mul_of_nonneg_right
-        · exact mul_le_mul_of_nonneg_left (by grw [hsu_ge]) (by linarith)
-        · positivity
       linarith [hBεℚ_num_pos]
     -- From inner_product_bound_10kappa: |innerA - innerAℚ| ≤ 10κ
     have hQv_norm : ‖Q i - poly.vertices.v k‖ ≤ 2 := calc
@@ -285,23 +287,18 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
         bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := by
       have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
       have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
-      have h_us2 : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
-        mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
-      have h_num_sub : 2 * (ε : ℝ) * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
-          2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
-        apply mul_le_mul_of_nonneg_right (mul_le_mul_of_nonneg_left
-          (by linarith [hsu_ge]) (by linarith))
-        positivity
+      have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+        mul_le_mul_of_nonneg_right h_us2_le hεℝ.le
       show (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε)) /
+            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
           ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + approx.upper_sqrt_two * ε + 3 * κ) *
-            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ)) ≤
+            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * approx.upper_sqrt_two * ε + 6 * κ)) ≤
           (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
             2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)) /
           ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
             (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
-      refine div_le_div₀ hAℚ_num_pos.le (by linarith) (by positivity) ?_
-      exact mul_le_mul_of_nonneg_right (by linarith) (by positivity)
+      refine div_le_div₀ hAℚ_num_pos.le (by linarith [h_num_sub]) (by positivity) ?_
+      gcongr
     -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
     have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
     -- Combine

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -19,8 +19,8 @@ def TriangleQ.toReal (t : TriangleQ) : Triangle :=
 /--
 Condition A_ε^ℚ from [SY25] Theorem 48
 -/
-def TriangleQ.Aεℚ (X : ℝ³) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
-  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪X, P_.toReal i⟫ > approx.upper_sqrt_two * ε + 3 * κ
+def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
+  ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪toR3 X, P_.toReal i⟫ > approx.upper_sqrt_two * ε + 3 * κ
 
 noncomputable
 def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (approx : RationalApprox.Approx) : ℝ :=
@@ -72,8 +72,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (approx : Approx)
     (hr₁ : BoundRℚ r ε p_.toReal (hpoly.transportTri Qi).toReal approx)
     (hδ : BoundDeltaℚ δ p_.toReal (hpoly.transportTri Pi).toReal (hpoly.transportTri Qi).toReal approx)
-    (ae₁ : (hpoly.transportTri Pi).Aεℚ p_.toReal.vecX₁ℚℝ ε approx)
-    (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.toReal.vecX₂ℚℝ ε approx)
+    (ae₁ : (hpoly.transportTri Pi).Aεℚ p_.vecX₁ℚ ε approx)
+    (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.vecX₂ℚ ε approx)
     (span₁ : (hpoly.transportTri Pi).toReal.κSpanning (p_.θ₁ : ℝ) (p_.φ₁ : ℝ) ε)
     (span₂ : (hpoly.transportTri Qi).toReal.κSpanning (p_.θ₂ : ℝ) (p_.φ₂ : ℝ) ε)
     (be : (hpoly.transportTri Qi).toReal.Bεℚ Qi
@@ -109,15 +109,22 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
   have span₂' : Q.Spanning p_.θ₂ p_.φ₂ ε :=
     ek_spanning_imp_e_spanning Q Q_ (fun i => hQapprox i) hQnorm hp.θ₂Bound hp.φ₂Bound span₂
   -- Bridge: Aεℚ → Aε
+  have h_toR3_vecXℚ : ∀ θ φ : ℚ, toR3 (vecXℚ θ φ) = vecXℚℝ (↑θ : ℝ) ↑φ := by
+    intro θ φ
+    ext j
+    unfold toR3 vecXℚ vecXℚℝ
+    fin_cases j <;> simp [sinℚ_match, cosℚ_match]
+  have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+    mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
   have ae₁' : P.Aε p_.vecX₁ ε := by
     obtain ⟨σ, hσ₁, hσ₂⟩ := ae₁
     refine ⟨σ, hσ₁, fun i => ?_⟩
     have hX : ‖⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₁) (φ := φ₁) (hPnorm i) (hPapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₁ ↑φ₁, P i⟫ > √2 * ε
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂ i
-    have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
-      mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
+    have hσ₂i' := hσ₂ i
+    simp only [Pose.vecX₁ℚ, h_toR3_vecXℚ] at hσ₂i'
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂i'
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₁ ↑φ₁, P i⟫ - ⟪vecXℚℝ ↑θ₁ ↑φ₁, P_ i⟫)| ≤ 3 * κ := by
@@ -130,9 +137,9 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have hX : ‖⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫‖ ≤ 3 * κ :=
       bounds_kappa3_X (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     change (-1) ^ σ * ⟪vecX ↑θ₂ ↑φ₂, Q i⟫ > √2 * ε
-    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂ i
-    have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
-      mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
+    have hσ₂i' := hσ₂ i
+    simp only [Pose.vecX₂ℚ, h_toR3_vecXℚ] at hσ₂i'
+    have hσ₂i : (-1) ^ σ * ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫ > approx.upper_sqrt_two * ε + 3 * κ := hσ₂i'
     rw [Real.norm_eq_abs] at hX
     have habs : |(-1 : ℝ) ^ σ| = 1 := abs_neg_one_zpow σ
     have hdiff : |(-1 : ℝ) ^ σ * (⟪vecX ↑θ₂ ↑φ₂, Q i⟫ - ⟪vecXℚℝ ↑θ₂ ↑φ₂, Q_ i⟫)| ≤ 3 * κ := by

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -23,17 +23,17 @@ def TriangleQ.Aεℚ (X : ℝ³) (P_ : TriangleQ) (ε : ℚ) : Prop :=
   ∃ σ ∈ ({-1, 1} : Set ℤ), ∀ i : Fin 3, (-1)^σ * ⟪X, P_.toReal i⟫ > √2 * ε + 3 * κ
 
 noncomputable
-def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (su : UpperSqrt) : ℝ :=
-   (⟪p.rotM₂ℚℝ v₁, p.rotM₂ℚℝ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (su.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
-   / ((su.norm (p.rotM₂ℚℝ v₁) + √2 * ε + 3 * κ) * (su.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
+def Triangle.Bεℚ.lhs (v₁ v₂ : Euc(3)) (p : Pose ℝ) (ε : ℚ) (approx : RationalApprox.Approx) : ℝ :=
+   (⟪p.rotM₂ℚℝ v₁, p.rotM₂ℚℝ (v₁ - v₂)⟫ - 10 * κ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κ) * (√2 + ε))
+   / ((approx.upper_sqrt.norm (p.rotM₂ℚℝ v₁) + √2 * ε + 3 * κ) * (approx.upper_sqrt.norm (p.rotM₂ℚℝ (v₁ - v₂)) + 2 * √2 * ε + 6 * κ))
 
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
 -/
 def Triangle.Bεℚ {ι : Type} [Fintype ι] (Q_ : Triangle) (Qi : Fin 3 → ι)
-    (v_ : ι → Euc(3)) (p : Pose ℝ) (ε δ r : ℚ)  (su : UpperSqrt) : Prop :=
+    (v_ : ι → Euc(3)) (p : Pose ℝ) (ε δ r : ℚ)  (approx : RationalApprox.Approx) : Prop :=
   ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
-    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε su
+    (δ + √5 * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε approx
 
 end Local
 
@@ -52,12 +52,12 @@ def κApproxPoly.transportTri {ι : Type} [Fintype ι]
 namespace LocalTheorem
 
 /-- The condition on δ -/
-def BoundDeltaℚ (δ : ℝ) (p : Pose ℝ) (P_ Q_ : Triangle) (su : UpperSqrt) : Prop :=
-  ∀ i : Fin 3, δ ≥ su.norm (p.rotR (p.rotM₁ℚℝ (P_ i)) - p.rotM₂ℚℝ (Q_ i))/2 + 3 * κ
+def BoundDeltaℚ (δ : ℝ) (p : Pose ℝ) (P_ Q_ : Triangle) (approx : Approx) : Prop :=
+  ∀ i : Fin 3, δ ≥ approx.upper_sqrt.norm (p.rotR (p.rotM₁ℚℝ (P_ i)) - p.rotM₂ℚℝ (Q_ i))/2 + 3 * κ
 
 /-- The condition on r -/
-def BoundRℚ (r ε : ℝ) (p : Pose ℝ) (Q_ : Triangle) (sl : LowerSqrt) : Prop :=
-  ∀ i : Fin 3, sl.norm (p.rotM₂ℚℝ (Q_ i)) > r + √2 * ε + 3 * κ
+def BoundRℚ (r ε : ℝ) (p : Pose ℝ) (Q_ : Triangle) (approx : Approx) : Prop :=
+  ∀ i : Fin 3, approx.lower_sqrt.norm (p.rotM₂ℚℝ (Q_ i)) > r + √2 * ε + 3 * κ
 
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"
@@ -69,15 +69,15 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (cong_tri : Triangle.Congruent (poly.vertices.v ∘ Pi) (poly.vertices.v ∘ Qi))
     (p_ : Pose ℚ) (hp : p_ ∈ fourInterval ℚ)
     (ε δ r : ℚ) (hε : 0 < ε) (hr : 0 < r)
-    (su : UpperSqrt) (sl : LowerSqrt)
-    (hr₁ : BoundRℚ r ε p_.toReal (hpoly.transportTri Qi).toReal sl)
-    (hδ : BoundDeltaℚ δ p_.toReal (hpoly.transportTri Pi).toReal (hpoly.transportTri Qi).toReal su)
+    (approx : Approx)
+    (hr₁ : BoundRℚ r ε p_.toReal (hpoly.transportTri Qi).toReal approx)
+    (hδ : BoundDeltaℚ δ p_.toReal (hpoly.transportTri Pi).toReal (hpoly.transportTri Qi).toReal approx)
     (ae₁ : (hpoly.transportTri Pi).Aεℚ p_.toReal.vecX₁ℚℝ ε)
     (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.toReal.vecX₂ℚℝ ε)
     (span₁ : (hpoly.transportTri Pi).toReal.κSpanning (p_.θ₁ : ℝ) (p_.φ₁ : ℝ) ε)
     (span₂ : (hpoly.transportTri Qi).toReal.κSpanning (p_.θ₂ : ℝ) (p_.φ₂ : ℝ) ε)
     (be : (hpoly.transportTri Qi).toReal.Bεℚ Qi
-          (fun k => poly_.toReal.v (hpoly.bijection k)) p_.toReal ε δ r su)
+          (fun k => poly_.toReal.v (hpoly.bijection k)) p_.toReal ε δ r approx)
     : ¬∃ p ∈ Metric.closedBall p_.toReal ε, RupertPose p poly.hull := by
   have hεℝ : 0 < (ε : ℝ) := span₁.pos
   set p_ := p_.toReal
@@ -138,14 +138,14 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
   -- Bridge: BoundRℚ → BoundR
   have hr₁' : Local.BoundR r ε p_ Q := by
     intro i
-    have hsl : sl.norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) ≤ ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
-      show sl.f _ ≤ _; calc sl.f (‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2)
-        _ ≤ √(‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2) := sl.bound _ (sq_nonneg _)
+    have hsl : approx.lower_norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) ≤ ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
+      show approx.lower_sqrt.f _ ≤ _; calc approx.lower_sqrt.f (‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2)
+        _ ≤ √(‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ^ 2) := approx.lower_sqrt.bound _ (sq_nonneg _)
         _ = ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := Real.sqrt_sq (norm_nonneg _)
     have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ - ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖)| ≤ 3 * κ :=
       bounds_kappa3_MQ (θ := θ₂) (φ := φ₂) (hQnorm i) (hQapprox i)
     show ‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ > r + √2 * ε
-    have hr₁i : sl.norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) > r + √2 * ε + 3 * κ := hr₁ i
+    have hr₁i : approx.lower_norm ((rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) > r + √2 * ε + 3 * κ := hr₁ i
     rw [abs_le] at hMQ
     linarith [hMQ.1]
   -- Bridge: BoundDeltaℚ → BoundDelta
@@ -154,8 +154,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     have := hδ i
     -- su.norm ≥ ‖·‖
     have hsu : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
-        su.norm (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) := by
-      exact UpperSqrt_norm_le su _
+        approx.upper_sqrt.norm (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) := by
+      exact UpperSqrt_norm_le approx.upper_sqrt _
     -- ‖real - rational‖ ≤ 6κ
     have hM₁diff : ‖rotM (↑θ₁ : ℝ) ↑φ₁ - rotMℚℝ ↑θ₁ ↑φ₁‖ ≤ κ :=
       M_difference_norm_bounded _ _ θ₁.property φ₁.property
@@ -208,20 +208,20 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     show (δ + √5 * ε) / r < Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε
     -- Helper facts
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
-    have hsu_ge : su.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le su _
+    have hsu_ge : approx.upper_sqrt.norm (Q_ i - v_) ≥ ‖Q_ i - v_‖ := UpperSqrt_norm_le approx.upper_sqrt _
     -- Denominator positivity (su.norm ≥ ‖·‖ ≥ 0, and √2*ε + 3κ > 0)
-    have hden_pos : 0 < (su.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
-        (su.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ) := by
-      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le su _)
-      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le su _)
+    have hden_pos : 0 < (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+        (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ) := by
+      have h₁ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i))) (UpperSqrt_norm_le approx.upper_sqrt _)
+      have h₂ := le_trans (norm_nonneg (p_.rotM₂ℚℝ (Q_ i - v_))) (UpperSqrt_norm_le approx.upper_sqrt _)
       positivity
     -- Extract positivity of Bεℚ numerator
     have hBεℚ_num_pos : 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-        2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+        2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
       have hδ_pos : 0 < (δ : ℝ) := by
         have hδ₀ := hδ 0
         linarith [le_trans (norm_nonneg _)
-           (UpperSqrt_norm_le su (p_.rotR (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)))]
+           (UpperSqrt_norm_le approx.upper_sqrt (p_.rotR (p_.rotM₁ℚℝ (P_ 0)) - p_.rotM₂ℚℝ (Q_ 0)))]
       have h0 : 0 < (δ + √5 * ε) / r := by positivity
       exact (div_pos_iff_of_pos_right hden_pos).mp (h0.trans hbe)
     -- su.norm ≥ ‖·‖ means numBεℚ ≤ numAℚ (subtracted term is bigger with su.norm)
@@ -230,7 +230,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
       show 0 < ⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
           2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)
       have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
-          2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+          2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
         apply mul_le_mul_of_nonneg_right
         · exact mul_le_mul_of_nonneg_left (by grw [hsu_ge]) (by linarith)
         · positivity
@@ -264,24 +264,24 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
         · positivity
       linarith [hAℚ_num_pos]
     -- Apply bounds_kappa4 (note: P Q P_ Q_ θ φ are explicit in bounds_kappa4)
-    have hbk4 : bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su ≤
+    have hbk4 : bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt ≤
         bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε :=
-      bounds_kappa4 (Q i) (poly.vertices.v k) (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hεℝ su hA_nonneg
+      bounds_kappa4 (Q i) (poly.vertices.v k) (Q_ i) v_ θ₂ φ₂ (hQnorm i) hvnorm (hQapprox i) hvapprox ε hεℝ approx.upper_sqrt hA_nonneg
     -- Bεℚ.lhs ≤ bounds_kappa4_Aℚ (su.norm ≥ ‖·‖ in numerator, denominators def. equal)
-    have hBεℚ_le : Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε su ≤
-        bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su := by
+    have hBεℚ_le : Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx ≤
+        bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := by
       -- Express both sides using p_.rotM₂ℚ (which is def. equal to rotMℚ ↑θ₂ ↑φ₂)
       show (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
-            2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε)) /
-          ((su.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
-            (su.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ)) ≤
+            2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε)) /
+          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ)) ≤
           (⟪p_.rotM₂ℚℝ (Q_ i), p_.rotM₂ℚℝ (Q_ i - v_)⟫ - 10 * κ -
             2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε)) /
-          ((su.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
-            (su.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
+          ((approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i)) + √2 * ε + 3 * κ) *
+            (approx.upper_sqrt.norm (p_.rotM₂ℚℝ (Q_ i - v_)) + 2 * √2 * ε + 6 * κ))
       apply div_le_div_of_nonneg_right _ (le_of_lt hden_pos)
       have h_sub_le : 2 * ε * (‖Q_ i - v_‖ + 2 * κ) * (√2 + ε) ≤
-          2 * ε * (su.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
+          2 * ε * (approx.upper_sqrt.norm (Q_ i - v_) + 2 * κ) * (√2 + ε) := by
         apply mul_le_mul_of_nonneg_right
         · exact mul_le_mul_of_nonneg_left (by grw [hsu_ge]) (by linarith)
         · positivity
@@ -289,8 +289,8 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     -- bounds_kappa4_A = Bε.lhs (definitionally: rotM ↑θ₂ ↑φ₂ = p_.rotM₂)
     have hA_eq : bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := rfl
     -- Combine
-    calc (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε su := hbe
-      _ ≤ bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε su := hBεℚ_le
+    calc (δ + √5 * ε) / r < Local.Triangle.Bεℚ.lhs (Q_ i) v_ p_ ε approx := hbe
+      _ ≤ bounds_kappa4_Aℚ (Q_ i) v_ θ₂ φ₂ ε approx.upper_sqrt := hBεℚ_le
       _ ≤ bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := hbk4
       _ = Local.Triangle.Bε.lhs (Q i) (poly.vertices.v k) p_ ε := hA_eq
   -- Apply local_theorem

--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -27,7 +27,7 @@ Condition A_ε^ℚ from [SY25] Theorem 48
 def TriangleQ.Aεℚ (X : Fin 3 → ℚ) (P_ : TriangleQ) (ε : ℚ) (approx : RationalApprox.Approx) : Prop :=
   ∃ σ ∈ ({0, 1} : Set ℕ), TriangleQ.Aεℚσ X P_ ε σ approx
 
-def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
+def TriangleQ.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
    (approx : RationalApprox.Approx) : ℚ :=
    (p.rotM₂ℚ v₁ ⬝ᵥ p.rotM₂ℚ (v₁ - v₂) - 10 * κℚ - 2 * ε * (approx.upper_sqrt.norm (v₁ - v₂) + 2 * κℚ) * (approx.upper_sqrt_two + ε))
    / ((approx.upper_sqrt.norm (p.rotM₂ℚ v₁) + approx.upper_sqrt_two * ε + 3 * κℚ) * (approx.upper_sqrt.norm (p.rotM₂ℚ (v₁ - v₂)) + 2 * approx.upper_sqrt_two * ε + 6 * κℚ))
@@ -35,10 +35,11 @@ def Triangle.Bεℚ.lhs (v₁ v₂ : Fin 3 → ℚ) (p : Pose ℚ) (ε : ℚ)
 /--
 Condition B_ε^ℚ from [SY25] Theorem 48
 -/
-def Triangle.Bεℚ {ι : Type} [Fintype ι] (Q_ : TriangleQ) (Qi : Fin 3 → ι)
+def TriangleQ.Bεℚ {ι : Type} [Fintype ι] [DecidableEq ι] (Q_ : TriangleQ) (Qi : Fin 3 → ι)
     (v_ : ι → Fin 3 → ℚ) (p : Pose ℚ) (ε δ r : ℚ) (approx : RationalApprox.Approx) : Prop :=
   ∀ i : Fin 3, ∀ k : ι, k ≠ Qi i →
-    (δ + approx.upper_sqrt_five * ε) / r < Triangle.Bεℚ.lhs (Q_ i) (v_ k) p ε approx
+    (δ + approx.upper_sqrt_five * ε) / r < TriangleQ.Bεℚ.lhs (Q_ i) (v_ k) p ε approx
+deriving Decidable
 
 end Local
 
@@ -204,7 +205,7 @@ deriving Decidable
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"
 -/
-theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
+theorem rational_local {ι : Type} [Fintype ι] [DecidableEq ι] [Nonempty ι]
     (poly : GoodPoly ι) (poly_ : Polyhedron ι (Fin 3 → ℚ))
     (hpoly : κApproxPoly poly.vertices poly_)
     (Pi Qi : Fin 3 → ι)
@@ -218,7 +219,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     (ae₂ : (hpoly.transportTri Qi).Aεℚ p_.vecX₂ℚ ε approx)
     (span₁ : (hpoly.transportTri Pi).toReal.κSpanning (p_.θ₁ : ℝ) (p_.φ₁ : ℝ) ε)
     (span₂ : (hpoly.transportTri Qi).toReal.κSpanning (p_.θ₂ : ℝ) (p_.φ₂ : ℝ) ε)
-    (be : Local.Triangle.Bεℚ (hpoly.transportTri Qi) Qi
+    (be : Local.TriangleQ.Bεℚ (hpoly.transportTri Qi) Qi
           (fun k => poly_.v (hpoly.bijection k)) p_ ε δ r approx)
     : ¬∃ p ∈ Metric.closedBall p_.toReal ε, RupertPose p poly.hull := by
   have hεℝ : 0 < (ε : ℝ) := span₁.pos
@@ -261,7 +262,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
     UpperSqrt_norm_le approx.upper_sqrt v
   -- Main bridge: rewrite `Bεℚ.lhs` in terms of explicit real-form expressions.
   have h_Bεℚ_lhs_bridge : ∀ (v₁ v₂ : Fin 3 → ℚ),
-      Local.Triangle.Bεℚ.lhs v₁ v₂ p_ℚ ε approx =
+      Local.TriangleQ.Bεℚ.lhs v₁ v₂ p_ℚ ε approx =
       (⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ - 10 * κ -
          2 * ε * ((approx.upper_sqrt.norm (v₁ - v₂) : ℝ) + 2 * κ) *
            (approx.upper_sqrt_two + ε)) /
@@ -269,7 +270,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
        ((approx.upper_sqrt.norm (p_ℚ.rotM₂ℚ (v₁ - v₂)) : ℝ) +
           2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
     intro v₁ v₂
-    unfold Local.Triangle.Bεℚ.lhs
+    unfold Local.TriangleQ.Bεℚ.lhs
     push_cast [← cast_κℚ]
     rw [show ((p_ℚ.rotM₂ℚ v₁ ⬝ᵥ p_ℚ.rotM₂ℚ (v₁ - v₂) : ℚ) : ℝ) =
         ⟪p_.rotM₂ℚℝ (toR3 v₁), p_.rotM₂ℚℝ (toR3 v₁ - toR3 v₂)⟫ from by
@@ -427,7 +428,7 @@ theorem rational_local {ι : Type} [Fintype ι] [Nonempty ι]
       have h_le : (↑δ + √5 * ↑ε) / ↑r ≤ (↑δ + ↑approx.upper_sqrt_five * ↑ε) / ↑r := by
         gcongr
       have hbe_ℝ : ((δ + approx.upper_sqrt_five * ε) / r : ℝ) <
-          (Local.Triangle.Bεℚ.lhs Q_ℚ v_ℚ p_ℚ ε approx : ℝ) := by exact_mod_cast hbe
+          (Local.TriangleQ.Bεℚ.lhs Q_ℚ v_ℚ p_ℚ ε approx : ℝ) := mod_cast hbe
       push_cast at hbe_ℝ
       exact h_le.trans_lt hbe_ℝ
     -- Helper facts

--- a/Noperthedron/SolutionTable/Local.lean
+++ b/Noperthedron/SolutionTable/Local.lean
@@ -1,11 +1,100 @@
 import Noperthedron.Checker.KappaApprox
 import Noperthedron.SolutionTable.Basic
+import Noperthedron.SolutionTable.Global
 import Noperthedron.Local.Congruent
 import Noperthedron.RationalApprox.RationalLocal
 import Noperthedron.Vertices.Exact
 import Noperthedron.Vertices.Symmetry
 
 namespace Noperthedron.Solution
+
+open scoped RealInnerProductSpace Real
+open scoped Matrix
+
+/-- The transported triangle for `exact_κApprox_python` is just `pythonVertex ∘ Pi`. -/
+private lemma transportTri_python (Pi : Fin 3 → VertexIndex) :
+    (KappaApprox.exact_κApprox_python.transportTri Pi : Local.TriangleQ) =
+      pythonVertex ∘ Pi := rfl
+
+/-- Bridge from rational `P_spanning` to real `κSpanning` for the Python polyhedron. -/
+private lemma py_κSpanning_of_rational
+    (Pi : Fin 3 → VertexIndex) (p : Pose ℚ) (ε : ℚ) (hε : 0 < ε)
+    (h : ∀ i : Fin 3,
+      2 * ε * (sqrt_twoℚ + ε) + 6 * κQ <
+        (rot90 *ᵥ (RationalApprox.rotMℚ_mat p.θ₁ p.φ₁ *ᵥ (pythonVertex (Pi i)))) ⬝ᵥ
+          (RationalApprox.rotMℚ_mat p.θ₁ p.φ₁ *ᵥ (pythonVertex (Pi (i + 1))))) :
+    (KappaApprox.exact_κApprox_python.transportTri Pi).toReal.κSpanning
+      (p.toReal.θ₁ : ℝ) (p.toReal.φ₁ : ℝ) ε := by
+  refine ⟨by exact_mod_cast hε, fun i => ?_⟩
+  -- bridge the rational LHS to the real κSpanning LHS
+  have hreal : (((rot90 *ᵥ (RationalApprox.rotMℚ_mat p.θ₁ p.φ₁ *ᵥ (pythonVertex (Pi i)))) ⬝ᵥ
+        (RationalApprox.rotMℚ_mat p.θ₁ p.φ₁ *ᵥ (pythonVertex (Pi (i + 1)))) : ℚ) : ℝ) =
+      ⟪rotR (π / 2) (RationalApprox.rotMℚℝ (p.θ₁ : ℝ) (p.φ₁ : ℝ) (toR3 (pythonVertex (Pi i)))),
+        RationalApprox.rotMℚℝ (p.θ₁ : ℝ) (p.φ₁ : ℝ) (toR3 (pythonVertex (Pi (i + 1))))⟫ := by
+    exact RationalApprox.rot90_rotMℚ_inner_eq_real_inner _ _ _ _
+  -- Cast rational hypothesis to ℝ
+  have hi := h i
+  have hcast : ((2 * ε * (sqrt_twoℚ + ε) + 6 * κQ : ℚ) : ℝ) <
+      (((rot90 *ᵥ (RationalApprox.rotMℚ_mat p.θ₁ p.φ₁ *ᵥ (pythonVertex (Pi i)))) ⬝ᵥ
+        (RationalApprox.rotMℚ_mat p.θ₁ p.φ₁ *ᵥ (pythonVertex (Pi (i + 1)))) : ℚ) : ℝ) := by
+    exact_mod_cast hi
+  rw [hreal] at hcast
+  -- bound 2 * ε * (sqrt_twoℚ + ε) ≥ 2 * ε * (√2 + ε), and 6 * κQ ≥ 6 * κ (equal in fact)
+  have hε_real : (0 : ℝ) ≤ (ε : ℝ) := by exact_mod_cast hε.le
+  have hsqrt2 : (√2 : ℝ) ≤ (142 / 100 : ℝ) := by
+    have h : Real.sqrt 2 < (1.42 : ℝ) :=
+      (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+    linarith
+  have hcastκ : ((κQ : ℚ) : ℝ) = RationalApprox.κ := by
+    show ((1 / 10 ^ 10 : ℚ) : ℝ) = 1 / 10 ^ 10
+    push_cast; rfl
+  have hbound :
+      2 * (ε : ℝ) * (Real.sqrt 2 + ε) + 6 * RationalApprox.κ ≤
+        ((2 * ε * (sqrt_twoℚ + ε) + 6 * κQ : ℚ) : ℝ) := by
+    push_cast [hcastκ]
+    have hk : 2 * (ε : ℝ) * (Real.sqrt 2 + ε) ≤ 2 * (ε : ℝ) * (142 / 100 + ε) :=
+      mul_le_mul_of_nonneg_left (by linarith) (by linarith)
+    linarith
+  -- Need to convert hcast goal `2 * ε * (√2 + ε) + 6 * κ < ⟪..⟫`
+  exact lt_of_le_of_lt hbound hcast
+
+/-- Bridge from rational `Q_spanning` to real `κSpanning`. -/
+private lemma py_κSpanning_of_rational_Q
+    (Qi : Fin 3 → VertexIndex) (p : Pose ℚ) (ε : ℚ) (hε : 0 < ε)
+    (h : ∀ i : Fin 3,
+      2 * ε * (sqrt_twoℚ + ε) + 6 * κQ <
+        (rot90 *ᵥ (RationalApprox.rotMℚ_mat p.θ₂ p.φ₂ *ᵥ (pythonVertex (Qi i)))) ⬝ᵥ
+          (RationalApprox.rotMℚ_mat p.θ₂ p.φ₂ *ᵥ (pythonVertex (Qi (i + 1))))) :
+    (KappaApprox.exact_κApprox_python.transportTri Qi).toReal.κSpanning
+      (p.toReal.θ₂ : ℝ) (p.toReal.φ₂ : ℝ) ε := by
+  refine ⟨by exact_mod_cast hε, fun i => ?_⟩
+  have hreal : (((rot90 *ᵥ (RationalApprox.rotMℚ_mat p.θ₂ p.φ₂ *ᵥ (pythonVertex (Qi i)))) ⬝ᵥ
+        (RationalApprox.rotMℚ_mat p.θ₂ p.φ₂ *ᵥ (pythonVertex (Qi (i + 1)))) : ℚ) : ℝ) =
+      ⟪rotR (π / 2) (RationalApprox.rotMℚℝ (p.θ₂ : ℝ) (p.φ₂ : ℝ) (toR3 (pythonVertex (Qi i)))),
+        RationalApprox.rotMℚℝ (p.θ₂ : ℝ) (p.φ₂ : ℝ) (toR3 (pythonVertex (Qi (i + 1))))⟫ := by
+    exact RationalApprox.rot90_rotMℚ_inner_eq_real_inner _ _ _ _
+  have hi := h i
+  have hcast : ((2 * ε * (sqrt_twoℚ + ε) + 6 * κQ : ℚ) : ℝ) <
+      (((rot90 *ᵥ (RationalApprox.rotMℚ_mat p.θ₂ p.φ₂ *ᵥ (pythonVertex (Qi i)))) ⬝ᵥ
+        (RationalApprox.rotMℚ_mat p.θ₂ p.φ₂ *ᵥ (pythonVertex (Qi (i + 1)))) : ℚ) : ℝ) := by
+    exact_mod_cast hi
+  rw [hreal] at hcast
+  have hε_real : (0 : ℝ) ≤ (ε : ℝ) := by exact_mod_cast hε.le
+  have hsqrt2 : (√2 : ℝ) ≤ (142 / 100 : ℝ) := by
+    have h : Real.sqrt 2 < (1.42 : ℝ) :=
+      (Real.sqrt_lt' (by norm_num)).mpr (by norm_num)
+    linarith
+  have hcastκ : ((κQ : ℚ) : ℝ) = RationalApprox.κ := by
+    show ((1 / 10 ^ 10 : ℚ) : ℝ) = 1 / 10 ^ 10
+    push_cast; rfl
+  have hbound :
+      2 * (ε : ℝ) * (Real.sqrt 2 + ε) + 6 * RationalApprox.κ ≤
+        ((2 * ε * (sqrt_twoℚ + ε) + 6 * κQ : ℚ) : ℝ) := by
+    push_cast [hcastκ]
+    have hk : 2 * (ε : ℝ) * (Real.sqrt 2 + ε) ≤ 2 * (ε : ℝ) * (142 / 100 + ε) :=
+      mul_le_mul_of_nonneg_left (by linarith) (by linarith)
+    linarith
+  exact lt_of_le_of_lt hbound hcast
 
 theorem valid_local_imp_no_rupert (tab : Table) (row : Row)
     (hrow : row.ValidLocal) :
@@ -34,7 +123,13 @@ theorem valid_local_imp_no_rupert (tab : Table) (row : Row)
     rw [show (row.α : ℝ) = ((row.interval.center .α : ℚ) : ℝ) from rfl, center_eq]
     rfl
   obtain ⟨s, hs₁, hs₂⟩ := hrow.exists_symmetry
-  have hε : 0 < ε := by sorry
+  have hε : 0 < ε := hrow.epsilon_pos
+  have hpbar_eq : row.interval.centerPose.toReal = pbar := by
+    show row.interval.centerPose.toReal = row.interval.toReal.center
+    have h (p : Param) : ((row.interval.center p : ℚ) : ℝ) =
+        row.interval.toReal.center.getParam p :=
+      (Interval.toReal_center_getParam row.interval p).symm
+    refine Pose.mk.injEq .. |>.mpr ⟨h .θ₁, h .θ₂, h .φ₁, h .φ₂, h .α⟩
   have := RationalApprox.LocalTheorem.rational_local
            exactPoly pythonPolyQ KappaApprox.exact_κApprox_python
            row.Pi row.Qi
@@ -48,13 +143,41 @@ theorem valid_local_imp_no_rupert (tab : Table) (row : Row)
            ?hspan2
            hrow.Bεℚ
   case hdelta =>
-    sorry
+    intro i
+    -- row.δ is Finset.max' over BoundDeltaℚi, so row.δ ≥ BoundDeltaℚi at i.
+    have hi_mem : RationalApprox.LocalTheorem.BoundDeltaℚi
+        row.interval.centerPose (pythonVertex ∘ row.Pi) (pythonVertex ∘ row.Qi)
+        RationalApprox.sqrtApprox i ∈
+        Finset.image (RationalApprox.LocalTheorem.BoundDeltaℚi
+          row.interval.centerPose (pythonVertex ∘ row.Pi) (pythonVertex ∘ row.Qi)
+          RationalApprox.sqrtApprox) Finset.univ :=
+      Finset.mem_image_of_mem _ (Finset.mem_univ i)
+    have hle := Finset.le_max' _ _ hi_mem
+    show row.δ ≥ RationalApprox.LocalTheorem.BoundDeltaℚi row.interval.centerPose
+      (KappaApprox.exact_κApprox_python.transportTri row.Pi)
+      (KappaApprox.exact_κApprox_python.transportTri row.Qi) RationalApprox.sqrtApprox i
+    rw [transportTri_python row.Pi, transportTri_python row.Qi]
+    exact hle
   case hx1 =>
-    sorry
+    refine ⟨0, by simp, ?_⟩
+    exact hrow.X₁_inner_gt
   case hx2 =>
-    sorry
+    refine ⟨row.sigma_Q.val, ?_, ?_⟩
+    · have hmem := row.sigma_Q.property
+      simp only [Finset.mem_Icc] at hmem
+      obtain ⟨_, h2⟩ := hmem
+      interval_cases row.sigma_Q.val <;> simp
+    · exact hrow.X₂_inner_gt
   case hspan1 =>
-    sorry
+    exact py_κSpanning_of_rational row.Pi row.interval.centerPose ε hε hrow.P_spanning
   case hspan2 =>
-    sorry
-  sorry
+    exact py_κSpanning_of_rational_Q row.Qi row.interval.centerPose ε hε hrow.Q_spanning
+  -- Final goal: derive False from `this : ¬ ∃ p ∈ Metric.closedBall pℚ.toReal ε, RupertPose p exactPoly.hull`
+  rw [hpbar_eq] at this
+  push Not at this
+  refine this q ?_ hqr
+  have hqi' : q ∈ iv := hqi
+  have hmem : q ∈ Metric.closedBall iv.center iv.radius :=
+    mem_closed_ball_center_of_mem iv q hqi'
+  rw [(row_epsilon_cast_eq_radius row).symm] at hmem
+  exact hmem

--- a/Noperthedron/SolutionTable/Local.lean
+++ b/Noperthedron/SolutionTable/Local.lean
@@ -103,10 +103,6 @@ theorem valid_local_imp_no_rupert (_tab : Table) (row : Row)
   let iv := row.toRealInterval
   let pbar := iv.center
   rintro ⟨q, hqi, hqr⟩
-  have center_eq : ∀ p : Param, ((row.interval.center p : ℚ) : ℝ) =
-      ((row.interval.min.getParam p : ℝ) + (row.interval.max.getParam p : ℝ)) / 2 := by
-    intro p
-    simp [Interval.center]
   obtain ⟨s, hs₁, hs₂⟩ := hrow.exists_symmetry
   have hε : 0 < ε := hrow.epsilon_pos
   have hpbar_eq : row.interval.centerPose.toReal = pbar := by

--- a/Noperthedron/SolutionTable/Local.lean
+++ b/Noperthedron/SolutionTable/Local.lean
@@ -96,7 +96,7 @@ private lemma py_κSpanning_of_rational_Q
     linarith
   exact lt_of_le_of_lt hbound hcast
 
-theorem valid_local_imp_no_rupert (tab : Table) (row : Row)
+theorem valid_local_imp_no_rupert (_tab : Table) (row : Row)
     (hrow : row.ValidLocal) :
     ¬ ∃ q ∈ row.interval.toReal, RupertPose q exactPolyhedron.hull := by
   let ε := row.epsilon
@@ -107,21 +107,6 @@ theorem valid_local_imp_no_rupert (tab : Table) (row : Row)
       ((row.interval.min.getParam p : ℝ) + (row.interval.max.getParam p : ℝ)) / 2 := by
     intro p
     simp [Interval.center]
-  have hθ₁ : (row.θ₁ : ℝ) = pbar.θ₁ := by
-    rw [show (row.θ₁ : ℝ) = ((row.interval.center .θ₁ : ℚ) : ℝ) from rfl, center_eq]
-    rfl
-  have hφ₁ : (row.φ₁ : ℝ) = pbar.φ₁ := by
-    rw [show (row.φ₁ : ℝ) = ((row.interval.center .φ₁ : ℚ) : ℝ) from rfl, center_eq]
-    rfl
-  have hθ₂ : (row.θ₂ : ℝ) = pbar.θ₂ := by
-    rw [show (row.θ₂ : ℝ) = ((row.interval.center .θ₂ : ℚ) : ℝ) from rfl, center_eq]
-    rfl
-  have hφ₂ : (row.φ₂ : ℝ) = pbar.φ₂ := by
-    rw [show (row.φ₂ : ℝ) = ((row.interval.center .φ₂ : ℚ) : ℝ) from rfl, center_eq]
-    rfl
-  have hα : (row.α : ℝ) = pbar.α := by
-    rw [show (row.α : ℝ) = ((row.interval.center .α : ℚ) : ℝ) from rfl, center_eq]
-    rfl
   obtain ⟨s, hs₁, hs₂⟩ := hrow.exists_symmetry
   have hε : 0 < ε := hrow.epsilon_pos
   have hpbar_eq : row.interval.centerPose.toReal = pbar := by

--- a/Noperthedron/SolutionTable/Local.lean
+++ b/Noperthedron/SolutionTable/Local.lean
@@ -10,10 +10,9 @@ namespace Noperthedron.Solution
 theorem valid_local_imp_no_rupert (tab : Table) (row : Row)
     (hrow : row.ValidLocal) :
     ¬ ∃ q ∈ row.interval.toReal, RupertPose q exactPolyhedron.hull := by
-  let ε := row.interval.radius
+  let ε := row.epsilon
   let iv := row.toRealInterval
   let pbar := iv.center
-  let r := iv.radius
   rintro ⟨q, hqi, hqr⟩
   have center_eq : ∀ p : Param, ((row.interval.center p : ℚ) : ℝ) =
       ((row.interval.min.getParam p : ℝ) + (row.interval.max.getParam p : ℝ)) / 2 := by
@@ -35,10 +34,27 @@ theorem valid_local_imp_no_rupert (tab : Table) (row : Row)
     rw [show (row.α : ℝ) = ((row.interval.center .α : ℚ) : ℝ) from rfl, center_eq]
     rfl
   obtain ⟨s, hs₁, hs₂⟩ := hrow.exists_symmetry
+  have hε : 0 < ε := by sorry
   have := RationalApprox.LocalTheorem.rational_local
            exactPoly pythonPolyQ KappaApprox.exact_κApprox_python
            row.Pi row.Qi
            (Noperthedron.TriangleSymmetry.congruent_of_apply s row.Pi row.Qi hs₁ hs₂)
            row.interval.centerPose hrow.center_in_fourQ
-           ε
+           ε row.δ row.r hε hrow.rpos RationalApprox.sqrtApprox hrow.r_valid
+           ?hdelta
+           ?hx1
+           ?hx2
+           ?hspan1
+           ?hspan2
+           hrow.Bεℚ
+  case hdelta =>
+    sorry
+  case hx1 =>
+    sorry
+  case hx2 =>
+    sorry
+  case hspan1 =>
+    sorry
+  case hspan2 =>
+    sorry
   sorry

--- a/blueprint/src/chapters/computational.tex
+++ b/blueprint/src/chapters/computational.tex
@@ -49,7 +49,7 @@ If a local node in the solution tree is valid, then there is no Rupert solution 
 \lean{Noperthedron.Solution.valid_local_imp_no_rupert}
 \end{theorem}
 
-\begin{proof}
+\begin{proof}\leanok
 \uses{thm:local_rational,lem:radius_noperthedron_one,lem:congruent,thm:nopertQ_approximate}
 \end{proof}
 


### PR DESCRIPTION
Redefines the hypotheses of the rational theorem to be stated in terms of rational numbers, uses them in `Row.ValidLocal`, and then uses them to prove `valid_local_imp_no_rupert`.