### PR TITLE
Cleanup: add PoseParam and Param-generic checker/parser dedup

### DIFF
--- a/Noperthedron.lean
+++ b/Noperthedron.lean
@@ -39,6 +39,7 @@ import Noperthedron.NoperthedronIsNotRupert
 import Noperthedron.PointSym
 import Noperthedron.Pose
 import Noperthedron.PoseClasses
+import Noperthedron.PoseParam
 import Noperthedron.PoseInterval
 import Noperthedron.ProofOfMainTheorem
 import Noperthedron.ProofOfMainTheoremWithHole

--- a/Noperthedron.lean
+++ b/Noperthedron.lean
@@ -39,8 +39,8 @@ import Noperthedron.NoperthedronIsNotRupert
 import Noperthedron.PointSym
 import Noperthedron.Pose
 import Noperthedron.PoseClasses
-import Noperthedron.PoseParam
 import Noperthedron.PoseInterval
+import Noperthedron.PoseParam
 import Noperthedron.ProofOfMainTheorem
 import Noperthedron.ProofOfMainTheoremWithHole
 import Noperthedron.RationalApprox

--- a/Noperthedron/Checker/Local.lean
+++ b/Noperthedron/Checker/Local.lean
@@ -120,30 +120,43 @@ namespace Row.δ
 
 open RationalApprox (sinℚ cosℚ)
 
+/-- The ten sin/cos values (of `θ₁ φ₁ α θ₂ φ₂`) of a rational pose, evaluated once per pose. -/
+private structure PoseTrigQ where
+  (st1 ct1 sp1 cp1 sa ca st2 ct2 sp2 cp2 : ℚ)
+
+@[inline] private def PoseTrigQ.ofPose (p : Pose ℚ) : PoseTrigQ where
+  st1 := sinℚ p.θ₁
+  ct1 := cosℚ p.θ₁
+  sp1 := sinℚ p.φ₁
+  cp1 := cosℚ p.φ₁
+  sa := sinℚ p.α
+  ca := cosℚ p.α
+  st2 := sinℚ p.θ₂
+  ct2 := cosℚ p.θ₂
+  sp2 := sinℚ p.φ₂
+  cp2 := cosℚ p.φ₂
+
 /-- `BoundDeltaℚi` for a single `i`, with the 10 trig values used by
-`M₁`, `R`, `M₂` (sin/cos of `θ₁ φ₁ α θ₂ φ₂`) passed in already evaluated. -/
-@[inline] private def boundDelta_at (st1 ct1 sp1 cp1 sa ca st2 ct2 sp2 cp2 : ℚ)
-    (P Q : Fin 3 → ℚ) : ℚ :=
+`M₁`, `R`, `M₂` passed in already evaluated. -/
+@[inline] private def boundDelta_at (t : PoseTrigQ) (P Q : Fin 3 → ℚ) : ℚ :=
   -- M₁ * P
-  let m1p_0 := -st1 * P 0 + ct1 * P 1
-  let m1p_1 := (-ct1 * cp1) * P 0 + (-st1 * cp1) * P 1 + sp1 * P 2
+  let m1p_0 := -t.st1 * P 0 + t.ct1 * P 1
+  let m1p_1 := (-t.ct1 * t.cp1) * P 0 + (-t.st1 * t.cp1) * P 1 + t.sp1 * P 2
   -- R * (M₁ * P)
-  let rm1p_0 := ca * m1p_0 + (-sa) * m1p_1
-  let rm1p_1 := sa * m1p_0 + ca * m1p_1
+  let rm1p_0 := t.ca * m1p_0 + (-t.sa) * m1p_1
+  let rm1p_1 := t.sa * m1p_0 + t.ca * m1p_1
   -- M₂ * Q
-  let m2q_0 := -st2 * Q 0 + ct2 * Q 1
-  let m2q_1 := (-ct2 * cp2) * Q 0 + (-st2 * cp2) * Q 1 + sp2 * Q 2
+  let m2q_0 := -t.st2 * Q 0 + t.ct2 * Q 1
+  let m2q_1 := (-t.ct2 * t.cp2) * Q 0 + (-t.st2 * t.cp2) * Q 1 + t.sp2 * Q 2
   let d0 := rm1p_0 - m2q_0
   let d1 := rm1p_1 - m2q_1
   let normSq := d0 * d0 + d1 * d1
   sqrtApprox.upper_sqrt.f normSq / 2 + 3 * κℚ
 
 lemma boundDelta_at_eq (p : Pose ℚ) (P Q : Fin 3 → ℚ) :
-    boundDelta_at (sinℚ p.θ₁) (cosℚ p.θ₁) (sinℚ p.φ₁) (cosℚ p.φ₁)
-                  (sinℚ p.α) (cosℚ p.α)
-                  (sinℚ p.θ₂) (cosℚ p.θ₂) (sinℚ p.φ₂) (cosℚ p.φ₂) P Q =
+    boundDelta_at (.ofPose p) P Q =
     sqrtApprox.upper_sqrt.norm (p.rotRℚ (p.rotM₁ℚ P) - p.rotM₂ℚ Q) / 2 + 3 * κℚ := by
-  unfold boundDelta_at RationalApprox.UpperSqrt.norm
+  unfold boundDelta_at PoseTrigQ.ofPose RationalApprox.UpperSqrt.norm
   unfold Pose.rotRℚ Pose.rotM₁ℚ Pose.rotM₂ℚ
   unfold RationalApprox.rotRℚ RationalApprox.rotMℚ
   unfold RationalApprox.rotRℚ_mat RationalApprox.rotMℚ_mat
@@ -163,20 +176,9 @@ Equivalent to `Finset.max' (Finset.image BoundDeltaℚi univ) _` (see
 `Row.δ_eq_max'_BoundDeltaℚi`), but the trig partial sums are hoisted once
 per pose for a ~6× runtime speedup. -/
 def Row.δ (row : Row) : ℚ :=
-  let p := row.interval.centerPose
-  let st1 := RationalApprox.sinℚ p.θ₁
-  let ct1 := RationalApprox.cosℚ p.θ₁
-  let sp1 := RationalApprox.sinℚ p.φ₁
-  let cp1 := RationalApprox.cosℚ p.φ₁
-  let sa  := RationalApprox.sinℚ p.α
-  let ca  := RationalApprox.cosℚ p.α
-  let st2 := RationalApprox.sinℚ p.θ₂
-  let ct2 := RationalApprox.cosℚ p.θ₂
-  let sp2 := RationalApprox.sinℚ p.φ₂
-  let cp2 := RationalApprox.cosℚ p.φ₂
+  let t := Row.δ.PoseTrigQ.ofPose row.interval.centerPose
   let f : Fin 3 → ℚ := fun i =>
-    Row.δ.boundDelta_at st1 ct1 sp1 cp1 sa ca st2 ct2 sp2 cp2
-      (pythonVertex (row.Pi i)) (pythonVertex (row.Qi i))
+    Row.δ.boundDelta_at t (pythonVertex (row.Pi i)) (pythonVertex (row.Qi i))
   Finset.max' (Finset.image f Finset.univ)
     (Finset.image_nonempty.mpr ⟨0, Finset.mem_univ 0⟩)
 
@@ -186,17 +188,7 @@ theorem Row.δ_eq_max'_BoundDeltaℚi (row : Row) :
         (pythonVertex ∘ row.Pi) (pythonVertex ∘ row.Qi) sqrtApprox) Finset.univ)
       (Finset.image_nonempty.mpr ⟨0, Finset.mem_univ 0⟩) := by
   show (Finset.image
-        (fun i => Row.δ.boundDelta_at
-          (RationalApprox.sinℚ row.interval.centerPose.θ₁)
-          (RationalApprox.cosℚ row.interval.centerPose.θ₁)
-          (RationalApprox.sinℚ row.interval.centerPose.φ₁)
-          (RationalApprox.cosℚ row.interval.centerPose.φ₁)
-          (RationalApprox.sinℚ row.interval.centerPose.α)
-          (RationalApprox.cosℚ row.interval.centerPose.α)
-          (RationalApprox.sinℚ row.interval.centerPose.θ₂)
-          (RationalApprox.cosℚ row.interval.centerPose.θ₂)
-          (RationalApprox.sinℚ row.interval.centerPose.φ₂)
-          (RationalApprox.cosℚ row.interval.centerPose.φ₂)
+        (fun i => Row.δ.boundDelta_at (Row.δ.PoseTrigQ.ofPose row.interval.centerPose)
           (pythonVertex (row.Pi i)) (pythonVertex (row.Qi i))) Finset.univ).max' _ =
       (Finset.image
         (RationalApprox.LocalTheorem.BoundDeltaℚi row.interval.centerPose

--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -25,18 +25,6 @@ private lemma f_le_max {n : ℕ} {V : Finset (E n)} (Vne : V.Nonempty) (w : E n 
   grw [fx_le_fvmax ⟨x, hx⟩]
   exact hw1 x hx
 
-private lemma extract_constant {n : ℕ} {V : Finset (E n)} (w : E n → ℝ)
-    (S : E n) (hs : S ∈ convexHull ℝ V) (f : E n →ₗ[ℝ] ℝ) :
-    ∑ x ∈ V, ↑(w x) * (Finset.image (⇑f) V).max = ↑(∑ x ∈ V, w x) * (Finset.image (⇑f) V).max := by
-  let ⟨S', hS'⟩ := convexHull_nonempty_iff.mp ⟨S, hs⟩
-  let ⟨m, hm⟩ := Finset.max_of_mem (Finset.mem_image_of_mem f hS')
-  rw [hm]
-  suffices h : (WithBot.some (∑ x ∈ V, (w x) * m)) = WithBot.some ((∑ x ∈ V, w x) * m) by
-    push_cast at h ⊢
-    exact h
-  refine congrArg WithBot.some ?_
-  rw [← Finset.sum_mul]
-
 theorem finset_hull_linear_max {n : ℕ} {V : Finset (E n)} (Vne : V.Nonempty)
     (S : E n) (hs : S ∈ convexHull ℝ V) (f : E n →ₗ[ℝ] ℝ) :
     f S ≤ (V.image f).max' (Finset.image_nonempty.mpr Vne) := by

--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -341,7 +341,7 @@ lemma partials_helper3 {pbar : Pose ℝ} {εα εθ₁ εφ₁ εθ₂ εφ₂ :
   by_cases hP : ‖P‖ = 0
   · simp [norm_eq_zero.mp hP, Pose.rotM₂θ, ContinuousLinearMap.map_zero]
   · simp only [GlobalTheoremPrecondition.fu_outer]
-    rw [show rotproj_outer_unit P pc.w = fun x => rotproj_outer P pc.w x / ‖P‖ from rfl]
+    rw [funext (rotproj_outer_unit_eq P pc.w)]
     rw [nth_partial_div_const 0 (rotproj_outer P pc.w) ‖P‖ pbar.outerParams
       ((Differentiable.inner ℝ (Differentiable.rotM_outer P) (differentiable_const pc.w)).differentiableAt)]
     rw [nth_partial_rotproj_outer_0]
@@ -355,7 +355,7 @@ lemma partials_helper4 {pbar : Pose ℝ} {εα εθ₁ εφ₁ εθ₂ εφ₂ :
   by_cases hP : ‖P‖ = 0
   · simp [norm_eq_zero.mp hP, Pose.rotM₂φ, ContinuousLinearMap.map_zero]
   · simp only [GlobalTheoremPrecondition.fu_outer]
-    rw [show rotproj_outer_unit P pc.w = fun x => rotproj_outer P pc.w x / ‖P‖ from rfl]
+    rw [funext (rotproj_outer_unit_eq P pc.w)]
     rw [nth_partial_div_const 1 (rotproj_outer P pc.w) ‖P‖ pbar.outerParams
       ((Differentiable.inner ℝ (Differentiable.rotM_outer P) (differentiable_const pc.w)).differentiableAt)]
     rw [nth_partial_rotproj_outer_1]

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -147,59 +147,40 @@ lemma fderiv_rotR'_rotM_in_e2 (S : Euc(3)) (y : E 3) (α θ φ : ℝ)
     ((ContinuousLinearMap.hasFDerivAt (rotR' α)).comp_hasDerivAt _ (hasDerivAt_rotM_φ θ φ S))
 
 /-!
-## fderiv of rotproj_inner in coordinate directions
-
-These combine `fderiv_inner_const` with `fderiv_rotR_rotM_in_e*` to give
-formulas for partial derivatives of rotproj_inner directly.
--/
-
-/-- fderiv of rotproj_inner in direction e₀ -/
-lemma fderiv_rotproj_inner_in_e0 (S : ℝ³) (w : ℝ²) (y : E 3)
-    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
-    (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) =
-    ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-  have heq : rotproj_inner S w = fun z => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ := by
-    ext z; simp [rotproj_inner, rotprojRM]
-  rw [heq, fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e0 S y hf_diff]
-
-/-- fderiv of rotproj_inner in direction e₁ -/
-lemma fderiv_rotproj_inner_in_e1 (S : ℝ³) (w : ℝ²) (y : E 3)
-    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
-    (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) =
-    ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-  have heq : rotproj_inner S w = fun z => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ := by
-    ext z; simp [rotproj_inner, rotprojRM]
-  rw [heq, fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e1 S y hf_diff]
-
-/-- fderiv of rotproj_inner in direction e₂ -/
-lemma fderiv_rotproj_inner_in_e2 (S : ℝ³) (w : ℝ²) (y : E 3)
-    (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y) :
-    (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) =
-    ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
-  have heq : rotproj_inner S w = fun z => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ := by
-    ext z; simp [rotproj_inner, rotprojRM]
-  rw [heq, fderiv_inner_const _ w y _ hf_diff, fderiv_rotR_rotM_in_e2 S y hf_diff]
-
-/-!
 ## nth_partial of rotproj_inner in coordinate directions
 
-These lift the pointwise `fderiv_rotproj_inner_in_e*` to function-level equalities
-of `nth_partial`, eliminating the `funext`/`congrArg` boilerplate at each use site.
+These combine `fderiv_inner_const` with `fderiv_rotR_rotM_in_e*` to give
+function-level formulas for the partial derivatives of `rotproj_inner`,
+eliminating the `funext`/`congrArg` boilerplate at each use site.
 -/
+
+/-- Function-level form of `rotproj_inner_eq`. -/
+private lemma rotproj_inner_funext (S : ℝ³) (w : ℝ²) :
+    rotproj_inner S w = fun z : E 3 => ⟪rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S), w⟫ :=
+  funext fun z => rotproj_inner_eq S w z
 
 lemma nth_partial_rotproj_inner_e0 (S : ℝ³) (w : ℝ²) :
     nth_partial 0 (rotproj_inner S w) =
-      fun (y : ℝ³) => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ :=
-  funext fun y => fderiv_rotproj_inner_in_e0 S w y (differentiableAt_rotR_rotM S y)
+      fun (y : ℝ³) => ⟪rotR' (y.ofLp 0) (rotM (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+  funext y
+  have hd := differentiableAt_rotR_rotM S y
+  show (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 0 1) = _
+  rw [rotproj_inner_funext, fderiv_inner_const _ w y _ hd, fderiv_rotR_rotM_in_e0 S y hd]
 
 lemma nth_partial_rotproj_inner_e1 (S : ℝ³) (w : ℝ²) :
     nth_partial 1 (rotproj_inner S w) =
-      fun (y : ℝ³) => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ :=
-  funext fun y => fderiv_rotproj_inner_in_e1 S w y (differentiableAt_rotR_rotM S y)
+      fun (y : ℝ³) => ⟪rotR (y.ofLp 0) (rotMθ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+  funext y
+  have hd := differentiableAt_rotR_rotM S y
+  show (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 1 1) = _
+  rw [rotproj_inner_funext, fderiv_inner_const _ w y _ hd, fderiv_rotR_rotM_in_e1 S y hd]
 
 lemma nth_partial_rotproj_inner_e2 (S : ℝ³) (w : ℝ²) :
     nth_partial 2 (rotproj_inner S w) =
-      fun (y : ℝ³) => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ :=
-  funext fun y => fderiv_rotproj_inner_in_e2 S w y (differentiableAt_rotR_rotM S y)
+      fun (y : ℝ³) => ⟪rotR (y.ofLp 0) (rotMφ (y.ofLp 1) (y.ofLp 2) S), w⟫ := by
+  funext y
+  have hd := differentiableAt_rotR_rotM S y
+  show (fderiv ℝ (rotproj_inner S w) y) (EuclideanSpace.single 2 1) = _
+  rw [rotproj_inner_funext, fderiv_inner_const _ w y _ hd, fderiv_rotR_rotM_in_e2 S y hd]
 
 end GlobalTheorem

--- a/Noperthedron/Local.lean
+++ b/Noperthedron/Local.lean
@@ -207,11 +207,11 @@ theorem local_theorem {ι : Type} [Fintype ι] [Nonempty ι]
   have hδnn : 0 ≤ δ := le_trans (by positivity) (hδ 0)
   have hY : ‖Y‖ = 1 := by simp [Y, Bounding.vecX_norm_one]
   have hZ : ‖Z‖ = 1 := by simp [Z, K, norm_smul, Bounding.vecX_norm_one]
-  have hα : |p.α - p_.α| ≤ ε := mem_closed_ball_abs_sub_α hΨ₁
-  have hθ₁ : |p.θ₁ - p_.θ₁| ≤ ε := mem_closed_ball_abs_sub_θ₁ hΨ₁
-  have hφ₁ : |p.φ₁ - p_.φ₁| ≤ ε := mem_closed_ball_abs_sub_φ₁ hΨ₁
-  have hθ₂ : |p.θ₂ - p_.θ₂| ≤ ε := mem_closed_ball_abs_sub_θ₂ hΨ₁
-  have hφ₂ : |p.φ₂ - p_.φ₂| ≤ ε := mem_closed_ball_abs_sub_φ₂ hΨ₁
+  have hα : |p.α - p_.α| ≤ ε := mem_closedBall_abs_sub_getParam hΨ₁ .α
+  have hθ₁ : |p.θ₁ - p_.θ₁| ≤ ε := mem_closedBall_abs_sub_getParam hΨ₁ .θ₁
+  have hφ₁ : |p.φ₁ - p_.φ₁| ≤ ε := mem_closedBall_abs_sub_getParam hΨ₁ .φ₁
+  have hθ₂ : |p.θ₂ - p_.θ₂| ≤ ε := mem_closedBall_abs_sub_getParam hΨ₁ .θ₂
+  have hφ₂ : |p.φ₂ - p_.φ₂| ≤ ε := mem_closedBall_abs_sub_getParam hΨ₁ .φ₂
   let P_ : Triangle := fun i ↦ (-1: ℝ) ^ σP • (P i)
   let Q_ : Triangle := fun i ↦ (-1: ℝ) ^ σQ • (Q i)
   have hP_ (i) : ‖P_ i‖ ≤ 1 := by

--- a/Noperthedron/PoseInterval.lean
+++ b/Noperthedron/PoseInterval.lean
@@ -3,6 +3,7 @@ import Noperthedron.Rupert.Basic
 import Noperthedron.PoseClasses
 import Noperthedron.Basic
 import Noperthedron.Pose
+import Noperthedron.PoseParam
 
 open scoped Matrix
 open scoped Real
@@ -76,6 +77,11 @@ def Pose.toReal (p : Pose ℚ) : Pose ℝ where
 @[simp] lemma Pose.toReal_φ₂ (p : Pose ℚ) : p.toReal.φ₂ = (p.φ₂ : ℝ) := rfl
 @[simp] lemma Pose.toReal_α (p : Pose ℚ) : p.toReal.α = (p.α : ℝ) := rfl
 
+/-- `Pose.toReal` commutes with `getParam`. -/
+lemma Pose.toReal_getParam (p : Pose ℚ) (a : Noperthedron.Solution.Param) :
+    p.toReal.getParam a = (p.getParam a : ℝ) := by
+  cases a <;> rfl
+
 instance {α : Type*} [Preorder α] [DecidableLE α] (p : α) (iv : NonemptyInterval α) :
     Decidable (p ∈ iv) :=
   decidable_of_iff _ NonemptyInterval.mem_def.symm
@@ -97,16 +103,22 @@ lemma contains_iff_components {R} [PartialOrder R] {iv : PoseInterval R} {p : Po
   simp only [contains, NonemptyInterval.mem_def, Set.mem_Icc, Pose.le_iff]
   grind
 
+theorem contains.getParamBound {R} [PartialOrder R] {iv : PoseInterval R} {p : Pose R}
+    (c : contains iv p) (a : Noperthedron.Solution.Param) :
+    p.getParam a ∈ Set.Icc (iv.min.getParam a) (iv.max.getParam a) := by
+  obtain ⟨h1, h2, h3, h4, h5⟩ := contains_iff_components.mp c
+  cases a <;> assumption
+
 theorem contains.θ₁Bound {R} [PartialOrder R] {iv : PoseInterval R} {p : Pose R} (c : contains iv p) :
-    p.θ₁ ∈ Set.Icc iv.min.θ₁ iv.max.θ₁ := (contains_iff_components.mp c).1
+    p.θ₁ ∈ Set.Icc iv.min.θ₁ iv.max.θ₁ := c.getParamBound .θ₁
 theorem contains.θ₂Bound {R} [PartialOrder R] {iv : PoseInterval R} {p : Pose R} (c : contains iv p) :
-    p.θ₂ ∈ Set.Icc iv.min.θ₂ iv.max.θ₂ := (contains_iff_components.mp c).2.1
+    p.θ₂ ∈ Set.Icc iv.min.θ₂ iv.max.θ₂ := c.getParamBound .θ₂
 theorem contains.φ₁Bound {R} [PartialOrder R] {iv : PoseInterval R} {p : Pose R} (c : contains iv p) :
-    p.φ₁ ∈ Set.Icc iv.min.φ₁ iv.max.φ₁ := (contains_iff_components.mp c).2.2.1
+    p.φ₁ ∈ Set.Icc iv.min.φ₁ iv.max.φ₁ := c.getParamBound .φ₁
 theorem contains.φ₂Bound {R} [PartialOrder R] {iv : PoseInterval R} {p : Pose R} (c : contains iv p) :
-    p.φ₂ ∈ Set.Icc iv.min.φ₂ iv.max.φ₂ := (contains_iff_components.mp c).2.2.2.1
+    p.φ₂ ∈ Set.Icc iv.min.φ₂ iv.max.φ₂ := c.getParamBound .φ₂
 theorem contains.αBound {R} [PartialOrder R] {iv : PoseInterval R} {p : Pose R} (c : contains iv p) :
-    p.α ∈ Set.Icc iv.min.α iv.max.α := (contains_iff_components.mp c).2.2.2.2
+    p.α ∈ Set.Icc iv.min.α iv.max.α := c.getParamBound .α
 
 noncomputable def center {R} [Field R] [PartialOrder R] (iv : PoseInterval R) : Pose R where
   θ₁ := (iv.min.θ₁ + iv.max.θ₁) / 2
@@ -162,25 +174,12 @@ theorem mem_closed_ball_center_of_mem (iv : PoseInterval ℝ) (p : Pose ℝ) (hp
   refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;>
     (simp only [PoseInterval.center, Real.dist_eq, abs_sub_le_iff]; constructor <;> linarith)
 
-lemma mem_closed_ball_abs_sub_α {p q : Pose ℝ} {ε : ℝ}
-    (hq : p ∈ Metric.closedBall q ε) : |p.α - q.α| ≤ ε :=
-  ((Pose.mem_closedBall_iff.mp hq).2.2.2.2)
-
-lemma mem_closed_ball_abs_sub_θ₁ {p q : Pose ℝ} {ε : ℝ}
-    (hq : p ∈ Metric.closedBall q ε) : |p.θ₁ - q.θ₁| ≤ ε :=
-  (Pose.mem_closedBall_iff.mp hq).1
-
-lemma mem_closed_ball_abs_sub_φ₁ {p q : Pose ℝ} {ε : ℝ}
-    (hq : p ∈ Metric.closedBall q ε) : |p.φ₁ - q.φ₁| ≤ ε :=
-  (Pose.mem_closedBall_iff.mp hq).2.2.1
-
-lemma mem_closed_ball_abs_sub_θ₂ {p q : Pose ℝ} {ε : ℝ}
-    (hq : p ∈ Metric.closedBall q ε) : |p.θ₂ - q.θ₂| ≤ ε :=
-  (Pose.mem_closedBall_iff.mp hq).2.1
-
-lemma mem_closed_ball_abs_sub_φ₂ {p q : Pose ℝ} {ε : ℝ}
-    (hq : p ∈ Metric.closedBall q ε) : |p.φ₂ - q.φ₂| ≤ ε :=
-  (Pose.mem_closedBall_iff.mp hq).2.2.2.1
+/-- Each parameter of a pose in a closed ball is within `ε` of the center's. -/
+lemma mem_closedBall_abs_sub_getParam {p q : Pose ℝ} {ε : ℝ}
+    (hq : p ∈ Metric.closedBall q ε) (a : Noperthedron.Solution.Param) :
+    |p.getParam a - q.getParam a| ≤ ε := by
+  rw [← Real.dist_eq]
+  exact Pose.mem_closedBall_iff_forall_getParam.mp hq a
 
 /--
 `p` lies in the closed box of per-axis radii `εθ₁ εφ₁ εθ₂ εφ₂ εα` around `pbar`.

--- a/Noperthedron/PoseParam.lean
+++ b/Noperthedron/PoseParam.lean
@@ -1,0 +1,76 @@
+import Mathlib.Tactic.DeriveFintype
+import Noperthedron.Pose
+
+/-!
+# `Param`: names for the five pose parameters
+
+`Param` lives in this small low-level module (rather than with the rest of the
+solution-table definitions in `SolutionTable/Defs.lean`) so that `Pose` and
+`PoseInterval` lemmas can be stated generically over the parameter being
+accessed, without dependency cycles.
+-/
+
+namespace Noperthedron.Solution
+
+inductive Param where | θ₁ | φ₁ | θ₂ | φ₂ | α
+deriving BEq, ReflBEq, LawfulBEq, Repr, Fintype, DecidableEq, Nonempty
+
+/-- The canonical split order of the five pose parameters, matching the CSV
+`split` codes 1–5 and the full-split `cubeFold` order. -/
+def Param.splitOrder : List Param := [.θ₁, .φ₁, .θ₂, .φ₂, .α]
+
+/-- Decode a CSV `split` column code (1–5) into the parameter being split. -/
+def Param.ofSplitCode? : ℕ → Option Param
+  | 0 => none
+  | n + 1 => Param.splitOrder[n]?
+
+#guard Param.ofSplitCode? 0 = none
+#guard Param.ofSplitCode? 1 = some .θ₁
+#guard Param.ofSplitCode? 5 = some .α
+#guard Param.ofSplitCode? 6 = none
+
+end Noperthedron.Solution
+
+/-! ## `Param`-indexed access on `Pose` -/
+
+namespace Pose
+variable {R : Type}
+
+/-- Read the component of a `Pose` selected by a `Solution.Param`. -/
+def getParam (p : Pose R) : Noperthedron.Solution.Param → R
+  | .θ₁ => p.θ₁
+  | .θ₂ => p.θ₂
+  | .φ₁ => p.φ₁
+  | .φ₂ => p.φ₂
+  | .α  => p.α
+
+/-- Replace the component of a `Pose` selected by a `Solution.Param`. -/
+def setParam (p : Pose R) : Noperthedron.Solution.Param → R → Pose R
+  | .θ₁, x => { p with θ₁ := x }
+  | .θ₂, x => { p with θ₂ := x }
+  | .φ₁, x => { p with φ₁ := x }
+  | .φ₂, x => { p with φ₂ := x }
+  | .α,  x => { p with α  := x }
+
+@[simp] lemma getParam_setParam_self (p : Pose R) (a : Noperthedron.Solution.Param) (x : R) :
+    (p.setParam a x).getParam a = x := by cases a <;> rfl
+
+@[simp] lemma getParam_setParam_of_ne (p : Pose R) {a b : Noperthedron.Solution.Param}
+    (h : b ≠ a) (x : R) :
+    (p.setParam a x).getParam b = p.getParam b := by
+  cases a <;> cases b <;> first | rfl | (exact absurd rfl h)
+
+lemma le_iff_forall_getParam [PartialOrder R] (p q : Pose R) :
+    p ≤ q ↔ ∀ a : Noperthedron.Solution.Param, p.getParam a ≤ q.getParam a := by
+  rw [le_iff]
+  refine ⟨fun ⟨h1, h2, h3, h4, h5⟩ a => by cases a <;> assumption,
+          fun h => ⟨h .θ₁, h .θ₂, h .φ₁, h .φ₂, h .α⟩⟩
+
+lemma mem_closedBall_iff_forall_getParam [MetricSpace R] {p q : Pose R} {ε : ℝ} :
+    p ∈ Metric.closedBall q ε ↔
+      ∀ a : Noperthedron.Solution.Param, dist (p.getParam a) (q.getParam a) ≤ ε := by
+  rw [mem_closedBall_iff]
+  refine ⟨fun ⟨h1, h2, h3, h4, h5⟩ a => by cases a <;> assumption,
+          fun h => ⟨h .θ₁, h .θ₂, h .φ₁, h .φ₂, h .α⟩⟩
+
+end Pose

--- a/Noperthedron/PoseParam.lean
+++ b/Noperthedron/PoseParam.lean
@@ -26,6 +26,9 @@ def Param.ofSplitCode? : ℕ → Option Param
 
 #guard Param.ofSplitCode? 0 = none
 #guard Param.ofSplitCode? 1 = some .θ₁
+#guard Param.ofSplitCode? 2 = some .φ₁
+#guard Param.ofSplitCode? 3 = some .θ₂
+#guard Param.ofSplitCode? 4 = some .φ₂
 #guard Param.ofSplitCode? 5 = some .α
 #guard Param.ofSplitCode? 6 = none
 

--- a/Noperthedron/SolutionTable.lean
+++ b/Noperthedron/SolutionTable.lean
@@ -134,16 +134,15 @@ termination_by (tab.size - row.ID, 2, 0)
 theorem valid_single_param_split_imp_no_rupert (tab : Table) (row : Row) (htab : tab.RowsValid)
     (hr : Row.ValidSingleParamSplit tab row) :
     ¬ ∃ q ∈ row.interval.toReal, RupertPose q exactPolyhedron.hull := by
-  rcases hr with ⟨_, h⟩ | ⟨_, h⟩ | ⟨_, h⟩ | ⟨_, h⟩ | ⟨_, h⟩ <;>
-  · exact valid_param_split_imp_no_rupert tab row htab _ h
+  obtain ⟨p, -, h⟩ := hr
+  exact valid_param_split_imp_no_rupert tab row htab p h
 termination_by (tab.size - row.ID, 1, 0)
 
 theorem valid_full_split_imp_no_rupert (tab : Table) (row : Row) (htab : tab.RowsValid)
     (_hgt : row.ID < row.IDfirstChild)
     (_hlt : row.ID < tab.size)
     (hi : tab.HasIntervals row.IDfirstChild
-      (cubeFold [Interval.lower_half, Interval.upper_half]
-       row.interval [Param.θ₁, Param.φ₁, Param.θ₂, Param.φ₂, Param.α])) :
+      (cubeFold [Interval.lower_half, Interval.upper_half] row.interval Param.splitOrder)) :
     ¬ ∃ q ∈ row.interval.toReal, RupertPose q exactPolyhedron.hull := by
   exact has_intervals_imp_no_rupert tab htab row.IDfirstChild row.interval _ hi
 termination_by (tab.size - row.ID, 1, 0)

--- a/Noperthedron/SolutionTable.lean
+++ b/Noperthedron/SolutionTable.lean
@@ -5,11 +5,6 @@ import Noperthedron.Vertices.Exact
 
 namespace Noperthedron.Solution
 
-/-- `Pose.toReal` commutes with `getParam`. -/
-lemma _root_.Pose.toReal_getParam (p : Pose ℚ) (a : Param) :
-    p.toReal.getParam a = (p.getParam a : ℝ) := by
-  cases a <;> rfl
-
 /-- Membership in the realification of a rational `Interval`, read off one parameter
 at a time. This is the single entry point for interval-membership reasoning below. -/
 lemma mem_toReal_iff {q : Pose ℝ} {iv : Interval} :

--- a/Noperthedron/SolutionTable/Basic.lean
+++ b/Noperthedron/SolutionTable/Basic.lean
@@ -16,13 +16,17 @@ structure Row.ValidSplitParam (tab : Table) (row : Row) (param : Param) : Prop w
 instance (tab : Table) (row : Row) (param : Param) : Decidable (Row.ValidSplitParam tab row param) :=
   decidable_of_iff _ (Row.validSplitParam_iff tab row param).symm
 
+/-- The row's `split` code selects a single parameter (via `Param.ofSplitCode?`),
+and the row is a valid split of its interval along that parameter. -/
 def Row.ValidSingleParamSplit (tab : Table) (row : Row) : Prop :=
-    ((row.split = 1 ∧ row.ValidSplitParam tab .θ₁) ∨
-     (row.split = 2 ∧ row.ValidSplitParam tab .φ₁) ∨
-     (row.split = 3 ∧ row.ValidSplitParam tab .θ₂) ∨
-     (row.split = 4 ∧ row.ValidSplitParam tab .φ₂) ∨
-     (row.split = 5 ∧ row.ValidSplitParam tab .α))
-deriving Decidable
+  ∃ p, Param.ofSplitCode? row.split = some p ∧ row.ValidSplitParam tab p
+
+instance (tab : Table) (row : Row) : Decidable (row.ValidSingleParamSplit tab) := by
+  unfold Row.ValidSingleParamSplit
+  generalize Param.ofSplitCode? row.split = code
+  cases code with
+  | none => exact .isFalse (by simp)
+  | some p => exact decidable_of_iff (row.ValidSplitParam tab p) (by simp)
 
 def Table.HasIntervals (tab : Table) (start : ℕ) (intervals : List Interval) : Prop :=
   ∀ i : Fin intervals.length,
@@ -31,7 +35,8 @@ deriving Decidable
 
 def Row.ValidFullSplit (tab : Table) (row : Row) : Prop :=
   row.nrChildren = 32 ∧ row.split = 6 ∧ row.IDfirstChild > row.ID ∧
-  tab.HasIntervals row.IDfirstChild (cubeFold [Interval.lower_half, Interval.upper_half] row.interval [.θ₁, .φ₁, .θ₂, .φ₂, .α])
+  tab.HasIntervals row.IDfirstChild
+    (cubeFold [Interval.lower_half, Interval.upper_half] row.interval Param.splitOrder)
 deriving Decidable
 
 def Row.ValidSplit (tab : Table) (row : Row) : Prop :=

--- a/Noperthedron/SolutionTable/Check.lean
+++ b/Noperthedron/SolutionTable/Check.lean
@@ -27,17 +27,26 @@ def Table.checkFullB (tab : Table) (nTasks : ℕ) : Bool :=
     decide (tab[0].interval = rowZero.interval) && tab.rowsValidParB nTasks
   else false
 
+/-- Assemble a `ValidTable` from the three facts that `Table.checkFullB` checks:
+nonemptiness, row 0 carrying `rowZero.interval`, and the parallel row-validity check. -/
+def Table.validTableOfChecks {tab : Table} {nTasks : ℕ} (h_nonempty : 0 < tab.size)
+    (h_first : tab[0].interval = rowZero.interval)
+    (h_valid : tab.rowsValidParB nTasks = true) : ValidTable where
+  table := tab
+  rows_valid := Table.rowsValid_of_rowsValidParB h_valid
+  nonempty := h_nonempty
+  contains_tightInterval := by
+    rw [show (tab[0].interval : Set (Pose ℝ)) = (rowZero.interval : Set (Pose ℝ))
+        from by rw [h_first]]
+    exact rowZero_contains_tightInterval
+
 theorem Table.exists_validTable_of_checkFullB {tab : Table} {nTasks : ℕ}
     (h : tab.checkFullB nTasks = true) : ∃ _ : ValidTable, True := by
   unfold Table.checkFullB at h
   split at h
   case isTrue hpos =>
     rw [Bool.and_eq_true, decide_eq_true_iff] at h
-    obtain ⟨hz, hv⟩ := h
-    refine ⟨⟨tab, Table.rowsValid_of_rowsValidParB hv, hpos, ?_⟩, trivial⟩
-    rw [show (tab[0].interval : Set (Pose ℝ)) = (rowZero.interval : Set (Pose ℝ))
-        from by rw [hz]]
-    exact rowZero_contains_tightInterval
+    exact ⟨Table.validTableOfChecks hpos h.1 h.2, trivial⟩
   case isFalse => exact absurd h (by simp)
 
 /-- Parse the solution-tree CSV (in `parseTasks` parallel chunks) and check

--- a/Noperthedron/SolutionTable/Defs.lean
+++ b/Noperthedron/SolutionTable/Defs.lean
@@ -1,8 +1,6 @@
 import Mathlib.Data.Finset.Max
 import Mathlib.Data.Real.Basic
 import Mathlib.Order.Interval.Finset.Nat
-import Mathlib.Tactic.DeriveFintype
-
 import Noperthedron.PoseInterval
 import Noperthedron.Vertices.Index
 import Noperthedron.Vertices.Python
@@ -13,63 +11,6 @@ namespace Noperthedron.Solution
 
 def DENOMQ : ℚ := 15360000
 
-inductive Param where | θ₁ | φ₁ | θ₂ | φ₂ | α
-deriving BEq, ReflBEq, LawfulBEq, Repr, Fintype, DecidableEq, Nonempty
-
-/-- The canonical split order of the five pose parameters, matching the CSV
-`split` codes 1–5 and the full-split `cubeFold` order. -/
-def Param.splitOrder : List Param := [.θ₁, .φ₁, .θ₂, .φ₂, .α]
-
-/-- Decode a CSV `split` column code (1–5) into the parameter being split. -/
-def Param.ofSplitCode? : ℕ → Option Param
-  | 0 => none
-  | n + 1 => Param.splitOrder[n]?
-
-#guard Param.ofSplitCode? 0 = none
-#guard Param.ofSplitCode? 1 = some .θ₁
-#guard Param.ofSplitCode? 5 = some .α
-#guard Param.ofSplitCode? 6 = none
-
-end Noperthedron.Solution
-
-/-! ## `Param`-indexed access on `Pose` -/
-
-namespace Pose
-variable {R : Type}
-
-/-- Read the component of a `Pose` selected by a `Solution.Param`. -/
-def getParam (p : Pose R) : Noperthedron.Solution.Param → R
-  | .θ₁ => p.θ₁
-  | .θ₂ => p.θ₂
-  | .φ₁ => p.φ₁
-  | .φ₂ => p.φ₂
-  | .α  => p.α
-
-/-- Replace the component of a `Pose` selected by a `Solution.Param`. -/
-def setParam (p : Pose R) : Noperthedron.Solution.Param → R → Pose R
-  | .θ₁, x => { p with θ₁ := x }
-  | .θ₂, x => { p with θ₂ := x }
-  | .φ₁, x => { p with φ₁ := x }
-  | .φ₂, x => { p with φ₂ := x }
-  | .α,  x => { p with α  := x }
-
-@[simp] lemma getParam_setParam_self (p : Pose R) (a : Noperthedron.Solution.Param) (x : R) :
-    (p.setParam a x).getParam a = x := by cases a <;> rfl
-
-@[simp] lemma getParam_setParam_of_ne (p : Pose R) {a b : Noperthedron.Solution.Param}
-    (h : b ≠ a) (x : R) :
-    (p.setParam a x).getParam b = p.getParam b := by
-  cases a <;> cases b <;> first | rfl | (exact absurd rfl h)
-
-lemma le_iff_forall_getParam [PartialOrder R] (p q : Pose R) :
-    p ≤ q ↔ ∀ a : Noperthedron.Solution.Param, p.getParam a ≤ q.getParam a := by
-  rw [le_iff]
-  refine ⟨fun ⟨h1, h2, h3, h4, h5⟩ a => by cases a <;> assumption,
-          fun h => ⟨h .θ₁, h .θ₂, h .φ₁, h .φ₂, h .α⟩⟩
-
-end Pose
-
-namespace Noperthedron.Solution
 
 /-- A solution-table interval is a `PoseInterval ℚ`: a `min ≤ max` pair of rational
 poses bounding a 5d box in parameter space. Stored values are the actual angle values

--- a/Noperthedron/SolutionTable/Defs.lean
+++ b/Noperthedron/SolutionTable/Defs.lean
@@ -16,6 +16,20 @@ def DENOMQ : ℚ := 15360000
 inductive Param where | θ₁ | φ₁ | θ₂ | φ₂ | α
 deriving BEq, ReflBEq, LawfulBEq, Repr, Fintype, DecidableEq, Nonempty
 
+/-- The canonical split order of the five pose parameters, matching the CSV
+`split` codes 1–5 and the full-split `cubeFold` order. -/
+def Param.splitOrder : List Param := [.θ₁, .φ₁, .θ₂, .φ₂, .α]
+
+/-- Decode a CSV `split` column code (1–5) into the parameter being split. -/
+def Param.ofSplitCode? : ℕ → Option Param
+  | 0 => none
+  | n + 1 => Param.splitOrder[n]?
+
+#guard Param.ofSplitCode? 0 = none
+#guard Param.ofSplitCode? 1 = some .θ₁
+#guard Param.ofSplitCode? 5 = some .α
+#guard Param.ofSplitCode? 6 = none
+
 end Noperthedron.Solution
 
 /-! ## `Param`-indexed access on `Pose` -/

--- a/Noperthedron/SolutionTable/Parse.lean
+++ b/Noperthedron/SolutionTable/Parse.lean
@@ -175,17 +175,3 @@ def parseSolutionTablePar (s : String) (nTasks : ℕ) : Except String Table := I
     | .ok rows => result := result ++ rows
     | .error e => return .error e
   return .ok result
-
-def readSolutionTable (filepath : String) : IO Table := do
-  let mut rows : Array Row := Array.empty
-  let h ← IO.FS.Handle.mk filepath IO.FS.Mode.read
-  let _ ← h.getLine -- ignore first line
-  while True do
-    let line ← h.getLine
-    let line := line.trimAscii.toString
-    if line.isEmpty then break
-    let row ← match parseRowCsv line with
-              | .ok row => pure row
-              | .error e => throw (IO.userError e)
-    rows := rows.push row
-  return rows

--- a/Noperthedron/SolutionTable/Parse.lean
+++ b/Noperthedron/SolutionTable/Parse.lean
@@ -32,6 +32,12 @@ def parseInt (name : String) : String → Except String Int
   let .some v := s.toInt? | throw s!"failed to parse {name} from '{s}'"
   pure v
 
+/-- Parse a vertex-index column: a natural number `< 90`, decoded via `VertexIndex.ofFin90`. -/
+def parseVertexIndex (name s : String) : Except String VertexIndex := do
+  let n ← parseNat name s
+  if h : n < 90 then pure (VertexIndex.ofFin90 ⟨n, h⟩)
+  else throw s!"invalid index for {name}: {n}"
+
 /-
 27 columns:
 ID,nodeType,nrChildren,IDfirstChild,split,
@@ -79,20 +85,14 @@ def parseRowCsv (s : String) : Except String Row := do
                  else throw "invalid interval"
 
   let p1i_str::p2i_str::p3i_str::rest := rest | throw "not enough columns"
-  let p1i ← parseNat "p1i" p1i_str
-  let p1i : Fin 90 ← if h : p1i < 90 then pure (⟨p1i, h⟩ : Fin 90) else throw "invalid index"
-  let p2i ← parseNat "p2i" p2i_str
-  let p2i : Fin 90 ← if h : p2i < 90 then pure (⟨p2i, h⟩ : Fin 90) else throw "invalid index"
-  let p3i ← parseNat "p3i" p3i_str
-  let p3i : Fin 90 ← if h : p3i < 90 then pure (⟨p3i, h⟩ : Fin 90) else throw "invalid index"
+  let p1i ← parseVertexIndex "p1i" p1i_str
+  let p2i ← parseVertexIndex "p2i" p2i_str
+  let p3i ← parseVertexIndex "p3i" p3i_str
 
   let q1i_str::q2i_str::q3i_str::rest := rest | throw "not enough columns"
-  let q1i ← parseNat "q1i" q1i_str
-  let q1i : Fin 90 ← if h : q1i < 90 then pure (⟨q1i, h⟩ : Fin 90) else throw "invalid index"
-  let q2i ← parseNat "q2i" q2i_str
-  let q2i : Fin 90 ← if h : q2i < 90 then pure (⟨q2i, h⟩ : Fin 90) else throw "invalid index"
-  let q3i ← parseNat "q3i" q3i_str
-  let q3i : Fin 90 ← if h : q3i < 90 then pure (⟨q3i, h⟩ : Fin 90) else throw "invalid index"
+  let q1i ← parseVertexIndex "q1i" q1i_str
+  let q2i ← parseVertexIndex "q2i" q2i_str
+  let q3i ← parseVertexIndex "q3i" q3i_str
 
   let r_str :: sigmaq_str :: rest := rest | throw "not enough columns"
   let r' ← parseInt "r_str" r_str
@@ -109,9 +109,7 @@ def parseRowCsv (s : String) : Except String Row := do
   let wden ← parseNat "wden" wden_str
 
   let sindex_str :: rest := rest | throw "not enough columns"
-  let sindex ← parseNat "sindex" sindex_str
-  let sindex : Fin 90 ← if h : sindex < 90 then pure (⟨sindex, h⟩ : Fin 90)
-                        else throw "invalid sindex"
+  let sindex ← parseVertexIndex "sindex" sindex_str
 
   let [] := rest | throw "too many columns"
 
@@ -122,16 +120,16 @@ def parseRowCsv (s : String) : Except String Row := do
     IDfirstChild := id_fst_child
     split := split
     interval := interval
-    S_index := VertexIndex.ofFin90 sindex
+    S_index := sindex
     wx_numerator := wxnum
     wy_numerator := wynum
     w_denominator := wden
-    P1_index := VertexIndex.ofFin90 p1i
-    P2_index := VertexIndex.ofFin90 p2i
-    P3_index := VertexIndex.ofFin90 p3i
-    Q1_index := VertexIndex.ofFin90 q1i
-    Q2_index := VertexIndex.ofFin90 q2i
-    Q3_index := VertexIndex.ofFin90 q3i
+    P1_index := p1i
+    P2_index := p2i
+    P3_index := p3i
+    Q1_index := q1i
+    Q2_index := q2i
+    Q3_index := q3i
     r' := r'
     sigma_Q := sigmaq
   }

--- a/Noperthedron/Vertices/Symmetry.lean
+++ b/Noperthedron/Vertices/Symmetry.lean
@@ -169,6 +169,18 @@ private lemma Cpt_eq_vec (i₀ : Fin 3) :
 private lemma Cpt_xy_sq_pos (i₀ : Fin 3) : 0 < (Cpt i₀ 0)^2 + (Cpt i₀ 1)^2 := by
   fin_cases i₀ <;> simp [Cpt, C1R, C2R, C3R, C1, C2, C3] <;> norm_num
 
+/-- A unit-|scalar| multiple of a norm-preserving linear map is norm-preserving. -/
+private lemma norm_smul_apply_of_abs_eq_one {s : ℝ} (hs : |s| = 1)
+    {L : ℝ³ →ₗ[ℝ] ℝ³} (hL : ∀ v, ‖L v‖ = ‖v‖) (v : ℝ³) : ‖(s • L) v‖ = ‖v‖ := by
+  rw [LinearMap.smul_apply, norm_smul, Real.norm_eq_abs, hs, one_mul, hL]
+
+/-- Shared closing step of the rotation/reflection congruence proofs: collect the
+`(-1)^m` witness scalar and the vertex's `(-1)^ℓ` sign into a single mod-2 power. -/
+private lemma neg_one_pow_mod_two_smul (m ℓ : ℕ) (w : ℝ³) :
+    (-1 : ℤ) ^ ((ℓ + m) % 2) • w = (-1 : ℝ) ^ m • ((-1 : ℤ) ^ ℓ • w) := by
+  rw [int_neg_one_pow_smul, int_neg_one_pow_smul, smul_smul, ← pow_add, add_comm m ℓ,
+      ← neg_one_pow_eq_pow_mod_two]
+
 /-- The rotation case: `⟨k, ℓ, i⟩ ↦ ⟨k + n, ℓ + m, i⟩` is realized by
 `v ↦ (-1)^m • Rz(2πn/15) v`, the same linear isometry for every triangle. -/
 private theorem congruent_of_rotation (Pi Qi : Fin 3 → VertexIndex)
@@ -177,12 +189,9 @@ private theorem congruent_of_rotation (Pi Qi : Fin 3 → VertexIndex)
     Local.Triangle.Congruent (exactVertex ∘ Pi) (exactVertex ∘ Qi) := by
   set s : ℝ := (-1 : ℝ)^m.val with hs_def
   set φ : ℝ := 2 * π * (n.val : ℝ) / 15 with hφ_def
-  have hs_abs : |s| = 1 := by
-    rw [hs_def, abs_pow, abs_neg, abs_one, one_pow]
-  have hnorm : ∀ v : ℝ³, ‖(s • (RzL φ).toLinearMap) v‖ = ‖v‖ := by
-    intro v
-    rw [LinearMap.smul_apply, norm_smul, Real.norm_eq_abs, hs_abs, one_mul]
-    exact Bounding.Rz_preserves_norm φ v
+  have hs_abs : |s| = 1 := abs_neg_one_pow m.val
+  have hnorm : ∀ v : ℝ³, ‖(s • (RzL φ).toLinearMap) v‖ = ‖v‖ :=
+    norm_smul_apply_of_abs_eq_one hs_abs (Bounding.Rz_preserves_norm φ)
   refine ⟨⟨s • (RzL φ).toLinearMap, hnorm⟩, ?_⟩
   intro j
   simp only [Function.comp_apply, hpq]
@@ -198,8 +207,7 @@ private theorem congruent_of_rotation (Pi Qi : Fin 3 → VertexIndex)
       RzL_nat_mod_15,
       show 2 * π * ((k.val + n.val : ℕ) : ℝ) / 15 = φ + θ by push_cast; rw [hφ_def, hθ_def]; ring,
       RzL_apply_add]
-  rw [int_neg_one_pow_smul, int_neg_one_pow_smul, hs_def, smul_smul, ← pow_add,
-      add_comm m.val ℓ.val, ← neg_one_pow_eq_pow_mod_two]
+  exact neg_one_pow_mod_two_smul m.val ℓ.val _
 
 /-- The reflection case: on a triangle whose vertices all lie in orbit `i₀`,
 `⟨k, ℓ, i₀⟩ ↦ ⟨n - k, ℓ + m, i₀⟩` is realized by the linear isometry
@@ -224,14 +232,13 @@ private theorem congruent_of_reflection (Pi Qi : Fin 3 → VertexIndex)
   have hCpt_eq : Cpt i₀ = !₂[a, b, c] := Cpt_eq_vec i₀
   set s : ℝ := (-1 : ℝ) ^ m.val with hs_def
   set φ : ℝ := 2 * π * (n.val : ℝ) / 15 with hφ_def
-  have hs_abs : |s| = 1 := by rw [hs_def, abs_pow, abs_neg, abs_one, one_pow]
+  have hs_abs : |s| = 1 := abs_neg_one_pow m.val
   have hnorm : ∀ v : ℝ³,
-      ‖(s • ((RzL φ).toLinearMap ∘ₗ (orbitReflL a b).toLinearMap)) v‖ = ‖v‖ := by
-    intro v
-    rw [LinearMap.smul_apply, norm_smul, Real.norm_eq_abs, hs_abs, one_mul,
-        LinearMap.comp_apply]
-    show ‖(RzL φ) ((orbitReflL a b) v)‖ = ‖v‖
-    rw [Bounding.Rz_preserves_norm, orbitReflL_preserves_norm _ _ hab]
+      ‖(s • ((RzL φ).toLinearMap ∘ₗ (orbitReflL a b).toLinearMap)) v‖ = ‖v‖ :=
+    norm_smul_apply_of_abs_eq_one hs_abs fun v => by
+      rw [LinearMap.comp_apply]
+      show ‖(RzL φ) ((orbitReflL a b) v)‖ = ‖v‖
+      rw [Bounding.Rz_preserves_norm, orbitReflL_preserves_norm _ _ hab]
   refine ⟨⟨s • ((RzL φ).toLinearMap ∘ₗ (orbitReflL a b).toLinearMap), hnorm⟩, ?_⟩
   intro j
   have hij : (Qi j).i = i₀ := hQi_i j
@@ -258,8 +265,7 @@ private theorem congruent_of_reflection (Pi Qi : Fin 3 → VertexIndex)
       show 2 * π * ((15 - k.val + n.val : ℕ) : ℝ) / 15 = (φ + -θ) + (1 : ℤ) * (2 * π) by
         push_cast [Nat.cast_sub hk_le]; rw [hφ_def, hθ_def]; ring,
       RzL_periodic]
-  rw [int_neg_one_pow_smul, int_neg_one_pow_smul, hs_def, smul_smul, ← pow_add,
-      add_comm m.val ℓ.val, ← neg_one_pow_eq_pow_mod_two]
+  exact neg_one_pow_mod_two_smul m.val ℓ.val _
 
 /-- Key theorem: whenever `Pi j = s.apply (Qi j)` for all `j` and the symmetry
 is applicable to `Qi`, the triangles `Pi` and `Qi` are congruent. -/

--- a/constructValidTable.lean
+++ b/constructValidTable.lean
@@ -35,15 +35,7 @@ def main (args : List String) : IO Unit := do
   if h_nonempty : 0 < table.size then
     if h_first : table[0].interval = rowZero.interval then
       if h_valid_b : table.rowsValidParB 512 then
-        let validTable : ValidTable := {
-          table := table
-          rows_valid := Table.rowsValid_of_rowsValidParB h_valid_b
-          nonempty := h_nonempty
-          contains_tightInterval := by
-            rw [show (table[0].interval : Set (Pose ℝ)) = (rowZero.interval : Set (Pose ℝ))
-                from by rw [h_first]]
-            exact rowZero_contains_tightInterval
-        }
+        let validTable : ValidTable := Table.validTableOfChecks h_nonempty h_first h_valid_b
         IO.println s!"ValidTable constructed with {validTable.table.size} rows."
       else
         throw (IO.userError "table rows are not valid")


### PR DESCRIPTION
## API-level changes

1. **`PoseParam.lean` moves `Param` down the import graph.** The `Param` inductive and the `Pose.getParam`/`setParam` block move from `SolutionTable/Defs.lean` into a new low-level module (same `Noperthedron.Solution` namespace, so no call sites change). This lets `Pose`/`PoseInterval` state lemmas generically over the parameter being accessed, without dependency cycles.

2. **Generic interval/closed-ball parameter lemmas replace component boilerplate.** New `PoseInterval.contains.getParamBound` and `mem_closedBall_abs_sub_getParam` (plus `Pose.mem_closedBall_iff_forall_getParam`); the five `contains.*Bound` wrappers remain as one-line specializations, and the five `mem_closed_ball_abs_sub_*` lemmas (single call site) are replaced by the generic form.

3. **Split-code decoding is centralized and guarded.** `Param.ofSplitCode? : ℕ → Option Param` documents the CSV encoding in one place, `Param.splitOrder` is now the single source of the split order used by both the decoder and the full-split `cubeFold` lists, and `#guard`s pin all five codes plus the 0/6 boundaries. `Row.ValidSingleParamSplit` becomes an `∃` over the decoder (manual `Decidable` instance on the `native_decide` hot path), and its consumer's five-way `rcases` collapses to a two-line `obtain`.

## Smaller cleanups

- `parseVertexIndex` helper collapses seven repeated parse-nat/prove-`<90`/`ofFin90` blocks in `parseRowCsv`.
- `Table.validTableOfChecks` is now shared between `exists_validTable_of_checkFullB` and the `constructValidTable` executable (removes a duplicated proof term).
- `Row.δ`'s ten per-pose trig `let`s are bundled into a `PoseTrigQ` cache (same idiom as `HEntries` in `RationalGlobal.lean`); the ten sin/cos expressions were previously spelled out three times. The single per-row `let` hoist (the documented ~6× runtime win) is preserved.
- Symmetry congruence proofs share `norm_smul_apply_of_abs_eq_one` and `neg_one_pow_mod_two_smul` instead of duplicated setup/closing blocks.
- `fderiv_rotproj_inner_in_e{0,1,2}` are fused into their sole consumers `nth_partial_rotproj_inner_e{0,1,2}` via a funext bridge over the existing `rotproj_inner_eq`; two manual `rw [show … from rfl]` in `Global.lean` now reuse `rotproj_outer_unit_eq`.
- Dead code removed: orphan topology `example` in `Pose.lean`, unused `extract_constant`, unused `readSolutionTable`.

## Not done (deliberately)

Deleting the `rotprojRM'_single_*` / RotMOuter `*_single_*` `@[simp]` families in favor of generic `columnsCLM_single` was attempted and reverted: bare `simp` calls in `SecondPartialOuter.lean` and `Global.lean` fire them anonymously, so they are live simp API. PoseSide unification and Fin-indexed derivative families are out of scope (architecture refactors with defeq/simp risk).

## Validation

- Full `lake build` green after every commit (staged so each commit builds independently).
- `lake build constructValidTable benchRows` green.
- Sorry count unchanged (exactly the 2 intentional ones in `ComputationalStep.lean`, untouched).
- `#print axioms` guard unchanged: `Table.rowsValid_of_rowsValidParB` still uses only `propext`, `Classical.choice`, `Quot.sound`.
- Informal before/after per-file elaboration timing: all within noise. (The one real hotspot, `rational_local` at ~20s, is untouched — proof-structure work for a separate PR.)
