### PR TITLE
Refactor: split rational_local into named bridge lemmas

### DIFF
--- a/Noperthedron/RationalApprox/RationalLocal.lean
+++ b/Noperthedron/RationalApprox/RationalLocal.lean
@@ -306,6 +306,308 @@ structure RationalLocalTheoremPrecondition {ι : Type} [Fintype ι] [DecidableEq
   be : Local.TriangleQ.Bεℚ Qi
         (fun k => poly_.v (hpoly.bijection k)) p_ ε δ r approx
 
+/-- Cast `Bεℚ.lhs` to `ℝ` (the rounded dot product stays a cast atom); the main
+bridge used inside `rational_local`'s `Bε` argument. -/
+private lemma Bεℚ_lhs_eq_real (p_ℚ : Pose ℚ) (ε : ℚ) (approx : Approx) (v₁ v₂ : Fin 3 → ℚ) :
+    (Local.TriangleQ.Bεℚ.lhs v₁ v₂ p_ℚ ε approx : ℝ) =
+    (((p_ℚ.rotM₂Rℚ v₁ ⬝ᵥ p_ℚ.rotM₂Rℚ (v₁ - v₂) : ℚ) : ℝ) - 10 * κ -
+       2 * ε * ((approx.upper_sqrt.norm (v₁ - v₂) : ℝ) + 2 * κ) *
+         (approx.upper_sqrt_two + ε)) /
+    (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ v₁) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+     ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (v₁ - v₂)) : ℝ) +
+        2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
+  unfold Local.TriangleQ.Bεℚ.lhs
+  push_cast [← cast_κℚ]
+  ring
+
+/-- Bridge `BoundRℚ` (rational side) to `BoundR` (real side), used inside `rational_local`. -/
+private lemma boundR_bridge {p_ℚ : Pose ℚ} {ε r : ℚ} {approx : Approx}
+    (T : Local.TriangleQ) (R : Triangle)
+    (hθ : ((p_ℚ.θ₂ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4) (hφ : ((p_ℚ.φ₂ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4)
+    (hRnorm : ∀ i : Fin 3, ‖R i‖ ≤ 1)
+    (hRapprox : ∀ i : Fin 3, ‖R i - toR3 (T i)‖ ≤ κ)
+    (hεℝ : 0 < (ε : ℝ))
+    (hr₁ : BoundRℚ r ε p_ℚ T approx) :
+    Local.BoundR r ε p_ℚ.toReal R := by
+  intro i
+  set θ₂ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.θ₂ : ℝ), hθ⟩
+  set φ₂ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.φ₂ : ℝ), hφ⟩
+  have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+    mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
+  have h_toR2_eq : (rotMℚℝ ↑θ₂ ↑φ₂) (toR3 (T i)) = toR2 (p_ℚ.rotM₂ℚ (T i)) :=
+    (toR2_pose_rotM₂ℚ _ _).symm
+  have hsl : (approx.lower_sqrt.norm (p_ℚ.rotM₂Rℚ (T i)) : ℝ) ≤
+      ‖(rotMℚℝ ↑θ₂ ↑φ₂) (toR3 (T i))‖ + 2 / 10 ^ 13 := by
+    rw [h_toR2_eq]; exact LowerSqrt_norm_round13v_le approx.lower_sqrt _
+  have hM₂diff : ‖rotM (↑θ₂ : ℝ) ↑φ₂ - rotMℚℝ ↑θ₂ ↑φ₂‖ ≤ κ :=
+    M_difference_norm_bounded _ _ θ₂.property φ₂.property
+  have hM₂ℚnorm : ‖rotMℚℝ (↑θ₂ : ℝ) ↑φ₂‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded θ₂.property φ₂.property
+  have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (R i)‖ - ‖(rotMℚℝ ↑θ₂ ↑φ₂) (toR3 (T i))‖)| ≤ 2 * κ + κ ^ 2 :=
+    (abs_norm_sub_norm_le _ _).trans
+      (clm_approx_apply_sub hM₂diff hM₂ℚnorm (hRnorm i) (hRapprox i))
+  show ‖(rotM ↑θ₂ ↑φ₂) (R i)‖ > r + √2 * ε
+  have hr₁i : (approx.lower_sqrt.norm (p_ℚ.rotM₂Rℚ (T i)) : ℝ) > r + √2 * ε + 3 * κ := by
+    have hcast : ((approx.lower_sqrt.norm (p_ℚ.rotM₂Rℚ (T i)) : ℚ) : ℝ) >
+        ((r + approx.upper_sqrt_two * ε + 3 * κℚ : ℚ) : ℝ) := mod_cast hr₁ i
+    push_cast [cast_κℚ] at hcast
+    linarith [h_us2_eps]
+  rw [abs_le] at hMQ
+  have hκabsorb : 2 / 10 ^ 13 + (2 * κ + κ ^ 2) ≤ 3 * κ := by unfold κ; norm_num
+  linarith [hMQ.1]
+
+private lemma boundDelta_bridge {p_ℚ : Pose ℚ} {δ : ℚ} {approx : Approx}
+    (T_P T_Q : Local.TriangleQ) (P Q : Triangle)
+    (hθ₁b : ((p_ℚ.θ₁ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4) (hφ₁b : ((p_ℚ.φ₁ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4)
+    (hθ₂b : ((p_ℚ.θ₂ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4) (hφ₂b : ((p_ℚ.φ₂ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4)
+    (hαb : ((p_ℚ.α : ℝ)) ∈ Set.Icc (-4 : ℝ) 4)
+    (hPnorm : ∀ i : Fin 3, ‖P i‖ ≤ 1) (hQnorm : ∀ i : Fin 3, ‖Q i‖ ≤ 1)
+    (hPapprox : ∀ i : Fin 3, ‖P i - toR3 (T_P i)‖ ≤ κ)
+    (hQapprox : ∀ i : Fin 3, ‖Q i - toR3 (T_Q i)‖ ≤ κ)
+    (hδ : BoundDeltaℚ δ p_ℚ T_P T_Q approx) :
+    Local.BoundDelta δ p_ℚ.toReal P Q := by
+  set p_ := p_ℚ.toReal with hp_def
+  set P_ := T_P.toReal with hP_def
+  set Q_ := T_Q.toReal with hQ_def
+  set θ₁ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.θ₁ : ℝ), hθ₁b⟩
+  set φ₁ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.φ₁ : ℝ), hφ₁b⟩
+  set θ₂ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.θ₂ : ℝ), hθ₂b⟩
+  set φ₂ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.φ₂ : ℝ), hφ₂b⟩
+  intro i
+  have hδi := hδ i
+  -- su.norm ≥ ‖·‖ (rational form, then convert to real with toR2)
+  have h_eq_real :
+      toR2 (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ (T_P i)) - p_ℚ.rotM₂ℚ (T_Q i)) =
+      p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i) := by
+    rw [toR2_sub, toR2_pose_rotRℚ, toR2_pose_rotM₁ℚ, toR2_pose_rotM₂ℚ]; rfl
+  have hsu : ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
+      (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ (T_P i)) -
+          p_ℚ.rotM₂ℚ (T_Q i)) : ℝ) := by
+    rw [← h_eq_real]; exact UpperSqrt_norm_le approx.upper_sqrt _
+  -- ‖p_.rotR (rotM₁ℚℝ P_) - rotRℚℝ (rotM₁ℚℝ P_)‖ ≤ κ * (1 + κ)  (rotR vs rotRℚℝ discrepancy)
+  have h_rotRdiff : ‖p_.rotR - p_.rotRℚℝ‖ ≤ κ := R_difference_norm_bounded p_.α hαb
+  have hκ_nn : (0 : ℝ) ≤ κ := by unfold κ; norm_num
+  have h_rotM₁ℚ_norm : ‖p_.rotM₁ℚℝ (P_ i)‖ ≤ (1 + κ) * (1 + κ) :=
+    approx_image_norm_le (Mℚ_norm_bounded θ₁.property φ₁.property) (hPnorm i) (hPapprox i)
+  have h_rotR_diff_apply : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))‖ ≤
+      κ * ((1 + κ) * (1 + κ)) := by
+    have := ContinuousLinearMap.le_opNorm (p_.rotR - p_.rotRℚℝ) (p_.rotM₁ℚℝ (P_ i))
+    simp only [sub_apply] at this
+    exact this.trans (mul_le_mul h_rotRdiff h_rotM₁ℚ_norm (norm_nonneg _) (by linarith))
+  -- ‖real - rational‖ ≤ 6κ
+  have hM₁diff : ‖rotM (↑θ₁ : ℝ) ↑φ₁ - rotMℚℝ ↑θ₁ ↑φ₁‖ ≤ κ :=
+    M_difference_norm_bounded _ _ θ₁.property φ₁.property
+  have hM₁ℚnorm : ‖rotMℚℝ (↑θ₁ : ℝ) ↑φ₁‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded θ₁.property φ₁.property
+  have hM₂diff : ‖rotM (↑θ₂ : ℝ) ↑φ₂ - rotMℚℝ ↑θ₂ ↑φ₂‖ ≤ κ :=
+    M_difference_norm_bounded _ _ θ₂.property φ₂.property
+  have hM₂ℚnorm : ‖rotMℚℝ (↑θ₂ : ℝ) ↑φ₂‖ ≤ 1 + κ :=
+    Mℚ_norm_bounded θ₂.property φ₂.property
+  have h₁ : ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hM₁diff hM₁ℚnorm (hPnorm i) (hPapprox i)
+  have h₂ : ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ≤ 2 * κ + κ ^ 2 :=
+    clm_approx_apply_sub hM₂diff hM₂ℚnorm (hQnorm i) (hQapprox i)
+  have hdiff : ‖(p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)) -
+      (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i))‖ ≤ 4 * κ + 2 * κ ^ 2 := by
+    show ‖(rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i)) -
+          (rotR p_.α ((rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i))‖ ≤ _
+    have hrw : rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i) -
+          (rotR p_.α ((rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) =
+          rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) -
+          ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) := by
+      simp [map_sub]; abel
+    rw [hrw]
+    calc ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) -
+            ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i))‖
+      _ ≤ ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i))‖ +
+          ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := norm_sub_le _ _
+      _ = ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)‖ +
+          ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
+        rw [Bounding.rotR_preserves_norm]
+      _ ≤ (2 * κ + κ ^ 2) + (2 * κ + κ ^ 2) := add_le_add h₁ h₂
+      _ = 4 * κ + 2 * κ ^ 2 := by ring
+  show (δ : ℝ) ≥ ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ / 2
+  have hnorm_le : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
+      ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + (4 * κ + 2 * κ ^ 2) := by
+    linarith [norm_le_insert' (p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i))
+      (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i))]
+  -- Bridge `p_.rotR` to `p_.rotRℚℝ` introducing extra κ-slack.
+  have h_rotR_to_rotRℚℝ : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
+      ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + κ * ((1 + κ) * (1 + κ)) := by
+    have h_diff_eq : p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i) =
+        (p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) +
+        (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))) := by abel
+    rw [h_diff_eq]
+    calc ‖(p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) +
+          (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)))‖
+      _ ≤ ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ +
+          ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))‖ := norm_add_le _ _
+      _ ≤ ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + κ * ((1 + κ) * (1 + κ)) := by
+          linarith [h_rotR_diff_apply]
+  have h_total_slack : κ * ((1 + κ) * (1 + κ)) + (4 * κ + 2 * κ ^ 2) ≤ 6 * κ := by
+    unfold κ; norm_num
+  -- Combine everything.
+  have h_chain : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
+      (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ (T_P i)) -
+          p_ℚ.rotM₂ℚ (T_Q i)) : ℝ) + 6 * κ := by
+    linarith [hsu, hnorm_le, h_rotR_to_rotRℚℝ, h_total_slack]
+  -- Now use hδi: δ ≥ s.norm(...) / 2 + 3 * κℚ in ℚ
+  have hδiℝ : (δ : ℝ) ≥
+      (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ (T_P i)) -
+          p_ℚ.rotM₂ℚ (T_Q i)) : ℝ) / 2 + 3 * κ := by
+    have hcast : ((approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ (T_P i)) -
+          p_ℚ.rotM₂ℚ (T_Q i)) / 2 + 3 * κℚ : ℚ) : ℝ) ≤ (δ : ℝ) := by
+      exact_mod_cast hδi
+    push_cast [cast_κℚ] at hcast
+    linarith
+  linarith [hδiℝ, h_chain]
+
+/-- Bridge `Bεℚ` (rational side) to `Bε` (real side), used inside `rational_local`. -/
+private lemma bε_bridge {ι : Type} [Fintype ι] [DecidableEq ι] [Nonempty ι]
+    {poly : GoodPoly ι} {poly_ : Polyhedron ι (Fin 3 → ℚ)}
+    (hpoly : κApproxPoly poly.vertices poly_)
+    (Qi : Fin 3 → ι) {p_ℚ : Pose ℚ} {ε δ r : ℚ} {approx : Approx}
+    (hθ₂b : ((p_ℚ.θ₂ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4) (hφ₂b : ((p_ℚ.φ₂ : ℝ)) ∈ Set.Icc (-4 : ℝ) 4)
+    (hεℝ : 0 < (ε : ℝ)) (hr : 0 < r) (hδ_pos : 0 < (δ : ℝ))
+    (be : Local.TriangleQ.Bεℚ Qi (fun k => poly_.v (hpoly.bijection k)) p_ℚ ε δ r approx) :
+    Local.Bε Qi poly.vertices.v p_ℚ.toReal ε δ r := by
+  set p_ := p_ℚ.toReal with hp_def
+  set Q : Triangle := fun j => poly.vertices.v (Qi j) with hQdef
+  set Q_ := (hpoly.transportTri Qi).toReal with hQ_def
+  set θ₂ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.θ₂ : ℝ), hθ₂b⟩
+  set φ₂ : Set.Icc (-4 : ℝ) 4 := ⟨(p_ℚ.φ₂ : ℝ), hφ₂b⟩
+  have hQnorm (j : Fin 3) : ‖Q j‖ ≤ 1 := poly.vertex_radius_le_one (Qi j)
+  have hQapprox (j : Fin 3) : ‖Q j - Q_ j‖ ≤ κ := hpoly.approx (Qi j)
+  have h_upper_norm_toR3 : ∀ (v : Fin 3 → ℚ),
+      (approx.upper_sqrt.norm v : ℝ) ≥ ‖toR3 v‖ := fun v =>
+    UpperSqrt_norm_le approx.upper_sqrt v
+  have h_upper_norm_toR2 : ∀ (v : Fin 2 → ℚ),
+      (approx.upper_sqrt.norm v : ℝ) ≥ ‖toR2 v‖ := fun v =>
+    UpperSqrt_norm_le approx.upper_sqrt v
+  have h_Bεℚ_lhs_bridge := Bεℚ_lhs_eq_real p_ℚ ε approx
+  intro i k hne_k
+  -- Map k to v_ in poly_
+  let k' := hpoly.bijection k
+  let v_ℚ : Fin 3 → ℚ := poly_.v k'
+  set v_ : ℝ³ := poly_.toReal.v k'
+  have hvapprox : ‖poly.vertices.v k - v_‖ ≤ κ := hpoly.approx k
+  have hvnorm : ‖poly.vertices.v k‖ ≤ 1 := poly.vertex_radius_le_one k
+  -- The rational forms of Q_ i and v_ (definitionally equal via toR3).
+  let Q_ℚ : Fin 3 → ℚ := (hpoly.transportTri Qi) i
+  -- Get the Bεℚ hypothesis
+  have hbe : (δ + approx.upper_sqrt_five * ε) / r <
+      Local.TriangleQ.Bεℚ.lhs Q_ℚ v_ℚ p_ℚ ε approx := be i k hne_k
+  show (δ + √5 * ε) / r < Local.Bε.lhs (Q i) (poly.vertices.v k) p_ ε
+  -- Use the bridge to rewrite `Bεℚ.lhs` into explicit real form.
+  have h_bridge_Qv := h_Bεℚ_lhs_bridge Q_ℚ v_ℚ
+  -- Bridge from approx.upper_sqrt_five to √5 (since upper_sqrt_five > √5)
+  have hbe' : (↑δ + √5 * ↑ε) / ↑r <
+      ((((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
+         2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
+      (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+       ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
+    rw [← h_bridge_Qv]
+    have h_le : (↑δ + √5 * ↑ε) / ↑r ≤ (↑δ + ↑approx.upper_sqrt_five * ↑ε) / ↑r := by
+      gcongr
+      exact approx.upper_sqrt_five_gt_sqrt_five.le
+    have hbe_ℝ : ((δ + approx.upper_sqrt_five * ε) / r : ℝ) <
+        (Local.TriangleQ.Bεℚ.lhs Q_ℚ v_ℚ p_ℚ ε approx : ℝ) := mod_cast hbe
+    exact h_le.trans_lt hbe_ℝ
+  -- Helper facts
+  have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
+  -- Bridges relating real and rational norms via UpperSqrt_norm_le.
+  have h_toR3_sub_Qv : toR3 (Q_ℚ - v_ℚ) = toR3 Q_ℚ - toR3 v_ℚ := toR3_sub _ _
+  have h_norm_Qv_rat : ‖toR3 Q_ℚ - toR3 v_ℚ‖ ≤ (approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) := by
+    rw [← h_toR3_sub_Qv]; exact h_upper_norm_toR3 _
+  have h_snorm_Q_nn : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) :=
+    le_trans (norm_nonneg (toR2 (p_ℚ.rotM₂Rℚ Q_ℚ))) (h_upper_norm_toR2 _)
+  have h_snorm_Qv_nn : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) :=
+    le_trans (norm_nonneg (toR2 (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)))) (h_upper_norm_toR2 _)
+  have h_us2_nn : (0 : ℝ) ≤ approx.upper_sqrt_two :=
+    (Real.sqrt_nonneg 2).trans approx.upper_sqrt_two_gt_sqrt_two.le
+  have h_us2_le : (√2 : ℝ) ≤ approx.upper_sqrt_two := approx.upper_sqrt_two_gt_sqrt_two.le
+  have hsu_norm_nn : (0 : ℝ) ≤ (approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) :=
+    (norm_nonneg _).trans h_norm_Qv_rat
+  -- Denominator positivity
+  have hden_pos : 0 < ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+      ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * approx.upper_sqrt_two * ε + 6 * κ) := by
+    positivity
+  -- Extract positivity of Bεℚ numerator
+  have hBεℚ_num_pos : 0 < (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
+      2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
+    have h0 : 0 < (δ + √5 * ε) / r := by positivity
+    refine (div_pos_iff_of_pos_right hden_pos).mp (h0.trans ?_)
+    exact hbe'
+  -- bounds_kappa4_Aℚ in real form
+  have h_num_sub : 2 * (ε : ℝ) * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) ≤
+      2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
+    apply mul_le_mul (mul_le_mul_of_nonneg_left (by linarith [h_norm_Qv_rat]) (by linarith))
+      (by linarith) (by positivity) (by positivity)
+  have hAℚ_num_pos : 0 < (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
+      2 * ε * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) := by
+    linarith [hBεℚ_num_pos]
+  -- Approximation bound for `Q i - v k` (used for the ε-term comparison)
+  have hQv_approx : ‖(Q i - poly.vertices.v k) - (toR3 Q_ℚ - toR3 v_ℚ)‖ ≤ 2 * κ := by
+    rw [show toR3 Q_ℚ - toR3 v_ℚ = Q_ i - v_ from rfl]
+    calc ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖
+        = ‖(Q i - Q_ i) - (poly.vertices.v k - v_)‖ := by congr 1; abel
+      _ ≤ ‖Q i - Q_ i‖ + ‖poly.vertices.v k - v_‖ := norm_sub_le _ _
+      _ ≤ κ + κ := add_le_add (hQapprox i) hvapprox
+      _ = 2 * κ := by ring
+  -- Apply bounds_kappa4
+  have h_Q_approx : ‖Q i - toR3 Q_ℚ‖ ≤ κ := hQapprox i
+  have h_v_approx : ‖poly.vertices.v k - toR3 v_ℚ‖ ≤ κ := hvapprox
+  have hA_nonneg : 0 ≤ ⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
+      (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ -
+      2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) := by
+    have h_inner_10 : |⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
+          (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ -
+        (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ)| ≤ 10 * κ :=
+      inner_product_bound_round_10kappa (θ := θ₂) (φ := φ₂) rfl rfl
+        (hQnorm i) hvnorm h_Q_approx h_v_approx
+    have h_inner_le : (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ ≤
+        ⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
+          (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ :=
+      sub_le_of_abs_sub_le_left h_inner_10
+    have h_norm_QR : ‖Q i - poly.vertices.v k‖ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ :=
+      calc ‖Q i - poly.vertices.v k‖
+        _ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ +
+            ‖(Q i - poly.vertices.v k) - (toR3 Q_ℚ - toR3 v_ℚ)‖ := norm_le_insert' _ _
+        _ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ := by grw [hQv_approx]
+    have h_eps_term : 2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) ≤
+        2 * ε * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) := by
+      apply mul_le_mul_of_nonneg_right
+      · exact mul_le_mul_of_nonneg_left h_norm_QR (by linarith)
+      · positivity
+    linarith [hAℚ_num_pos]
+  have hbk4 : bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt ≤
+      bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε :=
+    bounds_kappa4 (Q i) (poly.vertices.v k) Q_ℚ v_ℚ p_ℚ
+      hθ₂b hφ₂b (hQnorm i) hvnorm h_Q_approx h_v_approx ε hεℝ
+      approx.upper_sqrt hA_nonneg
+  -- Bridge `Bεℚ.lhs` real form ≤ `bounds_kappa4_Aℚ`
+  have hBεℚ_le :
+      ((((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
+          2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
+        (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
+          ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) +
+            2 * approx.upper_sqrt_two * ε + 6 * κ)) ≤
+      bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt := by
+    show _ ≤ ((((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
+          2 * ε * (‖toR3 (Q_ℚ - v_ℚ)‖ + 2 * κ) * (√2 + ε)) /
+      (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + √2 * ε + 3 * κ) *
+       ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * √2 * ε + 6 * κ))
+    have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
+      mul_le_mul_of_nonneg_right h_us2_le hεℝ.le
+    rw [h_toR3_sub_Qv]
+    refine div_le_div₀ hAℚ_num_pos.le (by linarith [h_num_sub]) (by positivity) ?_
+    gcongr
+  -- Combine (final step uses defeq `bounds_kappa4_A = Bε.lhs`).
+  calc (δ + √5 * ε) / r
+      < _ := hbe'
+    _ ≤ bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt := hBεℚ_le
+    _ ≤ bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := hbk4
+
 /--
 [SY25] Theorem 48 "The Rational Local Theorem"
 -/
@@ -352,18 +654,7 @@ theorem rational_local {ι : Type} [Fintype ι] [DecidableEq ι] [Nonempty ι]
       (approx.upper_sqrt.norm v : ℝ) ≥ ‖toR2 v‖ := fun v =>
     UpperSqrt_norm_le approx.upper_sqrt v
   -- Main bridge: cast `Bεℚ.lhs` to `ℝ` (the rounded dot product stays a cast atom).
-  have h_Bεℚ_lhs_bridge : ∀ (v₁ v₂ : Fin 3 → ℚ),
-      (Local.TriangleQ.Bεℚ.lhs v₁ v₂ p_ℚ ε approx : ℝ) =
-      (((p_ℚ.rotM₂Rℚ v₁ ⬝ᵥ p_ℚ.rotM₂Rℚ (v₁ - v₂) : ℚ) : ℝ) - 10 * κ -
-         2 * ε * ((approx.upper_sqrt.norm (v₁ - v₂) : ℝ) + 2 * κ) *
-           (approx.upper_sqrt_two + ε)) /
-      (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ v₁) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
-       ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (v₁ - v₂)) : ℝ) +
-          2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
-    intro v₁ v₂
-    unfold Local.TriangleQ.Bεℚ.lhs
-    push_cast [← cast_κℚ]
-    ring
+  have h_Bεℚ_lhs_bridge := Bεℚ_lhs_eq_real p_ℚ ε approx
   have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
     mul_le_mul_of_nonneg_right approx.upper_sqrt_two_gt_sqrt_two.le hεℝ.le
   have ae₁' : P.Aε p_.vecX₁ ε :=
@@ -372,256 +663,24 @@ theorem rational_local {ι : Type} [Fintype ι] [DecidableEq ι] [Nonempty ι]
   have ae₂' : Q.Aε p_.vecX₂ ε :=
     aε_bridge (T := hpoly.transportTri Qi) (R := Q) hp.θ₂Bound hp.φ₂Bound
       hQnorm hQapprox ae₂ hεℝ
-  -- Bridge: BoundRℚ → BoundR. `BoundRℚ` bounds the `LowerSqrt` norm of the
-  -- *rounded* applied vector; the `2/10¹³` rounding perturbation plus the
-  -- `2κ + κ²` approximation error fit inside the `3κ` term.
-  have hr₁' : Local.BoundR r ε p_ Q := by
-    intro i
-    have h_toR2_eq : (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i) =
-        toR2 (p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) :=
-      (toR2_pose_rotM₂ℚ _ _).symm
-    have hsl : (approx.lower_sqrt.norm (p_ℚ.rotM₂Rℚ ((hpoly.transportTri Qi) i)) : ℝ) ≤
-        ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ + 2 / 10 ^ 13 := by
-      rw [h_toR2_eq]; exact LowerSqrt_norm_round13v_le approx.lower_sqrt _
-    have hM₂diff : ‖rotM (↑θ₂ : ℝ) ↑φ₂ - rotMℚℝ ↑θ₂ ↑φ₂‖ ≤ κ :=
-      M_difference_norm_bounded _ _ θ₂.property φ₂.property
-    have hM₂ℚnorm : ‖rotMℚℝ (↑θ₂ : ℝ) ↑φ₂‖ ≤ 1 + κ :=
-      Mℚ_norm_bounded θ₂.property φ₂.property
-    have hMQ : |(‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ - ‖(rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖)| ≤ 2 * κ + κ ^ 2 :=
-      (abs_norm_sub_norm_le _ _).trans
-        (clm_approx_apply_sub hM₂diff hM₂ℚnorm (hQnorm i) (hQapprox i))
-    show ‖(rotM ↑θ₂ ↑φ₂) (Q i)‖ > r + √2 * ε
-    have hr₁i : (approx.lower_sqrt.norm (p_ℚ.rotM₂Rℚ ((hpoly.transportTri Qi) i)) : ℝ) >
-        r + √2 * ε + 3 * κ := by
-      have hcast : ((approx.lower_sqrt.norm (p_ℚ.rotM₂Rℚ ((hpoly.transportTri Qi) i)) : ℚ) : ℝ) >
-          ((r + approx.upper_sqrt_two * ε + 3 * κℚ : ℚ) : ℝ) := mod_cast hr₁ i
-      push_cast [cast_κℚ] at hcast
-      linarith [h_us2_eps]
-    rw [abs_le] at hMQ
-    have hκabsorb : 2 / 10 ^ 13 + (2 * κ + κ ^ 2) ≤ 3 * κ := by unfold κ; norm_num
-    linarith [hMQ.1]
-  have hδ' : Local.BoundDelta δ p_ P Q := by
-    intro i
-    have hδi := hδ i
-    -- su.norm ≥ ‖·‖ (rational form, then convert to real with toR2)
-    have h_eq_real :
-        toR2 (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
-              p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) =
-        p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i) := by
-      rw [toR2_sub, toR2_pose_rotRℚ, toR2_pose_rotM₁ℚ, toR2_pose_rotM₂ℚ]; rfl
-    have hsu : ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
-        (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
-            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) := by
-      rw [← h_eq_real]; exact UpperSqrt_norm_le approx.upper_sqrt _
-    -- ‖p_.rotR (rotM₁ℚℝ P_) - rotRℚℝ (rotM₁ℚℝ P_)‖ ≤ κ * (1 + κ)  (rotR vs rotRℚℝ discrepancy)
-    have h_rotRdiff : ‖p_.rotR - p_.rotRℚℝ‖ ≤ κ := R_difference_norm_bounded p_.α hp.αBound
-    have hκ_nn : (0 : ℝ) ≤ κ := by unfold κ; norm_num
-    have h_rotM₁ℚ_norm : ‖p_.rotM₁ℚℝ (P_ i)‖ ≤ (1 + κ) * (1 + κ) :=
-      approx_image_norm_le (Mℚ_norm_bounded θ₁.property φ₁.property) (hPnorm i) (hPapprox i)
-    have h_rotR_diff_apply : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))‖ ≤
-        κ * ((1 + κ) * (1 + κ)) := by
-      have := ContinuousLinearMap.le_opNorm (p_.rotR - p_.rotRℚℝ) (p_.rotM₁ℚℝ (P_ i))
-      simp only [sub_apply] at this
-      exact this.trans (mul_le_mul h_rotRdiff h_rotM₁ℚ_norm (norm_nonneg _) (by linarith))
-    -- ‖real - rational‖ ≤ 6κ
-    have hM₁diff : ‖rotM (↑θ₁ : ℝ) ↑φ₁ - rotMℚℝ ↑θ₁ ↑φ₁‖ ≤ κ :=
-      M_difference_norm_bounded _ _ θ₁.property φ₁.property
-    have hM₁ℚnorm : ‖rotMℚℝ (↑θ₁ : ℝ) ↑φ₁‖ ≤ 1 + κ :=
-      Mℚ_norm_bounded θ₁.property φ₁.property
-    have hM₂diff : ‖rotM (↑θ₂ : ℝ) ↑φ₂ - rotMℚℝ ↑θ₂ ↑φ₂‖ ≤ κ :=
-      M_difference_norm_bounded _ _ θ₂.property φ₂.property
-    have hM₂ℚnorm : ‖rotMℚℝ (↑θ₂ : ℝ) ↑φ₂‖ ≤ 1 + κ :=
-      Mℚ_norm_bounded θ₂.property φ₂.property
-    have h₁ : ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)‖ ≤ 2 * κ + κ ^ 2 :=
-      clm_approx_apply_sub hM₁diff hM₁ℚnorm (hPnorm i) (hPapprox i)
-    have h₂ : ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ ≤ 2 * κ + κ ^ 2 :=
-      clm_approx_apply_sub hM₂diff hM₂ℚnorm (hQnorm i) (hQapprox i)
-    have hdiff : ‖(p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)) -
-        (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i))‖ ≤ 4 * κ + 2 * κ ^ 2 := by
-      show ‖(rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i)) -
-            (rotR p_.α ((rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i))‖ ≤ _
-      have hrw : rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i)) - (rotM ↑θ₂ ↑φ₂) (Q i) -
-            (rotR p_.α ((rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) =
-            rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) -
-            ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)) := by
-        simp [map_sub]; abel
-      rw [hrw]
-      calc ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)) -
-              ((rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i))‖
-        _ ≤ ‖rotR p_.α ((rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i))‖ +
-            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := norm_sub_le _ _
-        _ = ‖(rotM ↑θ₁ ↑φ₁) (P i) - (rotMℚℝ ↑θ₁ ↑φ₁) (P_ i)‖ +
-            ‖(rotM ↑θ₂ ↑φ₂) (Q i) - (rotMℚℝ ↑θ₂ ↑φ₂) (Q_ i)‖ := by
-          rw [Bounding.rotR_preserves_norm]
-        _ ≤ (2 * κ + κ ^ 2) + (2 * κ + κ ^ 2) := add_le_add h₁ h₂
-        _ = 4 * κ + 2 * κ ^ 2 := by ring
-    show (δ : ℝ) ≥ ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ / 2
-    have hnorm_le : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
-        ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + (4 * κ + 2 * κ ^ 2) := by
-      linarith [norm_le_insert' (p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i))
-        (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i))]
-    -- Bridge `p_.rotR` to `p_.rotRℚℝ` introducing extra κ-slack.
-    have h_rotR_to_rotRℚℝ : ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ ≤
-        ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + κ * ((1 + κ) * (1 + κ)) := by
-      have h_diff_eq : p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i) =
-          (p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) +
-          (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))) := by abel
-      rw [h_diff_eq]
-      calc ‖(p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)) +
-            (p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)))‖
-        _ ≤ ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ +
-            ‖p_.rotR (p_.rotM₁ℚℝ (P_ i)) - p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i))‖ := norm_add_le _ _
-        _ ≤ ‖p_.rotRℚℝ (p_.rotM₁ℚℝ (P_ i)) - p_.rotM₂ℚℝ (Q_ i)‖ + κ * ((1 + κ) * (1 + κ)) := by
-            linarith [h_rotR_diff_apply]
-    have h_total_slack : κ * ((1 + κ) * (1 + κ)) + (4 * κ + 2 * κ ^ 2) ≤ 6 * κ := by
-      unfold κ; norm_num
-    -- Combine everything.
-    have h_chain : ‖p_.rotR (p_.rotM₁ (P i)) - p_.rotM₂ (Q i)‖ ≤
-        (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
-            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) + 6 * κ := by
-      linarith [hsu, hnorm_le, h_rotR_to_rotRℚℝ, h_total_slack]
-    -- Now use hδi: δ ≥ s.norm(...) / 2 + 3 * κℚ in ℚ
-    have hδiℝ : (δ : ℝ) ≥
-        (approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
-            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) : ℝ) / 2 + 3 * κ := by
-      have hcast : ((approx.upper_sqrt.norm (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) i)) -
-            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) i)) / 2 + 3 * κℚ : ℚ) : ℝ) ≤ (δ : ℝ) := by
-        exact_mod_cast hδi
-      push_cast [cast_κℚ] at hcast
-      linarith
-    linarith [hδiℝ, h_chain]
-  -- Bridge: Bεℚ → Bε
-  have be' : Local.Bε Qi poly.vertices.v p_ ε δ r := by
-    intro i k hne_k
-    -- Map k to v_ in poly_
-    let k' := hpoly.bijection k
-    let v_ℚ : Fin 3 → ℚ := poly_.v k'
-    set v_ : ℝ³ := poly_.toReal.v k'
-    have hvapprox : ‖poly.vertices.v k - v_‖ ≤ κ := hpoly.approx k
-    have hvnorm : ‖poly.vertices.v k‖ ≤ 1 := poly.vertex_radius_le_one k
-    -- The rational forms of Q_ i and v_ (definitionally equal via toR3).
-    let Q_ℚ : Fin 3 → ℚ := (hpoly.transportTri Qi) i
-    -- Get the Bεℚ hypothesis
-    have hbe : (δ + approx.upper_sqrt_five * ε) / r <
-        Local.TriangleQ.Bεℚ.lhs Q_ℚ v_ℚ p_ℚ ε approx := be i k hne_k
-    show (δ + √5 * ε) / r < Local.Bε.lhs (Q i) (poly.vertices.v k) p_ ε
-    -- Use the bridge to rewrite `Bεℚ.lhs` into explicit real form.
-    have h_bridge_Qv := h_Bεℚ_lhs_bridge Q_ℚ v_ℚ
-    -- Bridge from approx.upper_sqrt_five to √5 (since upper_sqrt_five > √5)
-    have hbe' : (↑δ + √5 * ↑ε) / ↑r <
-        ((((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
-           2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
-        (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
-         ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * approx.upper_sqrt_two * ε + 6 * κ)) := by
-      rw [← h_bridge_Qv]
-      have h_le : (↑δ + √5 * ↑ε) / ↑r ≤ (↑δ + ↑approx.upper_sqrt_five * ↑ε) / ↑r := by
-        gcongr
-        exact approx.upper_sqrt_five_gt_sqrt_five.le
-      have hbe_ℝ : ((δ + approx.upper_sqrt_five * ε) / r : ℝ) <
-          (Local.TriangleQ.Bεℚ.lhs Q_ℚ v_ℚ p_ℚ ε approx : ℝ) := mod_cast hbe
-      exact h_le.trans_lt hbe_ℝ
-    -- Helper facts
+  -- Bridge: BoundRℚ → BoundR.
+  have hr₁' : Local.BoundR r ε p_ Q :=
+    boundR_bridge (hpoly.transportTri Qi) Q hp.θ₂Bound hp.φ₂Bound hQnorm hQapprox hεℝ hr₁
+  have hδ' : Local.BoundDelta δ p_ P Q :=
+    boundDelta_bridge (hpoly.transportTri Pi) (hpoly.transportTri Qi) P Q
+      hp.θ₁Bound hp.φ₁Bound hp.θ₂Bound hp.φ₂Bound hp.αBound
+      hPnorm hQnorm hPapprox hQapprox hδ
+  -- Bridge: Bεℚ → Bε (the δ-positivity fact is extracted from `hδ 0`)
+  have hδ_pos : 0 < (δ : ℝ) := by
     have hκ_pos : (0 : ℝ) < κ := by unfold κ; norm_num
-    -- Bridges relating real and rational norms via UpperSqrt_norm_le.
-    have h_toR3_sub_Qv : toR3 (Q_ℚ - v_ℚ) = toR3 Q_ℚ - toR3 v_ℚ := toR3_sub _ _
-    have h_norm_Qv_rat : ‖toR3 Q_ℚ - toR3 v_ℚ‖ ≤ (approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) := by
-      rw [← h_toR3_sub_Qv]; exact h_upper_norm_toR3 _
-    have h_snorm_Q_nn : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) :=
-      le_trans (norm_nonneg (toR2 (p_ℚ.rotM₂Rℚ Q_ℚ))) (h_upper_norm_toR2 _)
-    have h_snorm_Qv_nn : (0 : ℝ) ≤ (approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) :=
-      le_trans (norm_nonneg (toR2 (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)))) (h_upper_norm_toR2 _)
-    have h_us2_nn : (0 : ℝ) ≤ approx.upper_sqrt_two :=
-      (Real.sqrt_nonneg 2).trans approx.upper_sqrt_two_gt_sqrt_two.le
-    have h_us2_le : (√2 : ℝ) ≤ approx.upper_sqrt_two := approx.upper_sqrt_two_gt_sqrt_two.le
-    have hsu_norm_nn : (0 : ℝ) ≤ (approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) :=
-      (norm_nonneg _).trans h_norm_Qv_rat
-    -- Denominator positivity
-    have hden_pos : 0 < ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
-        ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * approx.upper_sqrt_two * ε + 6 * κ) := by
-      positivity
-    -- Extract positivity of Bεℚ numerator
-    have hBεℚ_num_pos : 0 < (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
-        2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
-      have hδ_pos : 0 < (δ : ℝ) := by
-        -- δ ≥ s.norm/2 + 3 * κℚ in ℚ, and s.norm ≥ 0 (it bounds a real norm).
-        have hsu0 := UpperSqrt_norm_le approx.upper_sqrt
-          (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
-            p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0))
-        have hcast := (Rat.cast_le (K := ℝ)).mpr (hδ 0)
-        push_cast [cast_κℚ] at hcast
-        linarith [(norm_nonneg _).trans hsu0]
-      have h0 : 0 < (δ + √5 * ε) / r := by positivity
-      refine (div_pos_iff_of_pos_right hden_pos).mp (h0.trans ?_)
-      exact hbe'
-    -- bounds_kappa4_Aℚ in real form
-    have h_num_sub : 2 * (ε : ℝ) * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) ≤
-        2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε) := by
-      apply mul_le_mul (mul_le_mul_of_nonneg_left (by linarith [h_norm_Qv_rat]) (by linarith))
-        (by linarith) (by positivity) (by positivity)
-    have hAℚ_num_pos : 0 < (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
-        2 * ε * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) := by
-      linarith [hBεℚ_num_pos]
-    -- Approximation bound for `Q i - v k` (used for the ε-term comparison)
-    have hQv_approx : ‖(Q i - poly.vertices.v k) - (toR3 Q_ℚ - toR3 v_ℚ)‖ ≤ 2 * κ := by
-      rw [show toR3 Q_ℚ - toR3 v_ℚ = Q_ i - v_ from rfl]
-      calc ‖(Q i - poly.vertices.v k) - (Q_ i - v_)‖
-          = ‖(Q i - Q_ i) - (poly.vertices.v k - v_)‖ := by congr 1; abel
-        _ ≤ ‖Q i - Q_ i‖ + ‖poly.vertices.v k - v_‖ := norm_sub_le _ _
-        _ ≤ κ + κ := add_le_add (hQapprox i) hvapprox
-        _ = 2 * κ := by ring
-    -- Apply bounds_kappa4
-    have h_Q_approx : ‖Q i - toR3 Q_ℚ‖ ≤ κ := hQapprox i
-    have h_v_approx : ‖poly.vertices.v k - toR3 v_ℚ‖ ≤ κ := hvapprox
-    have hA_nonneg : 0 ≤ ⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
-        (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ -
-        2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) := by
-      have h_inner_10 : |⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
-            (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ -
-          (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ)| ≤ 10 * κ :=
-        inner_product_bound_round_10kappa (θ := θ₂) (φ := φ₂) rfl rfl
-          (hQnorm i) hvnorm h_Q_approx h_v_approx
-      have h_inner_le : (((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ ≤
-          ⟪(rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i),
-            (rotM (p_ℚ.θ₂ : ℝ) (p_ℚ.φ₂ : ℝ)) (Q i - poly.vertices.v k)⟫ :=
-        sub_le_of_abs_sub_le_left h_inner_10
-      have h_norm_QR : ‖Q i - poly.vertices.v k‖ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ :=
-        calc ‖Q i - poly.vertices.v k‖
-          _ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ +
-              ‖(Q i - poly.vertices.v k) - (toR3 Q_ℚ - toR3 v_ℚ)‖ := norm_le_insert' _ _
-          _ ≤ ‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ := by grw [hQv_approx]
-      have h_eps_term : 2 * ε * ‖Q i - poly.vertices.v k‖ * (√2 + ε) ≤
-          2 * ε * (‖toR3 Q_ℚ - toR3 v_ℚ‖ + 2 * κ) * (√2 + ε) := by
-        apply mul_le_mul_of_nonneg_right
-        · exact mul_le_mul_of_nonneg_left h_norm_QR (by linarith)
-        · positivity
-      linarith [hAℚ_num_pos]
-    have hbk4 : bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt ≤
-        bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε :=
-      bounds_kappa4 (Q i) (poly.vertices.v k) Q_ℚ v_ℚ p_ℚ
-        hp.θ₂Bound hp.φ₂Bound (hQnorm i) hvnorm h_Q_approx h_v_approx ε hεℝ
-        approx.upper_sqrt hA_nonneg
-    -- Bridge `Bεℚ.lhs` real form ≤ `bounds_kappa4_Aℚ`
-    have hBεℚ_le :
-        ((((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
-            2 * ε * ((approx.upper_sqrt.norm (Q_ℚ - v_ℚ) : ℝ) + 2 * κ) * (approx.upper_sqrt_two + ε)) /
-          (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + approx.upper_sqrt_two * ε + 3 * κ) *
-            ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) +
-              2 * approx.upper_sqrt_two * ε + 6 * κ)) ≤
-        bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt := by
-      show _ ≤ ((((p_ℚ.rotM₂Rℚ Q_ℚ ⬝ᵥ p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℚ) : ℝ) - 10 * κ -
-            2 * ε * (‖toR3 (Q_ℚ - v_ℚ)‖ + 2 * κ) * (√2 + ε)) /
-        (((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ Q_ℚ) : ℝ) + √2 * ε + 3 * κ) *
-         ((approx.upper_sqrt.norm (p_ℚ.rotM₂Rℚ (Q_ℚ - v_ℚ)) : ℝ) + 2 * √2 * ε + 6 * κ))
-      have h_us2_eps : (√2 : ℝ) * ε ≤ approx.upper_sqrt_two * ε :=
-        mul_le_mul_of_nonneg_right h_us2_le hεℝ.le
-      rw [h_toR3_sub_Qv]
-      refine div_le_div₀ hAℚ_num_pos.le (by linarith [h_num_sub]) (by positivity) ?_
-      gcongr
-    -- Combine (final step uses defeq `bounds_kappa4_A = Bε.lhs`).
-    calc (δ + √5 * ε) / r
-        < _ := hbe'
-      _ ≤ bounds_kappa4_Aℚ Q_ℚ v_ℚ p_ℚ ε approx.upper_sqrt := hBεℚ_le
-      _ ≤ bounds_kappa4_A (Q i) (poly.vertices.v k) θ₂ φ₂ ε := hbk4
+    have hsu0 := UpperSqrt_norm_le approx.upper_sqrt
+      (p_ℚ.rotRℚ (p_ℚ.rotM₁ℚ ((hpoly.transportTri Pi) 0)) -
+        p_ℚ.rotM₂ℚ ((hpoly.transportTri Qi) 0))
+    have hcast := (Rat.cast_le (K := ℝ)).mpr (hδ 0)
+    push_cast [cast_κℚ] at hcast
+    linarith [(norm_nonneg _).trans hsu0]
+  have be' : Local.Bε Qi poly.vertices.v p_ ε δ r :=
+    bε_bridge hpoly Qi hp.θ₂Bound hp.φ₂Bound hεℝ hr hδ_pos be
   -- Apply local_theorem
   exact Local.local_theorem poly p_ ε
     { Pi := Pi, Qi := Qi, cong_tri := cong_tri, δ := δ, r := r,


### PR DESCRIPTION
## What

`RationalApprox.LocalTheorem.rational_local` is a ~315-line monolithic tactic proof that elaborates in **18.3s** — the single largest elaboration hotspot in the project. This splits its four ℚ→ℝ bridging blocks into named private lemmas, following the pattern of the existing `aε_bridge`:

- `Bεℚ_lhs_eq_real` — casts `Bεℚ.lhs` to `ℝ` (was the inline `h_Bεℚ_lhs_bridge`).
- `boundR_bridge` — `BoundRℚ` → `Local.BoundR` (was inline `hr₁'`).
- `boundDelta_bridge` — `BoundDeltaℚ` → `Local.BoundDelta` (was inline `hδ'`).
- `bε_bridge` — `Bεℚ` → `Local.Bε` (was inline `be'`, ~130 lines; takes `0 < (δ : ℝ)` as a hypothesis, derived once in the main proof from `hδ 0`).

The block bodies are moved verbatim (up to context→parameter renaming); `rational_local` becomes setup + five bridge applications + the `local_theorem` record. The statement of `rational_local` and all public signatures are unchanged.

Re-extracted against current `main` — this version tracks #62's proof internals (the `rotM₂Rℚ` rounded-matrix form, `LowerSqrt_norm_round13v_le`, `inner_product_bound_round_10kappa`), so it is not a rebase of the earlier draft but a fresh extraction.

## Why / measurements

- `rational_local` proof elaboration: **18.3s → below the 1.5s threshold**.
- The three heavy bridges now elaborate independently/async: `bε_bridge` 10.7s, `boundDelta_bridge` 4.3s, `boundR_bridge` 1.8s.

Intentionally a maintainability/scheduler tradeoff: the file gets a little longer (net +59 lines), but the long serial proof is decomposed into named bridge lemmas that Lean elaborates in parallel.

## Validation

- Full `lake build` green on current `main`; `lake build constructValidTable benchRows` green.
- Sorry count unchanged (2 intentional in `ComputationalStep.lean`).
- `#print axioms rational_local` unchanged: `propext`, `Classical.choice`, `Quot.sound`.
- Only `RationalApprox/RationalLocal.lean` changes.
