### PR TITLE
Perf: factor rotation regularity through generic matrix transport

### DIFF
--- a/Noperthedron/Global/RotationDerivs.lean
+++ b/Noperthedron/Global/RotationDerivs.lean
@@ -1,5 +1,7 @@
 import Mathlib.Algebra.Lie.OfAssociative
 import Mathlib.Analysis.Calculus.Deriv.Prod
+import Mathlib.Analysis.Calculus.FDeriv.WithLp
+import Mathlib.Analysis.Calculus.ContDiff.WithLp
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 import Noperthedron.Basic
 
@@ -32,6 +34,33 @@ lemma hasDerivAt_toEuclideanLin_apply {m n : ℕ} {M M' : ℝ → Matrix (Fin m)
     (WithLp.linearEquiv 2 ℝ (Fin m → ℝ)).symm.toContinuousLinearMap
   simpa [lpmap, Matrix.toLpLin_apply, LinearMap.coe_toContinuousLinearMap'] using
     HasDerivAt.clm_apply (hasDerivAt_const t lpmap) hpi
+
+/-- Transport `Differentiable` through application of a matrix path to a varying vector:
+if every entry of `M` is differentiable in the parameter, so is
+`fun x => (M x).toEuclideanLin.toContinuousLinearMap (v x)` for differentiable `v`. -/
+lemma differentiable_toEuclideanLin_apply
+    {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] {m n : ℕ}
+    {M : X → Matrix (Fin m) (Fin n) ℝ} {v : X → EuclideanSpace ℝ (Fin n)}
+    (hM : ∀ i j, Differentiable ℝ fun x => M x i j) (hv : Differentiable ℝ v) :
+    Differentiable ℝ fun x => (M x).toEuclideanLin.toContinuousLinearMap (v x) := by
+  rw [differentiable_piLp]
+  intro i
+  simp only [Matrix.toLpLin_apply, LinearMap.coe_toContinuousLinearMap', Matrix.mulVec,
+    dotProduct]
+  fun_prop
+
+/-- Transport `ContDiff` through application of a matrix path to a varying vector,
+analogously to `differentiable_toEuclideanLin_apply`. -/
+lemma contDiff_toEuclideanLin_apply
+    {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] {m n k : ℕ}
+    {M : X → Matrix (Fin m) (Fin n) ℝ} {v : X → EuclideanSpace ℝ (Fin n)}
+    (hM : ∀ i j, ContDiff ℝ k fun x => M x i j) (hv : ContDiff ℝ k v) :
+    ContDiff ℝ k fun x => (M x).toEuclideanLin.toContinuousLinearMap (v x) := by
+  rw [contDiff_piLp]
+  intro i
+  simp only [Matrix.toLpLin_apply, LinearMap.coe_toContinuousLinearMap', Matrix.mulVec,
+    dotProduct]
+  fun_prop
 
 theorem HasDerivAt_rotR (α : ℝ) (v : ℝ²) :
     HasDerivAt (rotR · v) (rotR' α v) α := by

--- a/Noperthedron/Global/RotationPartials/RotMOuter.lean
+++ b/Noperthedron/Global/RotationPartials/RotMOuter.lean
@@ -23,17 +23,6 @@ namespace GlobalTheorem
 
 private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 
-private lemma outerParams_0 (pbar : Pose ℝ) : pbar.outerParams.ofLp 0 = pbar.θ₂ := by simp [Pose.outerParams]
-private lemma outerParams_1 (pbar : Pose ℝ) : pbar.outerParams.ofLp 1 = pbar.φ₂ := by simp [Pose.outerParams]
-
-/-- Coordinate extraction in `E 2`: direction `e_i`, same coordinate (moves). -/
-private lemma coord2_same (i : Fin 2) (y : E 2) (t : ℝ) :
-    (y + t • (EuclideanSpace.single i 1 : E 2)).ofLp i = y.ofLp i + t := by simp
-
-/-- Coordinate extraction in `E 2`: direction `e_i`, different coordinate (fixed). -/
-private lemma coord2_other {i j : Fin 2} (hij : j ≠ i) (y : E 2) (t : ℝ) :
-    (y + t • (EuclideanSpace.single i 1 : E 2)).ofLp j = y.ofLp j := by simp [hij]
-
 /-- The fderiv of rotM applied to a fixed vector P, as a function of (θ, φ).
 Columns: [rotMθ, rotMφ]. -/
 noncomputable

--- a/Noperthedron/Global/RotationPartials/RotMOuter.lean
+++ b/Noperthedron/Global/RotationPartials/RotMOuter.lean
@@ -41,10 +41,8 @@ def rotM' (pbar : Pose ℝ) (P : ℝ³) : ℝ² →L[ℝ] ℝ² :=
   columnsCLM ![rotMθ pbar.θ₂ pbar.φ₂ P, rotMφ pbar.θ₂ pbar.φ₂ P]
 
 lemma Differentiable.rotM_outer (P : ℝ³) :
-    Differentiable ℝ fun (x : ℝ²) => (rotM (x 0) (x 1)) P := by
-  rw [differentiable_piLp]
-  intro i
-  fin_cases i <;> simp [rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+    Differentiable ℝ fun (x : ℝ²) => (rotM (x 0) (x 1)) P :=
+  differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const P)
 
 @[simp]
 lemma rotM'_single_0 (pbar : Pose ℝ) (P : ℝ³) :
@@ -58,14 +56,12 @@ lemma rotM'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotM_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotM (x.ofLp 0) (x.ofLp 1)) P) (rotM' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (Differentiable.rotM_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotM_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotM_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotM', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotM θ φ P) pbar.outerParams
+      (rotMθ pbar.θ₂ pbar.φ₂ P) (rotMφ pbar.θ₂ pbar.φ₂ P)
+      (Differentiable.rotM_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotM_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotM_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMθ: columns are [rotMθθ, rotMθφ]. -/
 noncomputable def rotMθ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -83,14 +79,12 @@ lemma rotMθ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMθ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMθ (x.ofLp 0) (x.ofLp 1)) P) (rotMθ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMθ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMθ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMθ θ φ P) pbar.outerParams
+      (rotMθθ pbar.θ₂ pbar.φ₂ P) (rotMθφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMθ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMφ: columns are [rotMθφ, rotMφφ]. -/
 noncomputable def rotMφ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -108,14 +102,12 @@ lemma rotMφ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMφ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMφ (x.ofLp 0) (x.ofLp 1)) P) (rotMφ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMφ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMφ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMφ θ φ P) pbar.outerParams
+      (rotMθφ pbar.θ₂ pbar.φ₂ P) (rotMφφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMφ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMθθ: columns are [-rotMθ, rotMθθφ] (Mθθθ = -Mθ). -/
 noncomputable def rotMθθ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -133,14 +125,12 @@ lemma rotMθθ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMθθ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMθθ (x.ofLp 0) (x.ofLp 1)) P) (rotMθθ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMθθ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθθ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθθ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMθθ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMθθ θ φ P) pbar.outerParams
+      (-(rotMθ pbar.θ₂ pbar.φ₂ P)) (rotMθθφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMθθ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθθ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθθ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMθφ: columns are [rotMθθφ, rotMθφφ]. -/
 noncomputable def rotMθφ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -158,14 +148,12 @@ lemma rotMθφ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMθφ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMθφ (x.ofLp 0) (x.ofLp 1)) P) (rotMθφ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMθφ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθφ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθφ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMθφ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMθφ θ φ P) pbar.outerParams
+      (rotMθθφ pbar.θ₂ pbar.φ₂ P) (rotMθφφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMθφ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθφ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθφ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMφφ: columns are [rotMθφφ, -rotMφ] (Mφφφ = -Mφ). -/
 noncomputable def rotMφφ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -183,13 +171,11 @@ lemma rotMφφ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMφφ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMφφ (x.ofLp 0) (x.ofLp 1)) P) (rotMφφ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMφφ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφφ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφφ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMφφ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMφφ θ φ P) pbar.outerParams
+      (rotMθφφ pbar.θ₂ pbar.φ₂ P) (-(rotMφ pbar.θ₂ pbar.φ₂ P))
+      (differentiableAt_rotMφφ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφφ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφφ_φ pbar.θ₂ pbar.φ₂ P)
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/Rotproj.lean
+++ b/Noperthedron/Global/RotationPartials/Rotproj.lean
@@ -27,9 +27,8 @@ private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 lemma Differentiable.rotprojRM (S : ℝ³) :
     Differentiable ℝ fun (x : ℝ³)  ↦ (_root_.rotprojRM (x 1) (x 2) (x 0)) S := by
   unfold _root_.rotprojRM
-  rw [differentiable_piLp]
-  intro i
-  fin_cases i <;> simp [rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+  exact differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))
 
 @[fun_prop]
 lemma Differentiable.rotproj_inner (S : ℝ³) (w : ℝ²) : Differentiable ℝ (rotproj_inner S w) :=
@@ -71,27 +70,26 @@ lemma rotprojRM'_single_2 (pbar : Pose ℝ) (S : ℝ³) :
 
 lemma HasFDerivAt.rotproj_inner (pbar : Pose ℝ) (S : ℝ³) (w : ℝ²) :
     HasFDerivAt (rotproj_inner S w) (rotproj_inner' pbar S w) pbar.innerParams := by
-  have hdiff : DifferentiableAt ℝ
-      (fun x : ℝ³ => rotR (x.ofLp 0) (rotM (x.ofLp 1) (x.ofLp 2) S)) pbar.innerParams :=
-    differentiableAt_rotR_rotM S pbar.innerParams
-  -- The derivative is a linear map determined by its values on the standard basis,
-  -- and those values were already computed in `FDerivHelpers`.
+  -- The derivative is the column map of the three partial derivatives.
   have z1 : HasFDerivAt (fun x => (rotprojRM (x.ofLp 1) (x.ofLp 2) (x.ofLp 0)) S)
       (rotprojRM' pbar S) pbar.innerParams := by
-    have h0 : pbar.innerParams.ofLp 0 = pbar.α := by simp [Pose.innerParams]
-    have h1 : pbar.innerParams.ofLp 1 = pbar.θ₁ := by simp [Pose.innerParams]
-    have h2 : pbar.innerParams.ofLp 2 = pbar.φ₁ := by simp [Pose.innerParams]
-    have hfd : fderiv ℝ (fun x : ℝ³ => rotR (x.ofLp 0) (rotM (x.ofLp 1) (x.ofLp 2) S))
-        pbar.innerParams = rotprojRM' pbar S := by
-      refine ContinuousLinearMap.coe_injective
-        ((EuclideanSpace.basisFun (Fin 3) ℝ).toBasis.ext fun i => ?_)
-      fin_cases i <;>
-        simp only [OrthonormalBasis.coe_toBasis, EuclideanSpace.basisFun_apply,
-          ContinuousLinearMap.coe_coe, Fin.zero_eta, Fin.mk_one, Fin.reduceFinMk]
-      · rw [fderiv_rotR_rotM_in_e0 S _ hdiff, rotprojRM'_single_0, h0, h1, h2]; rfl
-      · rw [fderiv_rotR_rotM_in_e1 S _ hdiff, rotprojRM'_single_1, h0, h1, h2]; rfl
-      · rw [fderiv_rotR_rotM_in_e2 S _ hdiff, rotprojRM'_single_2, h0, h1, h2]; rfl
-    exact hfd ▸ hdiff.hasFDerivAt
+    have zplain := hasFDerivAt_three_params
+      (fun α θ φ => rotR α (rotM θ φ S)) pbar.innerParams
+      (rotR' pbar.α (rotM pbar.θ₁ pbar.φ₁ S))
+      (rotR pbar.α (rotMθ pbar.θ₁ pbar.φ₁ S))
+      (rotR pbar.α (rotMφ pbar.θ₁ pbar.φ₁ S))
+      (differentiableAt_rotR_rotM S pbar.innerParams)
+      (by simpa [Pose.innerParams] using HasDerivAt_rotR pbar.α (rotM pbar.θ₁ pbar.φ₁ S))
+      (by
+        simpa [Pose.innerParams, Function.comp_def] using
+          (ContinuousLinearMap.hasFDerivAt (rotR pbar.α)).comp_hasDerivAt pbar.θ₁
+            (hasDerivAt_rotM_θ pbar.θ₁ pbar.φ₁ S))
+      (by
+        simpa [Pose.innerParams, Function.comp_def] using
+          (ContinuousLinearMap.hasFDerivAt (rotR pbar.α)).comp_hasDerivAt pbar.φ₁
+            (hasDerivAt_rotM_φ pbar.θ₁ pbar.φ₁ S))
+    simpa [rotprojRM, rotprojRM', Pose.innerParams, Pose.rotR, Pose.rotR',
+      Pose.rotM₁, Pose.rotM₁θ, Pose.rotM₁φ] using zplain
 
   have step : (rotproj_inner' pbar S w) = ((fderivInnerCLM ℝ
       ((rotprojRM (pbar.innerParams.ofLp 1) (pbar.innerParams.ofLp 2) (pbar.innerParams.ofLp 0)) S, w)).comp

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -334,6 +334,33 @@ lemma hasFDerivAt_of_partials {n : ℕ} {f : E n → ℝ²} {y : E n} (cols : Fi
     exact fderiv_single_eq hdiff (h i)
   exact hfd ▸ hdiff.hasFDerivAt
 
+/-- `HasFDerivAt` constructor for a two-parameter family: the Fréchet derivative
+is the column map of the two partial derivatives. -/
+lemma hasFDerivAt_two_params (F : ℝ → ℝ → ℝ²) (y : E 2) (Fθ Fφ : ℝ²)
+    (hdiff : DifferentiableAt ℝ (fun x : E 2 => F (x.ofLp 0) (x.ofLp 1)) y)
+    (hθ : HasDerivAt (fun t => F t (y.ofLp 1)) Fθ (y.ofLp 0))
+    (hφ : HasDerivAt (fun t => F (y.ofLp 0) t) Fφ (y.ofLp 1)) :
+    HasFDerivAt (fun x : E 2 => F (x.ofLp 0) (x.ofLp 1)) (columnsCLM ![Fθ, Fφ]) y := by
+  refine hasFDerivAt_of_partials _ hdiff fun i => ?_
+  fin_cases i
+  · simpa using hasDerivAt_comp_add _ _ _ hθ
+  · simpa using hasDerivAt_comp_add _ _ _ hφ
+
+/-- `HasFDerivAt` constructor for a three-parameter family: the Fréchet derivative
+is the column map of the three partial derivatives. -/
+lemma hasFDerivAt_three_params (F : ℝ → ℝ → ℝ → ℝ²) (y : E 3) (F₀ F₁ F₂ : ℝ²)
+    (hdiff : DifferentiableAt ℝ (fun x : E 3 => F (x.ofLp 0) (x.ofLp 1) (x.ofLp 2)) y)
+    (h₀ : HasDerivAt (fun t => F t (y.ofLp 1) (y.ofLp 2)) F₀ (y.ofLp 0))
+    (h₁ : HasDerivAt (fun t => F (y.ofLp 0) t (y.ofLp 2)) F₁ (y.ofLp 1))
+    (h₂ : HasDerivAt (fun t => F (y.ofLp 0) (y.ofLp 1) t) F₂ (y.ofLp 2)) :
+    HasFDerivAt (fun x : E 3 => F (x.ofLp 0) (x.ofLp 1) (x.ofLp 2))
+      (columnsCLM ![F₀, F₁, F₂]) y := by
+  refine hasFDerivAt_of_partials _ hdiff fun i => ?_
+  fin_cases i
+  · simpa using hasDerivAt_comp_add _ _ _ h₀
+  · simpa using hasDerivAt_comp_add _ _ _ h₁
+  · simpa using hasDerivAt_comp_add _ _ _ h₂
+
 /-- fderiv of a composition `z ↦ X (z 0) (N (z 1) (z 2) S)` in direction e₁,
 given the derivative of the matrix family `N` in its first (θ) argument.
 The head `X` is arbitrary since e₁ does not move the `z 0` coordinate. -/

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -27,113 +27,171 @@ private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 /-!
 ## DifferentiableAt lemmas for rotation compositions
 
-These lemmas eliminate the repeated `rw [differentiableAt_piLp]; intro i; fin_cases i ...`
-pattern that appears ~30+ times in third_partial_inner_rotM_inner.
+Each rotation map is a matrix path applied to a vector, so joint differentiability
+in the angles and the vector follows from `differentiable_toEuclideanLin_apply`
+plus entrywise trigonometric facts. The compositional `@[fun_prop]` cores below
+prove this once per map; the `differentiableAt_*` family (used ~30+ times in
+`third_partial_inner_rotM_inner`) then consists of one-line applications.
 -/
+
+/-- Joint differentiability of `rotM` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotM_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotM (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotM_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotM_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMθ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMθ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMθ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMφ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMφ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMφ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMθθ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθθ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθθ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMθθ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMθθ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMθφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθφ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMθφ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMθφ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMφφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMφφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMφφ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMφφ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMφφ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotR` in the angle and the vector. -/
+@[fun_prop]
+lemma differentiable_rotR_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f : X → ℝ} {h : X → ℝ²}
+    (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotR (f x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotR_mat (f x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotR_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotR'` in the angle and the vector. -/
+@[fun_prop]
+lemma differentiable_rotR'_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f : X → ℝ} {h : X → ℝ²}
+    (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotR' (f x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotR'_mat (f x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotR'_mat] <;> fun_prop
 
 /-- DifferentiableAt for rotMθ (outer, E 2) -/
 lemma differentiableAt_rotMθ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθ, rotMθ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMφ (outer, E 2) -/
 lemma differentiableAt_rotMφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMφ, rotMφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMθθ (outer, E 2) -/
 lemma differentiableAt_rotMθθ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθθ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθθ, rotMθθ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 2 => rotMθθ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθθ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMθφ (outer, E 2) -/
 lemma differentiableAt_rotMθφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθφ, rotMθφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMθφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMφφ (outer, E 2) -/
 lemma differentiableAt_rotMφφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMφφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMφφ, rotMφφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMφφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMφφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotM -/
 lemma differentiableAt_rotR_rotM (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotM, rotM_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
-
-/-- DifferentiableAt for rotR' ∘ rotM -/
-lemma differentiableAt_rotR'_rotM (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotM, rotM_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθ -/
 lemma differentiableAt_rotR_rotMθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθ, rotMθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMφ -/
 lemma differentiableAt_rotR_rotMφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMφ, rotMφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
-
-/-- DifferentiableAt for rotR' ∘ rotMθ -/
-lemma differentiableAt_rotR'_rotMθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMθ, rotMθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
-
-/-- DifferentiableAt for rotR' ∘ rotMφ -/
-lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMφ, rotMφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθθ -/
 lemma differentiableAt_rotR_rotMθθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθθ, rotMθθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθφ -/
 lemma differentiableAt_rotR_rotMθφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθφ, rotMθφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMφφ -/
 lemma differentiableAt_rotR_rotMφφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMφφ, rotMφφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMφφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
+
+/-- DifferentiableAt for rotR' ∘ rotM -/
+lemma differentiableAt_rotR'_rotM (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
+
+/-- DifferentiableAt for rotR' ∘ rotMθ -/
+lemma differentiableAt_rotR'_rotMθ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
+
+/-- DifferentiableAt for rotR' ∘ rotMφ -/
+lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-!
 ## Inner product fderiv helper


### PR DESCRIPTION
Supersedes the main regularity/performance work in drafts #59 and #61. This branch is based directly on current `main` and is independent of both.

## What

Two recurring elaboration costs are removed:

1. repeated coordinate expansion of matrix–vector products when proving differentiability, and
2. repeated coordinate/basis reconstruction when proving explicit Fréchet derivatives.

All existing lemma statements are unchanged. Three commits.

### 1. Generic matrix-application transport

`RotationDerivs.lean` already contains `hasDerivAt_toEuclideanLin_apply`, which differentiates a matrix path applied to a fixed vector entrywise. This adds the corresponding `Differentiable` and finite-order `ContDiff` transports beside it:

```lean
lemma differentiable_toEuclideanLin_apply …
    (hM : ∀ i j, Differentiable ℝ fun x => M x i j) (hv : Differentiable ℝ v) :
    Differentiable ℝ fun x => (M x).toEuclideanLin.toContinuousLinearMap (v x)

lemma contDiff_toEuclideanLin_apply …  -- ContDiff ℝ k version
```

Every rotation map here is a matrix family applied to a vector, so the generic lemma pays the matrix–vector transport cost once; each rotation-specific proof only checks differentiability of its matrix entries. Eight compositional `@[fun_prop]` cores are proved this way (`differentiable_rotM_comp`, `differentiable_rotMθ_comp`, `differentiable_rotMφ_comp`, `differentiable_rotMθθ_comp`, `differentiable_rotMθφ_comp`, `differentiable_rotMφφ_comp`, `differentiable_rotR_comp`, `differentiable_rotR'_comp`), and all 14 `differentiableAt_*` lemmas in `SecondPartialHelpers.lean` — with roughly 30 downstream uses in the third-partial development — become small compositional terms. The `ContDiff` transport completes the parallel regularity API; the consumers changed in this PR use the `Differentiable` version.

### 2. Parameter-family `HasFDerivAt` constructors

`hasFDerivAt_two_params` and `hasFDerivAt_three_params` wrap `hasFDerivAt_of_partials`: given the coordinatewise `HasDerivAt` facts, the Fréchet derivative is the corresponding column map.

The six `HasFDerivAt.rotM*_outer` proofs in `RotMOuter.lean` replace their repeated `fin_cases`/coordinate-simplification scripts with one constructor call each, and the same abstraction replaces the basis-extensionality/`fderiv` reconstruction of `z1` inside `HasFDerivAt.rotproj_inner` (`Rotproj.lean`). `Differentiable.rotM_outer` and `Differentiable.rotprojRM` also reduce to direct applications of the cores.

### 3. Cleanup

The coordinate helpers `outerParams_0/1` and `coord2_same/other` in `RotMOuter.lean`, made unused by the constructors, are removed.

## Performance

Representative module build times on the same machine:

| module | before | after |
|---|---|---|
| SecondPartialHelpers | ~30s | 18s |
| RotMOuter | 7.0s | 5.5s |
| Rotproj | 7.9s | 6.9s |

The eight cores elaborate in ~0.6–1.1s each. For comparison, the core implementation in draft #59 took ~2–3.7s per map, and the original coordinate-expanded consumer proofs took ~2–6s each. The 14 consumers here elaborate in ~0.5s each.

## Relation to #59 and #61

This covers the intended regularity API and consumer refactors of #59 and #61 independently, via the cheaper generic transport layer; if this lands, both drafts can be closed. The two incidental proof golfs in #59 (`fderiv_inner_const`, `hasDerivAt_comp_add`) are orthogonal and can be recovered separately if still desired.

## Validation

- Full `lake build` passes on current `main`; `lake build constructValidTable benchRows` passes.
- Zero sorries on the branch.
- All existing lemma statements are unchanged; the only new public names are the two transport lemmas, eight compositional cores, and two parameter-family constructors.
