### PR TITLE
Perf: reuse fun_prop cores in rotM_outer and rotprojRM (stacked on #59)

### DIFF
--- a/Noperthedron/Global/RotationPartials/RotMOuter.lean
+++ b/Noperthedron/Global/RotationPartials/RotMOuter.lean
@@ -41,10 +41,8 @@ def rotM' (pbar : Pose ℝ) (P : ℝ³) : ℝ² →L[ℝ] ℝ² :=
   columnsCLM ![rotMθ pbar.θ₂ pbar.φ₂ P, rotMφ pbar.θ₂ pbar.φ₂ P]
 
 lemma Differentiable.rotM_outer (P : ℝ³) :
-    Differentiable ℝ fun (x : ℝ²) => (rotM (x 0) (x 1)) P := by
-  rw [differentiable_piLp]
-  intro i
-  fin_cases i <;> simp [rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+    Differentiable ℝ fun (x : ℝ²) => (rotM (x 0) (x 1)) P :=
+  differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const P)
 
 @[simp]
 lemma rotM'_single_0 (pbar : Pose ℝ) (P : ℝ³) :

--- a/Noperthedron/Global/RotationPartials/Rotproj.lean
+++ b/Noperthedron/Global/RotationPartials/Rotproj.lean
@@ -27,9 +27,8 @@ private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 lemma Differentiable.rotprojRM (S : ℝ³) :
     Differentiable ℝ fun (x : ℝ³)  ↦ (_root_.rotprojRM (x 1) (x 2) (x 0)) S := by
   unfold _root_.rotprojRM
-  rw [differentiable_piLp]
-  intro i
-  fin_cases i <;> simp [rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+  exact differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))
 
 @[fun_prop]
 lemma Differentiable.rotproj_inner (S : ℝ³) (w : ℝ²) : Differentiable ℝ (rotproj_inner S w) :=

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -27,25 +27,65 @@ private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 /-!
 ## DifferentiableAt lemmas for rotation compositions
 
-These lemmas eliminate the repeated `rw [differentiableAt_piLp]; intro i; fin_cases i ...`
-pattern that appears ~30+ times in third_partial_inner_rotM_inner.
+Compositional `@[fun_prop]` core lemmas prove joint differentiability of each
+rotation map once, at the matrix-entry level; the `differentiableAt_*` family below
+(used ~30+ times in third_partial_inner_rotM_inner) then follows by `fun_prop`.
 -/
+
+/-- Joint differentiability of `rotM` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotM_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {f g : E → ℝ} {h : E → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotM (f x) (g x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotM, rotM_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- Joint differentiability of `rotMθ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθ_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {f g : E → ℝ} {h : E → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθ (f x) (g x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotMθ, rotMθ_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_three]; fun_prop)
+
+/-- Joint differentiability of `rotMφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMφ_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {f g : E → ℝ} {h : E → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMφ (f x) (g x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotMφ, rotMφ_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_three]; try fun_prop)
+
+/-- Joint differentiability of `rotR` in the angle and the vector. -/
+@[fun_prop]
+lemma differentiable_rotR_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {f : E → ℝ} {h : E → ℝ²}
+    (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotR (f x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotR, rotR_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_two]; fun_prop)
+
+/-- Joint differentiability of `rotR'` in the angle and the vector. -/
+@[fun_prop]
+lemma differentiable_rotR'_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {f : E → ℝ} {h : E → ℝ²}
+    (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotR' (f x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotR', rotR'_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_two]; fun_prop)
 
 /-- DifferentiableAt for rotMθ (outer, E 2) -/
 lemma differentiableAt_rotMθ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθ, rotMθ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMφ (outer, E 2) -/
 lemma differentiableAt_rotMφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMφ, rotMφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMθθ (outer, E 2) -/
 lemma differentiableAt_rotMθθ_outer (S : ℝ³) (y : E 2) :
@@ -74,45 +114,39 @@ lemma differentiableAt_rotMφφ_outer (S : ℝ³) (y : E 2) :
 
 /-- DifferentiableAt for rotR ∘ rotM -/
 lemma differentiableAt_rotR_rotM (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotM, rotM_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR' ∘ rotM -/
 lemma differentiableAt_rotR'_rotM (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotM, rotM_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθ -/
 lemma differentiableAt_rotR_rotMθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθ, rotMθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMφ -/
 lemma differentiableAt_rotR_rotMφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMφ, rotMφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR' ∘ rotMθ -/
 lemma differentiableAt_rotR'_rotMθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMθ, rotMθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR' ∘ rotMφ -/
 lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMφ, rotMφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθθ -/
 lemma differentiableAt_rotR_rotMθθ (S : ℝ³) (y : E 3) :

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -34,8 +34,8 @@ rotation map once, at the matrix-entry level; the `differentiableAt_*` family be
 
 /-- Joint differentiability of `rotM` in the two angles and the vector. -/
 @[fun_prop]
-lemma differentiable_rotM_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {f g : E → ℝ} {h : E → ℝ³}
+lemma differentiable_rotM_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
     (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
     Differentiable ℝ fun x => rotM (f x) (g x) (h x) := by
   rw [differentiable_piLp]; intro i
@@ -43,8 +43,8 @@ lemma differentiable_rotM_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace �
 
 /-- Joint differentiability of `rotMθ` in the two angles and the vector. -/
 @[fun_prop]
-lemma differentiable_rotMθ_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {f g : E → ℝ} {h : E → ℝ³}
+lemma differentiable_rotMθ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
     (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
     Differentiable ℝ fun x => rotMθ (f x) (g x) (h x) := by
   rw [differentiable_piLp]; intro i
@@ -52,8 +52,8 @@ lemma differentiable_rotMθ_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace
 
 /-- Joint differentiability of `rotMφ` in the two angles and the vector. -/
 @[fun_prop]
-lemma differentiable_rotMφ_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {f g : E → ℝ} {h : E → ℝ³}
+lemma differentiable_rotMφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
     (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
     Differentiable ℝ fun x => rotMφ (f x) (g x) (h x) := by
   rw [differentiable_piLp]; intro i
@@ -61,8 +61,8 @@ lemma differentiable_rotMφ_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace
 
 /-- Joint differentiability of `rotR` in the angle and the vector. -/
 @[fun_prop]
-lemma differentiable_rotR_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {f : E → ℝ} {h : E → ℝ²}
+lemma differentiable_rotR_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f : X → ℝ} {h : X → ℝ²}
     (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
     Differentiable ℝ fun x => rotR (f x) (h x) := by
   rw [differentiable_piLp]; intro i
@@ -70,8 +70,8 @@ lemma differentiable_rotR_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace �
 
 /-- Joint differentiability of `rotR'` in the angle and the vector. -/
 @[fun_prop]
-lemma differentiable_rotR'_comp {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {f : E → ℝ} {h : E → ℝ²}
+lemma differentiable_rotR'_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f : X → ℝ} {h : X → ℝ²}
     (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
     Differentiable ℝ fun x => rotR' (f x) (h x) := by
   rw [differentiable_piLp]; intro i
@@ -187,10 +187,7 @@ The result is: `fderiv (⟪f·, w⟫) y d = ⟪fderiv f y d, w⟫` when `w` is c
 lemma fderiv_inner_const {n : ℕ} (f : E n → ℝ²) (w : ℝ²) (y : E n) (d : E n)
     (hf : DifferentiableAt ℝ f y) :
     (fderiv ℝ (fun z => ⟪f z, w⟫) y) d = ⟪(fderiv ℝ f y) d, w⟫ := by
-  have hInner := fderiv_inner_apply ℝ hf (differentiableAt_const w) d
-  rw [(hasFDerivAt_const w y).fderiv] at hInner
-  simp only [zero_apply, inner_zero_right, zero_add] at hInner
-  exact hInner
+  simpa [(hasFDerivAt_const w y).fderiv] using fderiv_inner_apply ℝ hf (differentiableAt_const w) d
 
 /-- |⟪A S, w⟫ / ‖S‖| ≤ 1 when ‖A‖ ≤ 1 and ‖w‖ = 1 -/
 lemma inner_bound_helper (A : ℝ³ →L[ℝ] ℝ²) (S : ℝ³) (w : ℝ²)
@@ -271,10 +268,8 @@ These factor out the lineDeriv_eq_fderiv + HasLineDerivAt pattern.
 
 /-- Helper for deriv → fderiv composition pattern -/
 lemma hasDerivAt_comp_add (f : ℝ → ℝ²) (f' : ℝ²) (a : ℝ) (hf : HasDerivAt f f' a) :
-    HasDerivAt (fun t => f (a + t)) f' 0 := by
-  have hid : HasDerivAt (fun t : ℝ => a + t) 1 0 := by simpa using (hasDerivAt_id 0).const_add a
-  have hf' : HasDerivAt f f' (a + 0) := by simp only [add_zero]; exact hf
-  exact HasDerivAt.comp_const_add a 0 hf'
+    HasDerivAt (fun t => f (a + t)) f' 0 :=
+  HasDerivAt.comp_const_add a 0 (by simpa using hf)
 
 /-- For a differentiable function, the `fderiv` along a basis direction can be computed
 as the one-variable derivative along the line through that direction. -/

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -59,6 +59,33 @@ lemma differentiable_rotMφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace
   rw [differentiable_piLp]; intro i
   fin_cases i <;> (simp [rotMφ, rotMφ_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_three]; try fun_prop)
 
+/-- Joint differentiability of `rotMθθ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθθ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθθ (f x) (g x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotMθθ, rotMθθ_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_three]; try fun_prop)
+
+/-- Joint differentiability of `rotMθφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθφ (f x) (g x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotMθφ, rotMθφ_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_three]; try fun_prop)
+
+/-- Joint differentiability of `rotMφφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMφφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMφφ (f x) (g x) (h x) := by
+  rw [differentiable_piLp]; intro i
+  fin_cases i <;> (simp [rotMφφ, rotMφφ_mat, Matrix.toLpLin_apply, dotProduct, Fin.sum_univ_three]; try fun_prop)
+
 /-- Joint differentiability of `rotR` in the angle and the vector. -/
 @[fun_prop]
 lemma differentiable_rotR_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
@@ -89,28 +116,18 @@ lemma differentiableAt_rotMφ_outer (S : ℝ³) (y : E 2) :
 
 /-- DifferentiableAt for rotMθθ (outer, E 2) -/
 lemma differentiableAt_rotMθθ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθθ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθθ, rotMθθ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 2 => rotMθθ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθθ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMθφ (outer, E 2) -/
 lemma differentiableAt_rotMθφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθφ, rotMθφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMθφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMφφ (outer, E 2) -/
 lemma differentiableAt_rotMφφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMφφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMφφ, rotMφφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMφφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMφφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotM -/
 lemma differentiableAt_rotR_rotM (S : ℝ³) (y : E 3) :
@@ -150,24 +167,21 @@ lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
 
 /-- DifferentiableAt for rotR ∘ rotMθθ -/
 lemma differentiableAt_rotR_rotMθθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθθ, rotMθθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθφ -/
 lemma differentiableAt_rotR_rotMθφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθφ, rotMθφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMφφ -/
 lemma differentiableAt_rotR_rotMφφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMφφ, rotMφφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMφφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-!
 ## Inner product fderiv helper


### PR DESCRIPTION
**Stacked on #59 — that PR must merge first.** This branch includes #59's two commits; only the top commit (`26f00f8`, "reuse fun_prop cores in rotM_outer and rotprojRM differentiability") is new here. After #59 lands, this rebases to a single-commit PR.

## What

Reuses the compositional `@[fun_prop]` core lemmas from #59 to replace the two remaining expensive trig-unfold differentiability proofs:

- `Differentiable.rotM_outer` (`Global/RotationPartials/RotMOuter.lean`) — was a `differentiable_piLp` + `fin_cases` + `simp`/`fun_prop` unfold; now a one-line application of `differentiable_rotM_comp`.
- `Differentiable.rotprojRM` (`Global/RotationPartials/Rotproj.lean`) — same, via `differentiable_rotR_comp ∘ differentiable_rotM_comp` after `unfold rotprojRM`.

Statements unchanged.

## Measurements

- `Differentiable.rotM_outer`: 3.2s → below the 300ms profiler threshold.
- `Differentiable.rotprojRM`: 4.4s → 0.6s.

## Not converted (deliberately)

- `rotation_partials_exist` / `rotation_partials_exist_outer` (`Global/Definitions.lean`): these are `ContDiff ℝ 2` statements — a different property class than the `Differentiable` cores — and cost only ~1s each.
- `HasFDerivAt.rotproj_inner` (1.9s): not a differentiability-unfold; different proof shape.

## Validation

- Full `lake build` green; `lake build constructValidTable benchRows` green.
- Sorry count unchanged.
