### PR TITLE
[ComputationalStep] replace sorry with a single parallel native_decide

### DIFF
--- a/Noperthedron.lean
+++ b/Noperthedron.lean
@@ -64,6 +64,7 @@ import Noperthedron.Rupert.Equivalences.Util
 import Noperthedron.Rupert.Set
 import Noperthedron.SolutionTable
 import Noperthedron.SolutionTable.Basic
+import Noperthedron.SolutionTable.Check
 import Noperthedron.SolutionTable.Defs
 import Noperthedron.SolutionTable.Global
 import Noperthedron.SolutionTable.Local

--- a/Noperthedron/ComputationalStep.lean
+++ b/Noperthedron/ComputationalStep.lean
@@ -1,32 +1,31 @@
 import Noperthedron.Checker.RowZero
 import Noperthedron.PoseInterval
 import Noperthedron.SolutionTable
+import Noperthedron.SolutionTable.Check
 import Noperthedron.SolutionTable.Parse
 import Noperthedron.Vertices.Exact
 
 /-!
-  Expensive computational step. We expect this to take at least 40 hours to complete.
+  Expensive computational step: `native_decide` parses the SY25 solution-tree
+  CSV and checks every row of the resulting ~18.7-million-row table. The work
+  is split into parallel tasks (see `Solution.checkSolutionCsv`), so on an
+  N-core machine it runs roughly N× faster than the sequential check; expect
+  it to take a few hours on 16 cores. Memory: the CSV is 2.5 GB and the parsed
+  table is several times that, so a machine with ≳32 GB of RAM is recommended.
 
-  `constructValidTable.lean` establishes the same result via an executable program.
+  `constructValidTable.lean` runs the same parse-and-check functions as a
+  natively compiled executable, which is faster than the `native_decide`
+  evaluation here (the interpreter executes the module's compiled IR but is
+  slower than optimized native code). It is useful as a dry run.
 -/
 
 namespace Noperthedron
 
+/-- The Steininger–Yurkevich solution tree, unzipped from
+https://github.com/Jakob256/Rupert/blob/main/data/solution_tree.zip -/
+def solution_csv : String :=
+  include_str "../../noperthedron-verification-py/data/solution_tree.csv"
+
 theorem exists_solution_table : ∃ (tab : Solution.ValidTable), True := by
-  sorry
-  -- Currently, the below seems to be much less efficient than the equivalent
-  -- logic in contructValidTable.lean. Can we improve it somehow?
-  /-
-  let solution_csv : String :=
-    -- unzipped from https://github.com/Jakob256/Rupert/blob/main/data/solution_tree.zip
-    include_str "../../noperthedron-verification-py/data/solution_tree.csv"
-  let tab := match Solution.parseSolutionTable solution_csv with
-             | .ok s => s
-             | .error _ => #[]
-  have hnonempty : 0 < tab.size := by native_decide
-  have hrowzero : tab[0].interval = Solution.rowZero.interval := by native_decide
-  have hvalid : tab.RowsValid := by native_decide
-  refine ⟨⟨tab, hvalid, hnonempty, ?_⟩, ⟨⟩⟩
-  rw [hrowzero]
-  exact Solution.rowZero_contains_tightInterval
-  -/
+  have h : Solution.checkSolutionCsv solution_csv 64 512 = true := by native_decide
+  exact Solution.checkSolutionCsv_sound h

--- a/Noperthedron/ComputationalStep.lean
+++ b/Noperthedron/ComputationalStep.lean
@@ -7,16 +7,16 @@ import Noperthedron.Vertices.Exact
 
 /-!
   Expensive computational step: `native_decide` parses the SY25 solution-tree
-  CSV and checks every row of the resulting ~18.7-million-row table. The work
-  is split into parallel tasks (see `Solution.checkSolutionCsv`), so on an
-  N-core machine it runs roughly N× faster than the sequential check; expect
-  it to take a few hours on 16 cores. Memory: the CSV is 2.5 GB and the parsed
-  table is several times that, so a machine with ≳32 GB of RAM is recommended.
+  CSV and checks every row of the resulting ~18.7-million-row table. On a 16
+  core machine, this takes about 30 hours and consumes about 55 GB of memory.
+  It would potentially go faster if we set `precompiledModules = true`.
 
-  `constructValidTable.lean` runs the same parse-and-check functions as a
-  natively compiled executable, which is faster than the `native_decide`
-  evaluation here (the interpreter executes the module's compiled IR but is
-  slower than optimized native code). It is useful as a dry run.
+  The full check is commented out so that it doesn't bog down compilation
+  as we work on the rest of the project.
+
+  To run the same check in a standalone native executable, try
+  `constructValidTable.lean`, which should take about 2.5 hours on a 16-core
+  machine.
 -/
 
 namespace Noperthedron
@@ -24,11 +24,13 @@ namespace Noperthedron
 /-- The Steininger–Yurkevich solution tree, unzipped from
 https://github.com/Jakob256/Rupert/blob/main/data/solution_tree.zip -/
 def solution_csv : String :=
-  include_str "../../noperthedron-verification-py/data/solution_tree.csv"
+  -- Uncomment the following line and point it to the file's location.
+  -- include_str "../../noperthedron-verification-py/data/solution_tree.csv"
+  sorry
 
 theorem exists_solution_table : ∃ (_ : Solution.ValidTable), True := by
   have h : Solution.checkSolutionCsv solution_csv 64 512 = true := by
-    -- Uncomment the following step to run the full check.
+    -- Uncomment the following step.
     -- native_decide
     sorry
   exact Solution.checkSolutionCsv_sound h

--- a/Noperthedron/ComputationalStep.lean
+++ b/Noperthedron/ComputationalStep.lean
@@ -26,6 +26,9 @@ https://github.com/Jakob256/Rupert/blob/main/data/solution_tree.zip -/
 def solution_csv : String :=
   include_str "../../noperthedron-verification-py/data/solution_tree.csv"
 
-theorem exists_solution_table : ∃ (tab : Solution.ValidTable), True := by
-  have h : Solution.checkSolutionCsv solution_csv 64 512 = true := by native_decide
+theorem exists_solution_table : ∃ (_ : Solution.ValidTable), True := by
+  have h : Solution.checkSolutionCsv solution_csv 64 512 = true := by
+    -- Uncomment the following step to run the full check.
+    -- native_decide
+    sorry
   exact Solution.checkSolutionCsv_sound h

--- a/Noperthedron/NoperthedronIsNotRupert.lean
+++ b/Noperthedron/NoperthedronIsNotRupert.lean
@@ -4,7 +4,7 @@ import Noperthedron.PoseInterval
 import Noperthedron.Tightening
 import Noperthedron.ConvertPose
 import Noperthedron.CommonCenter
-import Noperthedron.ComputationalStep
+import Noperthedron.SolutionTable
 import Noperthedron.Vertices.Exact
 
 open scoped Matrix

--- a/Noperthedron/ProofOfMainTheorem.lean
+++ b/Noperthedron/ProofOfMainTheorem.lean
@@ -1,3 +1,4 @@
+import Noperthedron.ComputationalStep
 import Noperthedron.MainTheorem
 import Noperthedron.NoperthedronIsNotRupert
 import Noperthedron.Vertices.InteriorNonempty

--- a/Noperthedron/SolutionTable/Basic.lean
+++ b/Noperthedron/SolutionTable/Basic.lean
@@ -182,6 +182,12 @@ theorem Table.rowsValid_of_rowsValidParB {tab : Table} {nTasks : ℕ}
     (h : tab.rowsValidParB nTasks = true) : tab.RowsValid :=
   Table.rowsValid_of_rowsValidChunkedB h
 
+/--
+info: 'Noperthedron.Solution.Table.rowsValid_of_rowsValidParB' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Table.rowsValid_of_rowsValidParB
+
 /-- The parallel checker is complete: for a positive number of tasks it agrees
 with `Table.RowsValid`. (Soundness, which is the direction the final proof
 needs, holds for any `nTasks`; see `Table.rowsValid_of_rowsValidParB`.) -/

--- a/Noperthedron/SolutionTable/Basic.lean
+++ b/Noperthedron/SolutionTable/Basic.lean
@@ -94,6 +94,116 @@ private theorem Table.rowsValidB_eq_true_iff (tab : Table) :
 instance Table.RowsValid.decidable (tab : Table) : Decidable tab.RowsValid :=
   decidable_of_iff _ tab.rowsValidB_eq_true_iff
 
+/-! ### Parallel validity checking
+
+`Table.rowsValidParB` splits the index range into chunks and checks them
+concurrently via `Task.spawn`. Since `Task.spawn fn` is *definitionally*
+`⟨fn ()⟩`, the parallelism is invisible to the logic, and correctness is proved
+exactly as for the sequential checker. This matters for
+`Noperthedron.exists_solution_table`, where `native_decide` runs this check
+over a table with ~18.7 million rows. -/
+
+private theorem task_get_spawn {α : Type} (fn : Unit → α) (prio : Task.Priority) :
+    (Task.spawn fn prio).get = fn () := rfl
+
+/-- `Row.ValidIx` at index `i` as a `Bool`, vacuously `true` past the end of the
+table (chunks are allowed to overhang the end). -/
+private def Table.validIxB (tab : Table) (i : ℕ) : Bool :=
+  if h : i < tab.size then decide (tab[i].ValidIx tab i) else true
+
+private theorem Table.validIxB_eq_true_iff (tab : Table) (i : ℕ) :
+    tab.validIxB i = true ↔ ∀ h : i < tab.size, tab[i].ValidIx tab i := by
+  unfold Table.validIxB
+  split
+  · rename_i h
+    rw [decide_eq_true_iff]
+    exact ⟨fun hv _ => hv, fun hv => hv h⟩
+  · rename_i h
+    simp only [true_iff]
+    exact fun h' => absurd h' h
+
+/-- Check validity of the rows with indices in `[start, start + cnt)`, as a flat
+`Fin.foldl` loop (see `Table.rowsValidB` for why this matters). -/
+private def Table.chunkValidB (tab : Table) (start cnt : ℕ) : Bool :=
+  Fin.foldl cnt (init := true) fun acc j => acc && tab.validIxB (start + j.val)
+
+private theorem Table.chunkValidB_eq_true_iff (tab : Table) (start cnt : ℕ) :
+    tab.chunkValidB start cnt = true ↔
+      ∀ k, start ≤ k → k < start + cnt → tab.validIxB k = true := by
+  unfold Table.chunkValidB
+  rw [Fin.foldl_and_eq_true_iff (fun j => tab.validIxB (start + j.val))]
+  constructor
+  · intro h k hk1 hk2
+    have := h ⟨k - start, by omega⟩
+    rwa [Nat.add_sub_cancel' hk1] at this
+  · intro h j
+    exact h (start + j.val) (Nat.le_add_right _ _) (by have := j.isLt; omega)
+
+/-- Check all rows of the table for validity, splitting the work into `nTasks`
+chunks of size `chunkSize` that run concurrently via `Task.spawn`. The leading
+`decide` guard ensures that the chunks cover the whole table, so that
+`Table.rowsValid_of_rowsValidChunkedB` holds for arbitrary (even nonsensical)
+values of `nTasks` and `chunkSize`. -/
+def Table.rowsValidChunkedB (tab : Table) (nTasks chunkSize : ℕ) : Bool :=
+  decide (tab.size ≤ nTasks * chunkSize) &&
+    (((List.range nTasks).map fun t =>
+        Task.spawn fun _ => tab.chunkValidB (t * chunkSize) chunkSize).all Task.get)
+
+theorem Table.rowsValid_of_rowsValidChunkedB {tab : Table} {nTasks chunkSize : ℕ}
+    (h : tab.rowsValidChunkedB nTasks chunkSize = true) : tab.RowsValid := by
+  unfold Table.rowsValidChunkedB at h
+  rw [Bool.and_eq_true, decide_eq_true_iff, List.all_eq_true] at h
+  obtain ⟨hsize, hall⟩ := h
+  intro i
+  have hc0 : 0 < chunkSize := by
+    rcases Nat.eq_zero_or_pos chunkSize with hc | hc
+    · subst hc; have := i.isLt; omega
+    · exact hc
+  have ht : (i : ℕ) / chunkSize < nTasks :=
+    (Nat.div_lt_iff_lt_mul hc0).mpr (lt_of_lt_of_le i.isLt hsize)
+  have hchunk : tab.chunkValidB ((i : ℕ) / chunkSize * chunkSize) chunkSize = true := by
+    have := hall _ (List.mem_map.mpr ⟨(i : ℕ) / chunkSize, List.mem_range.mpr ht, rfl⟩)
+    rwa [task_get_spawn] at this
+  rw [Table.chunkValidB_eq_true_iff] at hchunk
+  have hk : tab.validIxB (i : ℕ) = true := by
+    have hdm := Nat.div_add_mod (i : ℕ) chunkSize
+    have hm := Nat.mod_lt (i : ℕ) hc0
+    rw [Nat.mul_comm] at hdm
+    exact hchunk (i : ℕ) (by omega) (by omega)
+  rw [Table.validIxB_eq_true_iff] at hk
+  exact hk i.isLt
+
+/-- Parallel analogue of `Table.rowsValidB`, splitting the table into `nTasks`
+chunks of (near-)equal size. -/
+def Table.rowsValidParB (tab : Table) (nTasks : ℕ) : Bool :=
+  tab.rowsValidChunkedB nTasks (tab.size / nTasks + 1)
+
+theorem Table.rowsValid_of_rowsValidParB {tab : Table} {nTasks : ℕ}
+    (h : tab.rowsValidParB nTasks = true) : tab.RowsValid :=
+  Table.rowsValid_of_rowsValidChunkedB h
+
+/-- The parallel checker is complete: for a positive number of tasks it agrees
+with `Table.RowsValid`. (Soundness, which is the direction the final proof
+needs, holds for any `nTasks`; see `Table.rowsValid_of_rowsValidParB`.) -/
+theorem Table.rowsValidParB_eq_true_iff {tab : Table} {nTasks : ℕ} (hn : 0 < nTasks) :
+    tab.rowsValidParB nTasks = true ↔ tab.RowsValid := by
+  refine ⟨Table.rowsValid_of_rowsValidParB, fun hv => ?_⟩
+  unfold Table.rowsValidParB Table.rowsValidChunkedB
+  rw [Bool.and_eq_true, decide_eq_true_iff, List.all_eq_true]
+  constructor
+  · have hdm := Nat.div_add_mod tab.size nTasks
+    have hm := Nat.mod_lt tab.size hn
+    rw [Nat.mul_succ]
+    omega
+  · intro b hb
+    rw [List.mem_map] at hb
+    obtain ⟨t, _, rfl⟩ := hb
+    rw [task_get_spawn, Table.chunkValidB_eq_true_iff]
+    intro k _ _
+    rw [Table.validIxB_eq_true_iff]
+    intro hk
+    exact hv ⟨k, hk⟩
+
 /-- The minimum endpoint of an `Interval`, viewed as a `Pose ℝ` via `Rat.cast`. -/
 def Interval.minPose (iv : Interval) : Pose ℝ := iv.min.toReal
 

--- a/Noperthedron/SolutionTable/Check.lean
+++ b/Noperthedron/SolutionTable/Check.lean
@@ -1,0 +1,75 @@
+import Noperthedron.Checker.RowZero
+import Noperthedron.SolutionTable.Basic
+import Noperthedron.SolutionTable.Parse
+
+/-!
+# Combined solution-table check
+
+A single `Bool`-valued function, `checkSolutionCsv`, that parses the SY25
+solution-tree CSV and verifies all the conditions needed to build a
+`Solution.ValidTable`, together with its soundness theorem
+`checkSolutionCsv_sound`. Bundling everything into one function means a single
+`native_decide` invocation (one parse, one pass over the table), and both the
+parse and the row checks run in parallel via `Task.spawn`.
+
+The same functions back the `constructValidTable` executable, so a (much
+faster, natively compiled) dry run of exactly the code that `native_decide`
+will evaluate is available via `lake exe constructValidTable`.
+-/
+
+namespace Noperthedron.Solution
+
+/-- Full validity check for a parsed table: nonempty, row 0's interval is
+`rowZero.interval` (hence contains `tightInterval`), and every row is valid.
+The row checks are split into `nTasks` parallel tasks. -/
+def Table.checkFullB (tab : Table) (nTasks : ℕ) : Bool :=
+  if h : 0 < tab.size then
+    decide (tab[0].interval = rowZero.interval) && tab.rowsValidParB nTasks
+  else false
+
+theorem Table.exists_validTable_of_checkFullB {tab : Table} {nTasks : ℕ}
+    (h : tab.checkFullB nTasks = true) : ∃ _ : ValidTable, True := by
+  unfold Table.checkFullB at h
+  split at h
+  case isTrue hpos =>
+    rw [Bool.and_eq_true, decide_eq_true_iff] at h
+    obtain ⟨hz, hv⟩ := h
+    refine ⟨⟨tab, Table.rowsValid_of_rowsValidParB hv, hpos, ?_⟩, trivial⟩
+    rw [show (tab[0].interval : Set (Pose ℝ)) = (rowZero.interval : Set (Pose ℝ))
+        from by rw [hz]]
+    exact rowZero_contains_tightInterval
+  case isFalse => exact absurd h (by simp)
+
+/-- Parse the solution-tree CSV (in `parseTasks` parallel chunks) and check
+that the result is a valid table (in `checkTasks` parallel chunks). -/
+def checkSolutionCsv (csv : String) (parseTasks checkTasks : ℕ) : Bool :=
+  match parseSolutionTablePar csv parseTasks with
+  | .error _ => false
+  | .ok tab => tab.checkFullB checkTasks
+
+theorem checkSolutionCsv_sound {csv : String} {parseTasks checkTasks : ℕ}
+    (h : checkSolutionCsv csv parseTasks checkTasks = true) : ∃ _ : ValidTable, True := by
+  unfold checkSolutionCsv at h
+  split at h
+  · exact absurd h (by simp)
+  · exact Table.exists_validTable_of_checkFullB h
+
+/-! ## Smoke tests -/
+
+/-- A 1-row table consisting of a known-valid global leaf. -/
+private def testTinyTable : Table := #[{ testGlobalRow with ID := 0 }]
+
+-- The parallel checker accepts a valid table (with the 512 chunks vastly
+-- overhanging the 1-row table) and agrees with the sequential decision
+-- procedure for `Table.RowsValid`.
+/-- info: (true, true) -/
+#guard_msgs in
+#eval (testTinyTable.rowsValidParB 512, decide testTinyTable.RowsValid)
+
+-- Degenerate parameters: zero tasks must fail the coverage guard on a
+-- nonempty table, and must accept the empty table.
+/-- info: (false, true) -/
+#guard_msgs in
+#eval (testTinyTable.rowsValidParB 0, Table.rowsValidParB #[] 0)
+
+end Noperthedron.Solution

--- a/Noperthedron/SolutionTable/Parse.lean
+++ b/Noperthedron/SolutionTable/Parse.lean
@@ -145,6 +145,37 @@ def parseSolutionTable (s : String) : Except String Table := do
     result := result.push row
   return result
 
+/-- Parse a contiguous range of lines into rows. -/
+private def parseChunk (lns : Array String.Slice) (start stop : ℕ) :
+    Except String (Array Row) := Id.run do
+  let mut out : Array Row := Array.mkEmpty (stop - start)
+  for ln in lns.extract start stop do
+    match parseRowCsv ln.toString with
+    | .ok row => out := out.push row
+    | .error e => return .error e
+  return .ok out
+
+/-- Parallel version of `parseSolutionTable`: split the lines after the header
+into `nTasks` contiguous chunks, parse each chunk in its own `Task`, and
+concatenate the results in order. No correctness lemmas are needed: every
+property of the resulting table that the proofs rely on is checked downstream
+(by `Table.rowsValidParB` etc.), so the parser need not be trusted. -/
+def parseSolutionTablePar (s : String) (nTasks : ℕ) : Except String Table := Id.run do
+  let mut lns : Array String.Slice := #[]
+  for ln in s.lines do
+    lns := lns.push ln
+  let n := lns.size
+  let chunkSize := (n - 1) / nTasks + 1
+  -- index 0 is the header line, so chunk `t` covers lines [1 + t * chunkSize, 1 + (t+1) * chunkSize)
+  let tasks := (List.range nTasks).map fun t =>
+    Task.spawn fun _ => parseChunk lns (1 + t * chunkSize) (min n (1 + (t + 1) * chunkSize))
+  let mut result : Array Row := Array.mkEmpty (n - 1)
+  for tsk in tasks do
+    match tsk.get with
+    | .ok rows => result := result ++ rows
+    | .error e => return .error e
+  return .ok result
+
 def readSolutionTable (filepath : String) : IO Table := do
   let mut rows : Array Row := Array.empty
   let h ← IO.FS.Handle.mk filepath IO.FS.Mode.read

--- a/constructValidTable.lean
+++ b/constructValidTable.lean
@@ -1,4 +1,4 @@
-import Noperthedron
+import Noperthedron.SolutionTable.Check
 
 /-!
   Program that constructs a `ValidTable` value -- exactly what fits into the "hole" in
@@ -6,25 +6,33 @@ import Noperthedron
 
   Accepts as input a path to a file that contains the unzipped csv from
   https://github.com/Jakob256/Rupert/blob/main/data/solution_tree.zip
+
+  This runs the same parallel parse-and-check functions that `native_decide`
+  evaluates in Noperthedron/ComputationalStep.lean, but compiled to native
+  code, so it is considerably faster. It serves as a dry run for that step.
 -/
 
 open Noperthedron.Solution
 
-unsafe def main (args : List String) : IO Unit := do
+def main (args : List String) : IO Unit := do
   let csv_filepath ←
     match args with
     | [arg] => pure arg
     | _ => throw (IO.userError "expects exactly one argument")
 
-  let table ← readSolutionTable csv_filepath
-  IO.println s!"parsing done!"
+  let csv ← IO.FS.readFile csv_filepath
+  let table ←
+    match parseSolutionTablePar csv 64 with
+    | .ok t => pure t
+    | .error e => throw (IO.userError s!"parse error: {e}")
+  IO.println s!"parsing done! {table.size} rows"
 
   if h_nonempty : 0 < table.size then
     if h_first : table[0].interval = rowZero.interval then
-      if h_valid : table.RowsValid then
+      if h_valid_b : table.rowsValidParB 512 then
         let validTable : ValidTable := {
           table := table
-          rows_valid := h_valid
+          rows_valid := Table.rowsValid_of_rowsValidParB h_valid_b
           nonempty := h_nonempty
           contains_tightInterval := by
             rw [show (table[0].interval : Set (Pose ℝ)) = (rowZero.interval : Set (Pose ℝ))

--- a/constructValidTable.lean
+++ b/constructValidTable.lean
@@ -9,7 +9,9 @@ import Noperthedron.SolutionTable.Check
 
   This runs the same parallel parse-and-check functions that `native_decide`
   evaluates in Noperthedron/ComputationalStep.lean, but compiled to native
-  code, so it is considerably faster. It serves as a dry run for that step.
+  code, so it is considerably faster.
+
+  Running this takes about 2.5 hours on a 16-core machine.
 -/
 
 open Noperthedron.Solution


### PR DESCRIPTION
Adds functions for farming the validation work out to parallel tasks. On my 16-core machine, the `native_decide` proof finished in 27 hours. We may be able to speed that up further with `precompileModules`.

This PR also updates the `constructValidTable` executable to use the new parallel functions. Now the validation completes in 2.5 hours on my 16-core machine -- down from 40 hours with the sequential version.


