### PR TITLE
Refactor: symbolic algebra for rotation-derivative operators (stacked on #65)

### DIFF
--- a/Noperthedron.lean
+++ b/Noperthedron.lean
@@ -25,6 +25,7 @@ import Noperthedron.Global.RotationPartials.Rotproj
 import Noperthedron.Global.RotationPartials.SecondPartialInner
 import Noperthedron.Global.RotationPartials.SecondPartialOuter
 import Noperthedron.Global.SecondPartialHelpers
+import Noperthedron.Global.SymbolicRotationDerivs
 import Noperthedron.Local
 import Noperthedron.Local.Congruent
 import Noperthedron.Local.Coss

--- a/Noperthedron/Global/FDerivHelpers.lean
+++ b/Noperthedron/Global/FDerivHelpers.lean
@@ -30,36 +30,6 @@ namespace GlobalTheorem
 
 private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 
--- Derivative of rotR' with respect to α: d/dα(rotR' α v) = -rotR α v
--- This is needed for the second derivative ∂²/∂α² of rotproj_inner
-lemma HasDerivAt_rotR' (α : ℝ) (v : ℝ²) :
-    HasDerivAt (rotR' · v) (-(rotR α v)) α := by
-  have h := hasDerivAt_toEuclideanLin_apply (M := rotR'_mat) (M' := (-rotR_mat ·)) (t := α)
-    (fun i j => ?_) v
-  · have e : ((-rotR_mat α).toEuclideanLin).toContinuousLinearMap v = -(rotR α v) := by
-      ext i
-      fin_cases i <;>
-        simp only [rotR, rotR_mat, AddChar.coe_mk, Matrix.neg_of, Matrix.neg_cons, neg_neg,
-          Matrix.neg_empty, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply,
-          Matrix.cons_mulVec, Matrix.cons_dotProduct, Matrix.vecHead, Matrix.vecTail,
-          Fin.isValue, neg_mul, Nat.succ_eq_add_one, Nat.reduceAdd, Function.comp_apply,
-          Fin.succ_zero_eq_one, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
-          Fin.zero_eta, Fin.mk_one, Matrix.cons_val_zero, Matrix.cons_val_one,
-          Matrix.cons_val_fin_one, PiLp.neg_apply, neg_add_rev] <;>
-        ring
-    rw [e] at h
-    exact h
-  · fin_cases i <;> fin_cases j <;>
-      simp only [rotR'_mat, rotR_mat, Matrix.neg_apply, Matrix.of_apply, Matrix.cons_val',
-        Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one, Matrix.empty_val',
-        Fin.zero_eta, Fin.isValue, Fin.mk_one, neg_neg]
-    · exact (Real.hasDerivAt_sin α).neg
-    · have h := (Real.hasDerivAt_cos α).neg
-      rw [neg_neg] at h
-      exact h
-    · exact Real.hasDerivAt_cos α
-    · exact (Real.hasDerivAt_sin α).neg
-
 /-- fderiv of rotR with any M in direction e₀ gives rotR' -/
 lemma fderiv_rotR_any_M_in_e0 (S : Euc(3)) (y : E 3) (M : ℝ → ℝ → ℝ³ →L[ℝ] ℝ²)
     (hf_diff : DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (M (z.ofLp 1) (z.ofLp 2) S)) y) :

--- a/Noperthedron/Global/RotationDerivs.lean
+++ b/Noperthedron/Global/RotationDerivs.lean
@@ -1,5 +1,7 @@
 import Mathlib.Algebra.Lie.OfAssociative
 import Mathlib.Analysis.Calculus.Deriv.Prod
+import Mathlib.Analysis.Calculus.FDeriv.WithLp
+import Mathlib.Analysis.Calculus.ContDiff.WithLp
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 import Noperthedron.Basic
 
@@ -32,6 +34,33 @@ lemma hasDerivAt_toEuclideanLin_apply {m n : ℕ} {M M' : ℝ → Matrix (Fin m)
     (WithLp.linearEquiv 2 ℝ (Fin m → ℝ)).symm.toContinuousLinearMap
   simpa [lpmap, Matrix.toLpLin_apply, LinearMap.coe_toContinuousLinearMap'] using
     HasDerivAt.clm_apply (hasDerivAt_const t lpmap) hpi
+
+/-- Transport `Differentiable` through application of a matrix path to a varying vector:
+if every entry of `M` is differentiable in the parameter, so is
+`fun x => (M x).toEuclideanLin.toContinuousLinearMap (v x)` for differentiable `v`. -/
+lemma differentiable_toEuclideanLin_apply
+    {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] {m n : ℕ}
+    {M : X → Matrix (Fin m) (Fin n) ℝ} {v : X → EuclideanSpace ℝ (Fin n)}
+    (hM : ∀ i j, Differentiable ℝ fun x => M x i j) (hv : Differentiable ℝ v) :
+    Differentiable ℝ fun x => (M x).toEuclideanLin.toContinuousLinearMap (v x) := by
+  rw [differentiable_piLp]
+  intro i
+  simp only [Matrix.toLpLin_apply, LinearMap.coe_toContinuousLinearMap', Matrix.mulVec,
+    dotProduct]
+  fun_prop
+
+/-- Transport `ContDiff` through application of a matrix path to a varying vector,
+analogously to `differentiable_toEuclideanLin_apply`. -/
+lemma contDiff_toEuclideanLin_apply
+    {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] {m n k : ℕ}
+    {M : X → Matrix (Fin m) (Fin n) ℝ} {v : X → EuclideanSpace ℝ (Fin n)}
+    (hM : ∀ i j, ContDiff ℝ k fun x => M x i j) (hv : ContDiff ℝ k v) :
+    ContDiff ℝ k fun x => (M x).toEuclideanLin.toContinuousLinearMap (v x) := by
+  rw [contDiff_piLp]
+  intro i
+  simp only [Matrix.toLpLin_apply, LinearMap.coe_toContinuousLinearMap', Matrix.mulVec,
+    dotProduct]
+  fun_prop
 
 theorem HasDerivAt_rotR (α : ℝ) (v : ℝ²) :
     HasDerivAt (rotR · v) (rotR' α v) α := by

--- a/Noperthedron/Global/RotationDerivs.lean
+++ b/Noperthedron/Global/RotationDerivs.lean
@@ -72,6 +72,40 @@ theorem HasDerivAt_rotR (α : ℝ) (v : ℝ²) :
   · exact Real.hasDerivAt_sin α
   · exact Real.hasDerivAt_cos α
 
+namespace GlobalTheorem
+
+-- Derivative of rotR' with respect to α: d/dα(rotR' α v) = -rotR α v
+-- This is needed for the second derivative ∂²/∂α² of rotproj_inner
+lemma HasDerivAt_rotR' (α : ℝ) (v : ℝ²) :
+    HasDerivAt (rotR' · v) (-(rotR α v)) α := by
+  have h := hasDerivAt_toEuclideanLin_apply (M := rotR'_mat) (M' := (-rotR_mat ·)) (t := α)
+    (fun i j => ?_) v
+  · have e : ((-rotR_mat α).toEuclideanLin).toContinuousLinearMap v = -(rotR α v) := by
+      ext i
+      fin_cases i <;>
+        simp only [rotR, rotR_mat, AddChar.coe_mk, Matrix.neg_of, Matrix.neg_cons, neg_neg,
+          Matrix.neg_empty, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply,
+          Matrix.cons_mulVec, Matrix.cons_dotProduct, Matrix.vecHead, Matrix.vecTail,
+          Fin.isValue, neg_mul, Nat.succ_eq_add_one, Nat.reduceAdd, Function.comp_apply,
+          Fin.succ_zero_eq_one, Matrix.dotProduct_of_isEmpty, add_zero, Matrix.empty_mulVec,
+          Fin.zero_eta, Fin.mk_one, Matrix.cons_val_zero, Matrix.cons_val_one,
+          Matrix.cons_val_fin_one, PiLp.neg_apply, neg_add_rev] <;>
+        ring
+    rw [e] at h
+    exact h
+  · fin_cases i <;> fin_cases j <;>
+      simp only [rotR'_mat, rotR_mat, Matrix.neg_apply, Matrix.of_apply, Matrix.cons_val',
+        Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one, Matrix.empty_val',
+        Fin.zero_eta, Fin.isValue, Fin.mk_one, neg_neg]
+    · exact (Real.hasDerivAt_sin α).neg
+    · have h := (Real.hasDerivAt_cos α).neg
+      rw [neg_neg] at h
+      exact h
+    · exact Real.hasDerivAt_cos α
+    · exact (Real.hasDerivAt_sin α).neg
+
+end GlobalTheorem
+
 /-- Derivative of rotM w.r.t. θ gives rotMθ -/
 lemma hasDerivAt_rotM_θ (θ φ : ℝ) (S : ℝ³) :
     HasDerivAt (fun θ' => rotM θ' φ S) (rotMθ θ φ S) θ := by

--- a/Noperthedron/Global/RotationPartials/RotMOuter.lean
+++ b/Noperthedron/Global/RotationPartials/RotMOuter.lean
@@ -23,17 +23,6 @@ namespace GlobalTheorem
 
 private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 
-private lemma outerParams_0 (pbar : Pose ℝ) : pbar.outerParams.ofLp 0 = pbar.θ₂ := by simp [Pose.outerParams]
-private lemma outerParams_1 (pbar : Pose ℝ) : pbar.outerParams.ofLp 1 = pbar.φ₂ := by simp [Pose.outerParams]
-
-/-- Coordinate extraction in `E 2`: direction `e_i`, same coordinate (moves). -/
-private lemma coord2_same (i : Fin 2) (y : E 2) (t : ℝ) :
-    (y + t • (EuclideanSpace.single i 1 : E 2)).ofLp i = y.ofLp i + t := by simp
-
-/-- Coordinate extraction in `E 2`: direction `e_i`, different coordinate (fixed). -/
-private lemma coord2_other {i j : Fin 2} (hij : j ≠ i) (y : E 2) (t : ℝ) :
-    (y + t • (EuclideanSpace.single i 1 : E 2)).ofLp j = y.ofLp j := by simp [hij]
-
 /-- The fderiv of rotM applied to a fixed vector P, as a function of (θ, φ).
 Columns: [rotMθ, rotMφ]. -/
 noncomputable

--- a/Noperthedron/Global/RotationPartials/RotMOuter.lean
+++ b/Noperthedron/Global/RotationPartials/RotMOuter.lean
@@ -41,10 +41,8 @@ def rotM' (pbar : Pose ℝ) (P : ℝ³) : ℝ² →L[ℝ] ℝ² :=
   columnsCLM ![rotMθ pbar.θ₂ pbar.φ₂ P, rotMφ pbar.θ₂ pbar.φ₂ P]
 
 lemma Differentiable.rotM_outer (P : ℝ³) :
-    Differentiable ℝ fun (x : ℝ²) => (rotM (x 0) (x 1)) P := by
-  rw [differentiable_piLp]
-  intro i
-  fin_cases i <;> simp [rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+    Differentiable ℝ fun (x : ℝ²) => (rotM (x 0) (x 1)) P :=
+  differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const P)
 
 @[simp]
 lemma rotM'_single_0 (pbar : Pose ℝ) (P : ℝ³) :
@@ -58,14 +56,12 @@ lemma rotM'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotM_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotM (x.ofLp 0) (x.ofLp 1)) P) (rotM' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (Differentiable.rotM_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotM_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotM_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotM', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotM θ φ P) pbar.outerParams
+      (rotMθ pbar.θ₂ pbar.φ₂ P) (rotMφ pbar.θ₂ pbar.φ₂ P)
+      (Differentiable.rotM_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotM_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotM_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMθ: columns are [rotMθθ, rotMθφ]. -/
 noncomputable def rotMθ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -83,14 +79,12 @@ lemma rotMθ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMθ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMθ (x.ofLp 0) (x.ofLp 1)) P) (rotMθ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMθ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMθ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMθ θ φ P) pbar.outerParams
+      (rotMθθ pbar.θ₂ pbar.φ₂ P) (rotMθφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMθ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMφ: columns are [rotMθφ, rotMφφ]. -/
 noncomputable def rotMφ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -108,14 +102,12 @@ lemma rotMφ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMφ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMφ (x.ofLp 0) (x.ofLp 1)) P) (rotMφ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMφ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMφ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMφ θ φ P) pbar.outerParams
+      (rotMθφ pbar.θ₂ pbar.φ₂ P) (rotMφφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMφ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMθθ: columns are [-rotMθ, rotMθθφ] (Mθθθ = -Mθ). -/
 noncomputable def rotMθθ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -133,14 +125,12 @@ lemma rotMθθ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMθθ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMθθ (x.ofLp 0) (x.ofLp 1)) P) (rotMθθ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMθθ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθθ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθθ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMθθ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMθθ θ φ P) pbar.outerParams
+      (-(rotMθ pbar.θ₂ pbar.φ₂ P)) (rotMθθφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMθθ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθθ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθθ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMθφ: columns are [rotMθθφ, rotMθφφ]. -/
 noncomputable def rotMθφ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -158,14 +148,12 @@ lemma rotMθφ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMθφ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMθφ (x.ofLp 0) (x.ofLp 1)) P) (rotMθφ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMθφ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθφ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMθφ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMθφ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMθφ θ φ P) pbar.outerParams
+      (rotMθθφ pbar.θ₂ pbar.φ₂ P) (rotMθφφ pbar.θ₂ pbar.φ₂ P)
+      (differentiableAt_rotMθφ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθφ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMθφ_φ pbar.θ₂ pbar.φ₂ P)
 
 /-- Fréchet derivative of rotMφφ: columns are [rotMθφφ, -rotMφ] (Mφφφ = -Mφ). -/
 noncomputable def rotMφφ' (pbar : Pose ℝ) (P : ℝ³) : E 2 →L[ℝ] ℝ² :=
@@ -183,13 +171,11 @@ lemma rotMφφ'_single_1 (pbar : Pose ℝ) (P : ℝ³) :
 
 lemma HasFDerivAt.rotMφφ_outer (pbar : Pose ℝ) (P : ℝ³) :
     HasFDerivAt (fun x => (rotMφφ (x.ofLp 0) (x.ofLp 1)) P) (rotMφφ' pbar P) pbar.outerParams := by
-  refine hasFDerivAt_of_partials _ (differentiableAt_rotMφφ_outer P pbar.outerParams) fun i => ?_
-  fin_cases i
-  · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, coord2_same,
-      coord2_other (by decide : (1 : Fin 2) ≠ 0), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφφ_θ pbar.θ₂ pbar.φ₂ P)
-  · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
-      coord2_same, coord2_other (by decide : (0 : Fin 2) ≠ 1), outerParams_0, outerParams_1]
-    exact hasDerivAt_comp_add _ _ _ (hasDerivAt_rotMφφ_φ pbar.θ₂ pbar.φ₂ P)
+  simpa [rotMφφ', Pose.outerParams] using
+    hasFDerivAt_two_params (fun θ φ => rotMφφ θ φ P) pbar.outerParams
+      (rotMθφφ pbar.θ₂ pbar.φ₂ P) (-(rotMφ pbar.θ₂ pbar.φ₂ P))
+      (differentiableAt_rotMφφ_outer P pbar.outerParams)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφφ_θ pbar.θ₂ pbar.φ₂ P)
+      (by simpa [Pose.outerParams] using hasDerivAt_rotMφφ_φ pbar.θ₂ pbar.φ₂ P)
 
 end GlobalTheorem

--- a/Noperthedron/Global/RotationPartials/Rotproj.lean
+++ b/Noperthedron/Global/RotationPartials/Rotproj.lean
@@ -27,9 +27,8 @@ private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 lemma Differentiable.rotprojRM (S : ℝ³) :
     Differentiable ℝ fun (x : ℝ³)  ↦ (_root_.rotprojRM (x 1) (x 2) (x 0)) S := by
   unfold _root_.rotprojRM
-  rw [differentiable_piLp]
-  intro i
-  fin_cases i <;> simp [rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail] <;> fun_prop
+  exact differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))
 
 @[fun_prop]
 lemma Differentiable.rotproj_inner (S : ℝ³) (w : ℝ²) : Differentiable ℝ (rotproj_inner S w) :=
@@ -71,27 +70,26 @@ lemma rotprojRM'_single_2 (pbar : Pose ℝ) (S : ℝ³) :
 
 lemma HasFDerivAt.rotproj_inner (pbar : Pose ℝ) (S : ℝ³) (w : ℝ²) :
     HasFDerivAt (rotproj_inner S w) (rotproj_inner' pbar S w) pbar.innerParams := by
-  have hdiff : DifferentiableAt ℝ
-      (fun x : ℝ³ => rotR (x.ofLp 0) (rotM (x.ofLp 1) (x.ofLp 2) S)) pbar.innerParams :=
-    differentiableAt_rotR_rotM S pbar.innerParams
-  -- The derivative is a linear map determined by its values on the standard basis,
-  -- and those values were already computed in `FDerivHelpers`.
+  -- The derivative is the column map of the three partial derivatives.
   have z1 : HasFDerivAt (fun x => (rotprojRM (x.ofLp 1) (x.ofLp 2) (x.ofLp 0)) S)
       (rotprojRM' pbar S) pbar.innerParams := by
-    have h0 : pbar.innerParams.ofLp 0 = pbar.α := by simp [Pose.innerParams]
-    have h1 : pbar.innerParams.ofLp 1 = pbar.θ₁ := by simp [Pose.innerParams]
-    have h2 : pbar.innerParams.ofLp 2 = pbar.φ₁ := by simp [Pose.innerParams]
-    have hfd : fderiv ℝ (fun x : ℝ³ => rotR (x.ofLp 0) (rotM (x.ofLp 1) (x.ofLp 2) S))
-        pbar.innerParams = rotprojRM' pbar S := by
-      refine ContinuousLinearMap.coe_injective
-        ((EuclideanSpace.basisFun (Fin 3) ℝ).toBasis.ext fun i => ?_)
-      fin_cases i <;>
-        simp only [OrthonormalBasis.coe_toBasis, EuclideanSpace.basisFun_apply,
-          ContinuousLinearMap.coe_coe, Fin.zero_eta, Fin.mk_one, Fin.reduceFinMk]
-      · rw [fderiv_rotR_rotM_in_e0 S _ hdiff, rotprojRM'_single_0, h0, h1, h2]; rfl
-      · rw [fderiv_rotR_rotM_in_e1 S _ hdiff, rotprojRM'_single_1, h0, h1, h2]; rfl
-      · rw [fderiv_rotR_rotM_in_e2 S _ hdiff, rotprojRM'_single_2, h0, h1, h2]; rfl
-    exact hfd ▸ hdiff.hasFDerivAt
+    have zplain := hasFDerivAt_three_params
+      (fun α θ φ => rotR α (rotM θ φ S)) pbar.innerParams
+      (rotR' pbar.α (rotM pbar.θ₁ pbar.φ₁ S))
+      (rotR pbar.α (rotMθ pbar.θ₁ pbar.φ₁ S))
+      (rotR pbar.α (rotMφ pbar.θ₁ pbar.φ₁ S))
+      (differentiableAt_rotR_rotM S pbar.innerParams)
+      (by simpa [Pose.innerParams] using HasDerivAt_rotR pbar.α (rotM pbar.θ₁ pbar.φ₁ S))
+      (by
+        simpa [Pose.innerParams, Function.comp_def] using
+          (ContinuousLinearMap.hasFDerivAt (rotR pbar.α)).comp_hasDerivAt pbar.θ₁
+            (hasDerivAt_rotM_θ pbar.θ₁ pbar.φ₁ S))
+      (by
+        simpa [Pose.innerParams, Function.comp_def] using
+          (ContinuousLinearMap.hasFDerivAt (rotR pbar.α)).comp_hasDerivAt pbar.φ₁
+            (hasDerivAt_rotM_φ pbar.θ₁ pbar.φ₁ S))
+    simpa [rotprojRM, rotprojRM', Pose.innerParams, Pose.rotR, Pose.rotR',
+      Pose.rotM₁, Pose.rotM₁θ, Pose.rotM₁φ] using zplain
 
   have step : (rotproj_inner' pbar S w) = ((fderivInnerCLM ℝ
       ((rotprojRM (pbar.innerParams.ofLp 1) (pbar.innerParams.ofLp 2) (pbar.innerParams.ofLp 0)) S, w)).comp

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -334,6 +334,33 @@ lemma hasFDerivAt_of_partials {n : ℕ} {f : E n → ℝ²} {y : E n} (cols : Fi
     exact fderiv_single_eq hdiff (h i)
   exact hfd ▸ hdiff.hasFDerivAt
 
+/-- `HasFDerivAt` constructor for a two-parameter family: the Fréchet derivative
+is the column map of the two partial derivatives. -/
+lemma hasFDerivAt_two_params (F : ℝ → ℝ → ℝ²) (y : E 2) (Fθ Fφ : ℝ²)
+    (hdiff : DifferentiableAt ℝ (fun x : E 2 => F (x.ofLp 0) (x.ofLp 1)) y)
+    (hθ : HasDerivAt (fun t => F t (y.ofLp 1)) Fθ (y.ofLp 0))
+    (hφ : HasDerivAt (fun t => F (y.ofLp 0) t) Fφ (y.ofLp 1)) :
+    HasFDerivAt (fun x : E 2 => F (x.ofLp 0) (x.ofLp 1)) (columnsCLM ![Fθ, Fφ]) y := by
+  refine hasFDerivAt_of_partials _ hdiff fun i => ?_
+  fin_cases i
+  · simpa using hasDerivAt_comp_add _ _ _ hθ
+  · simpa using hasDerivAt_comp_add _ _ _ hφ
+
+/-- `HasFDerivAt` constructor for a three-parameter family: the Fréchet derivative
+is the column map of the three partial derivatives. -/
+lemma hasFDerivAt_three_params (F : ℝ → ℝ → ℝ → ℝ²) (y : E 3) (F₀ F₁ F₂ : ℝ²)
+    (hdiff : DifferentiableAt ℝ (fun x : E 3 => F (x.ofLp 0) (x.ofLp 1) (x.ofLp 2)) y)
+    (h₀ : HasDerivAt (fun t => F t (y.ofLp 1) (y.ofLp 2)) F₀ (y.ofLp 0))
+    (h₁ : HasDerivAt (fun t => F (y.ofLp 0) t (y.ofLp 2)) F₁ (y.ofLp 1))
+    (h₂ : HasDerivAt (fun t => F (y.ofLp 0) (y.ofLp 1) t) F₂ (y.ofLp 2)) :
+    HasFDerivAt (fun x : E 3 => F (x.ofLp 0) (x.ofLp 1) (x.ofLp 2))
+      (columnsCLM ![F₀, F₁, F₂]) y := by
+  refine hasFDerivAt_of_partials _ hdiff fun i => ?_
+  fin_cases i
+  · simpa using hasDerivAt_comp_add _ _ _ h₀
+  · simpa using hasDerivAt_comp_add _ _ _ h₁
+  · simpa using hasDerivAt_comp_add _ _ _ h₂
+
 /-- fderiv of a composition `z ↦ X (z 0) (N (z 1) (z 2) S)` in direction e₁,
 given the derivative of the matrix family `N` in its first (θ) argument.
 The head `X` is arbitrary since e₁ does not move the `z 0` coordinate. -/

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.Calculus.FDeriv.WithLp
 import Mathlib.Analysis.Calculus.LineDeriv.Basic
 import Noperthedron.Global.RotationDerivs
+import Noperthedron.Global.SymbolicRotationDerivs
 import Noperthedron.Bounding.OpNorm
 
 /-!
@@ -464,31 +465,22 @@ noncomputable def inner_second_partial_A (α θ φ : ℝ) (i j : Fin 3) : ℝ³ 
   | 2, 1 => rotR α ∘L rotMθφ θ φ   -- = A[1,2] by mixed partial symmetry
   | 2, 2 => rotR α ∘L rotMφφ θ φ
 
-/-- Composition norm bound: ‖A ∘L B‖ ≤ 1 when ‖A‖ ≤ 1 and ‖B‖ ≤ 1 -/
-lemma comp_norm_le_one {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
-    ‖A ∘L B‖ ≤ 1 :=
-  calc ‖A ∘L B‖ ≤ ‖A‖ * ‖B‖ := ContinuousLinearMap.opNorm_comp_le A B
-    _ ≤ 1 * 1 := mul_le_mul hA hB (norm_nonneg _) zero_le_one
-    _ = 1 := one_mul 1
-
-/-- Negated composition norm bound: ‖-(A ∘L B)‖ ≤ 1 when ‖A‖ ≤ 1 and ‖B‖ ≤ 1 -/
-lemma neg_comp_norm_le_one {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
-    ‖-(A ∘L B)‖ ≤ 1 := by
-  rw [norm_neg]; exact comp_norm_le_one hA hB
+/-- The hand-written second-partial table agrees with the symbolically generated one. -/
+lemma inner_second_partial_A_eq_symbolic (α θ φ : ℝ) (i j : Fin 3) :
+    inner_second_partial_A α θ φ i j = (SymbolicRotation.secondTerm i j).eval α θ φ := by
+  fin_cases i <;> fin_cases j <;> rfl
 
 /-- All A[i,j] have operator norm ≤ 1. -/
 lemma inner_second_partial_A_norm_le (α θ φ : ℝ) (i j : Fin 3) :
     ‖inner_second_partial_A α θ φ i j‖ ≤ 1 := by
-  fin_cases i <;> fin_cases j
-  · exact neg_comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one _)) (le_of_eq (Bounding.rotM_norm_one _ _))
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMθ_norm_le_one _ _)
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMφ_norm_le_one _ _)
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMθ_norm_le_one _ _)
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMθθ_norm_le_one _ _)
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMθφ_norm_le_one _ _)
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR'_norm_one _)) (Bounding.rotMφ_norm_le_one _ _)
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMθφ_norm_le_one _ _)
-  · exact comp_norm_le_one (le_of_eq (Bounding.rotR_norm_one _)) (Bounding.rotMφφ_norm_le_one _ _)
+  rw [inner_second_partial_A_eq_symbolic]
+  exact (SymbolicRotation.secondTerm i j).norm_le_one α θ φ
+
+/-- Mixed second partials commute at the operator level. -/
+lemma inner_second_partial_A_symm (α θ φ : ℝ) (i j : Fin 3) :
+    inner_second_partial_A α θ φ i j = inner_second_partial_A α θ φ j i := by
+  rw [inner_second_partial_A_eq_symbolic, inner_second_partial_A_eq_symbolic,
+    SymbolicRotation.second_comm]
 
 /-!
 ## A[i,j,k] Table for Third Partials
@@ -540,38 +532,27 @@ noncomputable def inner_third_partial_A (α θ φ : ℝ) (i j k : Fin 3) : ℝ³
   | 1, 2, 2 => rotR α ∘L rotMθφφ θ φ
   | 2, 2, 2 => -(rotR α ∘L rotMφ θ φ)
 
+/-- The hand-written third-partial table agrees with the symbolically generated one. -/
+lemma inner_third_partial_A_eq_symbolic (α θ φ : ℝ) (i j k : Fin 3) :
+    inner_third_partial_A α θ φ i j k = (SymbolicRotation.thirdTerm i j k).eval α θ φ := by
+  fin_cases i <;> fin_cases j <;> fin_cases k <;> rfl
+
 /-- All A₃[i,j,k] have operator norm ≤ 1. -/
 lemma inner_third_partial_A_norm_le (α θ φ : ℝ) (i j k : Fin 3) :
     ‖inner_third_partial_A α θ φ i j k‖ ≤ 1 := by
-  have hR := le_of_eq (Bounding.rotR_norm_one α)
-  have hR' := le_of_eq (Bounding.rotR'_norm_one α)
-  fin_cases i <;> fin_cases j <;> fin_cases k
-  · exact neg_comp_norm_le_one hR' (le_of_eq (Bounding.rotM_norm_one _ _))
-  · exact neg_comp_norm_le_one hR (Bounding.rotMθ_norm_le_one _ _)
-  · exact neg_comp_norm_le_one hR (Bounding.rotMφ_norm_le_one _ _)
-  · exact neg_comp_norm_le_one hR (Bounding.rotMθ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθθ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθφ_norm_le_one _ _)
-  · exact neg_comp_norm_le_one hR (Bounding.rotMφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMφφ_norm_le_one _ _)
-  · exact neg_comp_norm_le_one hR (Bounding.rotMθ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθθ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθθ_norm_le_one _ _)
-  · exact neg_comp_norm_le_one hR (Bounding.rotMθ_norm_le_one _ _)
-  · exact comp_norm_le_one hR (Bounding.rotMθθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR (Bounding.rotMθθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR (Bounding.rotMθφφ_norm_le_one _ _)
-  · exact neg_comp_norm_le_one hR (Bounding.rotMφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMφφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR (Bounding.rotMθθφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR (Bounding.rotMθφφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR' (Bounding.rotMφφ_norm_le_one _ _)
-  · exact comp_norm_le_one hR (Bounding.rotMθφφ_norm_le_one _ _)
-  · exact neg_comp_norm_le_one hR (Bounding.rotMφ_norm_le_one _ _)
+  rw [inner_third_partial_A_eq_symbolic]
+  exact (SymbolicRotation.thirdTerm i j k).norm_le_one α θ φ
+
+/-- The first two indices of the third-partial table commute at the operator level. -/
+lemma inner_third_partial_A_swap_first (α θ φ : ℝ) (i j k : Fin 3) :
+    inner_third_partial_A α θ φ i j k = inner_third_partial_A α θ φ j i k := by
+  rw [inner_third_partial_A_eq_symbolic, inner_third_partial_A_eq_symbolic,
+    SymbolicRotation.third_swap_first]
+
+/-- The last two indices of the third-partial table commute at the operator level. -/
+lemma inner_third_partial_A_swap_last (α θ φ : ℝ) (i j k : Fin 3) :
+    inner_third_partial_A α θ φ i j k = inner_third_partial_A α θ φ i k j := by
+  rw [inner_third_partial_A_eq_symbolic, inner_third_partial_A_eq_symbolic,
+    SymbolicRotation.third_swap_last]
 
 end GlobalTheorem

--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -27,113 +27,171 @@ private abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
 /-!
 ## DifferentiableAt lemmas for rotation compositions
 
-These lemmas eliminate the repeated `rw [differentiableAt_piLp]; intro i; fin_cases i ...`
-pattern that appears ~30+ times in third_partial_inner_rotM_inner.
+Each rotation map is a matrix path applied to a vector, so joint differentiability
+in the angles and the vector follows from `differentiable_toEuclideanLin_apply`
+plus entrywise trigonometric facts. The compositional `@[fun_prop]` cores below
+prove this once per map; the `differentiableAt_*` family (used ~30+ times in
+`third_partial_inner_rotM_inner`) then consists of one-line applications.
 -/
+
+/-- Joint differentiability of `rotM` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotM_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotM (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotM_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotM_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMθ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMθ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMθ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMφ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMφ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMφ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMθθ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθθ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθθ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMθθ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMθθ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMθφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMθφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMθφ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMθφ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMθφ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotMφφ` in the two angles and the vector. -/
+@[fun_prop]
+lemma differentiable_rotMφφ_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f g : X → ℝ} {h : X → ℝ³}
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotMφφ (f x) (g x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotMφφ_mat (f x) (g x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotMφφ_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotR` in the angle and the vector. -/
+@[fun_prop]
+lemma differentiable_rotR_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f : X → ℝ} {h : X → ℝ²}
+    (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotR (f x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotR_mat (f x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotR_mat] <;> fun_prop
+
+/-- Joint differentiability of `rotR'` in the angle and the vector. -/
+@[fun_prop]
+lemma differentiable_rotR'_comp {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+    {f : X → ℝ} {h : X → ℝ²}
+    (hf : Differentiable ℝ f) (hh : Differentiable ℝ h) :
+    Differentiable ℝ fun x => rotR' (f x) (h x) := by
+  apply differentiable_toEuclideanLin_apply (M := fun x => rotR'_mat (f x)) (v := h) ?_ hh
+  intro i j
+  fin_cases i <;> fin_cases j <;> simp [rotR'_mat] <;> fun_prop
 
 /-- DifferentiableAt for rotMθ (outer, E 2) -/
 lemma differentiableAt_rotMθ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθ, rotMθ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 2 => rotMθ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMφ (outer, E 2) -/
 lemma differentiableAt_rotMφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMφ, rotMφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMθθ (outer, E 2) -/
 lemma differentiableAt_rotMθθ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθθ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθθ, rotMθθ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i <;> (simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 2 => rotMθθ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθθ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMθφ (outer, E 2) -/
 lemma differentiableAt_rotMθφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMθφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMθφ, rotMθφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMθφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMθφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotMφφ (outer, E 2) -/
 lemma differentiableAt_rotMφφ_outer (S : ℝ³) (y : E 2) :
-    DifferentiableAt ℝ (fun z : E 2 => rotMφφ (z.ofLp 0) (z.ofLp 1) S) y := by
-  rw [differentiableAt_piLp]; intro i
-  simp only [rotMφφ, rotMφφ_mat, LinearMap.coe_toContinuousLinearMap', Matrix.toLpLin_apply]
-  fin_cases i
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]
-  · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_three]; fun_prop
+    DifferentiableAt ℝ (fun z : E 2 => rotMφφ (z.ofLp 0) (z.ofLp 1) S) y :=
+  (differentiable_rotMφφ_comp (by fun_prop) (by fun_prop) (differentiable_const S)).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotM -/
 lemma differentiableAt_rotR_rotM (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotM, rotM_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
-
-/-- DifferentiableAt for rotR' ∘ rotM -/
-lemma differentiableAt_rotR'_rotM (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotM, rotM_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθ -/
 lemma differentiableAt_rotR_rotMθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθ, rotMθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMφ -/
 lemma differentiableAt_rotR_rotMφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMφ, rotMφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
-
-/-- DifferentiableAt for rotR' ∘ rotMθ -/
-lemma differentiableAt_rotR'_rotMθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMθ, rotMθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
-
-/-- DifferentiableAt for rotR' ∘ rotMφ -/
-lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR', rotR'_mat, rotMφ, rotMφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθθ -/
 lemma differentiableAt_rotR_rotMθθ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθθ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθθ, rotMθθ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMθφ -/
 lemma differentiableAt_rotR_rotMθφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMθφ, rotMθφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMθφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMθφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-- DifferentiableAt for rotR ∘ rotMφφ -/
 lemma differentiableAt_rotR_rotMφφ (S : ℝ³) (y : E 3) :
-    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφφ (z.ofLp 1) (z.ofLp 2) S)) y := by
-  rw [differentiableAt_piLp]; intro i
-  fin_cases i <;> (simp [rotR, rotR_mat, rotMφφ, rotMφφ_mat, Matrix.toLpLin_apply,
-    Matrix.vecHead, Matrix.vecTail, dotProduct, Fin.sum_univ_three]; fun_prop)
+    DifferentiableAt ℝ (fun z : E 3 => rotR (z.ofLp 0) (rotMφφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR_comp (by fun_prop)
+    (differentiable_rotMφφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
+
+/-- DifferentiableAt for rotR' ∘ rotM -/
+lemma differentiableAt_rotR'_rotM (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotM (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotM_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
+
+/-- DifferentiableAt for rotR' ∘ rotMθ -/
+lemma differentiableAt_rotR'_rotMθ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMθ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotMθ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
+
+/-- DifferentiableAt for rotR' ∘ rotMφ -/
+lemma differentiableAt_rotR'_rotMφ (S : ℝ³) (y : E 3) :
+    DifferentiableAt ℝ (fun z : E 3 => rotR' (z.ofLp 0) (rotMφ (z.ofLp 1) (z.ofLp 2) S)) y :=
+  (differentiable_rotR'_comp (by fun_prop)
+    (differentiable_rotMφ_comp (by fun_prop) (by fun_prop) (differentiable_const S))).differentiableAt
 
 /-!
 ## Inner product fderiv helper

--- a/Noperthedron/Global/SymbolicRotationDerivs.lean
+++ b/Noperthedron/Global/SymbolicRotationDerivs.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2026 Cameron Freer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Cameron Freer
+-/
+import Noperthedron.Global.RotationDerivs
+import Noperthedron.Bounding.OpNorm
+
+/-!
+# Symbolic algebra for rotation-derivative operators
+
+The second- and third-partial developments work with operator-valued derivatives of
+`rotR α ∘L rotM θ φ`. Through third order, every such operator is (up to sign) a
+composition `head ∘L body` with `head ∈ {rotR, rotR'}` and `body` one of eight matrix
+families. This file records that vocabulary as a tiny symbolic algebra:
+
+* `Sign`, `Head`, `Body` — a sign, the head state, and the matrix-family state;
+* `Term` — a signed composition, with `Term.eval` giving the actual operator;
+* `Term.deriv` — symbolic coordinate differentiation (partial: transitions that would
+  leave the vocabulary return `none`);
+* `Head.deriv_correct`, `Body.derivθ_correct`, `Body.derivφ_correct` — each primitive
+  transition is certified against the existing `HasDerivAt` lemmas;
+* `secondTerm`/`thirdTerm` — the generated second- and third-order tables, with
+  `second_defined`/`third_defined` showing all derivations through third order stay
+  inside the vocabulary.
+
+Structural consequences replace case-by-case reasoning: `Term.norm_le_one` bounds every
+term uniformly, and the permutation symmetries `second_comm`, `third_swap_first`,
+`third_swap_last` are decidable facts about the symbolic tables. `SecondPartialHelpers`
+proves its hand-written `inner_second_partial_A`/`inner_third_partial_A` tables equal
+the generated ones definitionally and inherits these properties.
+-/
+
+open scoped RealInnerProductSpace
+
+namespace GlobalTheorem
+
+/-- Composition norm bound: ‖A ∘L B‖ ≤ 1 when ‖A‖ ≤ 1 and ‖B‖ ≤ 1 -/
+lemma comp_norm_le_one {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
+    ‖A ∘L B‖ ≤ 1 :=
+  calc ‖A ∘L B‖ ≤ ‖A‖ * ‖B‖ := ContinuousLinearMap.opNorm_comp_le A B
+    _ ≤ 1 * 1 := mul_le_mul hA hB (norm_nonneg _) zero_le_one
+    _ = 1 := one_mul 1
+
+/-- Negated composition norm bound: ‖-(A ∘L B)‖ ≤ 1 when ‖A‖ ≤ 1 and ‖B‖ ≤ 1 -/
+lemma neg_comp_norm_le_one {A : ℝ² →L[ℝ] ℝ²} {B : ℝ³ →L[ℝ] ℝ²} (hA : ‖A‖ ≤ 1) (hB : ‖B‖ ≤ 1) :
+    ‖-(A ∘L B)‖ ≤ 1 := by
+  rw [norm_neg]; exact comp_norm_le_one hA hB
+
+namespace SymbolicRotation
+
+/-- A sign, acting on any type with negation. -/
+inductive Sign where
+  | pos
+  | neg
+  deriving DecidableEq, Repr
+
+namespace Sign
+
+def mul : Sign → Sign → Sign
+  | .pos, s => s
+  | .neg, .pos => .neg
+  | .neg, .neg => .pos
+
+def act {A : Type*} [Neg A] : Sign → A → A
+  | .pos, a => a
+  | .neg, a => -a
+
+end Sign
+
+/-- The head state of a rotation-derivative operator: `rotR` or `rotR'`. -/
+inductive Head where
+  | r
+  | r'
+  deriving DecidableEq, Repr
+
+namespace Head
+
+noncomputable def eval : Head → ℝ → (ℝ² →L[ℝ] ℝ²)
+  | .r => rotR
+  | .r' => rotR'
+
+lemma norm_one (h : Head) (α : ℝ) : ‖h.eval α‖ = 1 := by
+  cases h
+  · exact Bounding.rotR_norm_one α
+  · exact Bounding.rotR'_norm_one α
+
+end Head
+
+/-- The matrix-family state: the eight `rotM` derivative matrices needed through
+third order. -/
+inductive Body where
+  | m
+  | mθ
+  | mφ
+  | mθθ
+  | mθφ
+  | mφφ
+  | mθθφ
+  | mθφφ
+  deriving DecidableEq, Repr
+
+namespace Body
+
+noncomputable def eval : Body → ℝ → ℝ → (ℝ³ →L[ℝ] ℝ²)
+  | .m => rotM
+  | .mθ => rotMθ
+  | .mφ => rotMφ
+  | .mθθ => rotMθθ
+  | .mθφ => rotMθφ
+  | .mφφ => rotMφφ
+  | .mθθφ => rotMθθφ
+  | .mθφφ => rotMθφφ
+
+lemma norm_le_one (b : Body) (θ φ : ℝ) : ‖b.eval θ φ‖ ≤ 1 := by
+  cases b
+  · exact le_of_eq (Bounding.rotM_norm_one θ φ)
+  · exact Bounding.rotMθ_norm_le_one θ φ
+  · exact Bounding.rotMφ_norm_le_one θ φ
+  · exact Bounding.rotMθθ_norm_le_one θ φ
+  · exact Bounding.rotMθφ_norm_le_one θ φ
+  · exact Bounding.rotMφφ_norm_le_one θ φ
+  · exact Bounding.rotMθθφ_norm_le_one θ φ
+  · exact Bounding.rotMθφφ_norm_le_one θ φ
+
+end Body
+
+/-- The three coordinate axes of the inner parameter space `(α, θ, φ)`. -/
+inductive Axis where
+  | α
+  | θ
+  | φ
+  deriving DecidableEq, Repr
+
+def axisOfFin : Fin 3 → Axis
+  | 0 => .α
+  | 1 => .θ
+  | 2 => .φ
+
+/-- A signed composition `± head ∘L body`. -/
+structure Term where
+  sign : Sign
+  head : Head
+  body : Body
+  deriving DecidableEq, Repr
+
+namespace Term
+
+noncomputable def eval (t : Term) (α θ φ : ℝ) : ℝ³ →L[ℝ] ℝ² :=
+  t.sign.act (t.head.eval α ∘L t.body.eval θ φ)
+
+/-- Every symbolic term denotes an operator of norm at most one. -/
+lemma norm_le_one (t : Term) (α θ φ : ℝ) : ‖t.eval α θ φ‖ ≤ 1 := by
+  rcases t with ⟨s, h, b⟩
+  have hnorm := comp_norm_le_one (le_of_eq (h.norm_one α)) (b.norm_le_one θ φ)
+  cases s <;> simpa [eval, Sign.act] using hnorm
+
+def derivHead : Head → Sign × Head
+  | .r => (.pos, .r')
+  | .r' => (.neg, .r)
+
+def derivBodyθ : Body → Option (Sign × Body)
+  | .m => some (.pos, .mθ)
+  | .mθ => some (.pos, .mθθ)
+  | .mφ => some (.pos, .mθφ)
+  | .mθθ => some (.neg, .mθ)
+  | .mθφ => some (.pos, .mθθφ)
+  | .mφφ => some (.pos, .mθφφ)
+  | .mθθφ => none
+  | .mθφφ => none
+
+def derivBodyφ : Body → Option (Sign × Body)
+  | .m => some (.pos, .mφ)
+  | .mθ => some (.pos, .mθφ)
+  | .mφ => some (.pos, .mφφ)
+  | .mθθ => some (.pos, .mθθφ)
+  | .mθφ => some (.pos, .mθφφ)
+  | .mφφ => some (.neg, .mφ)
+  | .mθθφ => none
+  | .mθφφ => none
+
+/-- Symbolic differentiation along a coordinate axis. `none` when the derivative
+would leave the eight-state vocabulary (which cannot happen through third order,
+see `second_defined`/`third_defined`). -/
+def deriv (a : Axis) (t : Term) : Option Term :=
+  match a with
+  | .α =>
+      let (s, h) := derivHead t.head
+      some ⟨t.sign.mul s, h, t.body⟩
+  | .θ => (derivBodyθ t.body).map fun (s, b) => ⟨t.sign.mul s, t.head, b⟩
+  | .φ => (derivBodyφ t.body).map fun (s, b) => ⟨t.sign.mul s, t.head, b⟩
+
+end Term
+
+/-! ## Semantic checks for the primitive transitions -/
+
+namespace Head
+
+/-- The symbolic head transition agrees with the existing derivative theorems. -/
+lemma deriv_correct (h : Head) (α : ℝ) (v : ℝ²) :
+    let (s, h') := Term.derivHead h
+    HasDerivAt (fun x => h.eval x v) (s.act (h'.eval α v)) α := by
+  cases h
+  · simpa [Term.derivHead, eval, Sign.act] using HasDerivAt_rotR α v
+  · simpa [Term.derivHead, eval, Sign.act] using HasDerivAt_rotR' α v
+
+end Head
+
+namespace Body
+
+/-- Every supported symbolic θ-transition agrees with the existing derivative theorems. -/
+lemma derivθ_correct (b : Body) (θ φ : ℝ) (S : ℝ³) :
+    match Term.derivBodyθ b with
+    | none => True
+    | some (s, b') =>
+        HasDerivAt (fun x => b.eval x φ S) (s.act (b'.eval θ φ S)) θ := by
+  cases b
+  · simpa [Term.derivBodyθ, eval, Sign.act] using hasDerivAt_rotM_θ θ φ S
+  · simpa [Term.derivBodyθ, eval, Sign.act] using hasDerivAt_rotMθ_θ θ φ S
+  · simpa [Term.derivBodyθ, eval, Sign.act] using hasDerivAt_rotMφ_θ θ φ S
+  · simpa [Term.derivBodyθ, eval, Sign.act] using hasDerivAt_rotMθθ_θ θ φ S
+  · simpa [Term.derivBodyθ, eval, Sign.act] using hasDerivAt_rotMθφ_θ θ φ S
+  · simpa [Term.derivBodyθ, eval, Sign.act] using hasDerivAt_rotMφφ_θ θ φ S
+  · simp [Term.derivBodyθ]
+  · simp [Term.derivBodyθ]
+
+/-- Every supported symbolic φ-transition agrees with the existing derivative theorems. -/
+lemma derivφ_correct (b : Body) (θ φ : ℝ) (S : ℝ³) :
+    match Term.derivBodyφ b with
+    | none => True
+    | some (s, b') =>
+        HasDerivAt (fun x => b.eval θ x S) (s.act (b'.eval θ φ S)) φ := by
+  cases b
+  · simpa [Term.derivBodyφ, eval, Sign.act] using hasDerivAt_rotM_φ θ φ S
+  · simpa [Term.derivBodyφ, eval, Sign.act] using hasDerivAt_rotMθ_φ θ φ S
+  · simpa [Term.derivBodyφ, eval, Sign.act] using hasDerivAt_rotMφ_φ θ φ S
+  · simpa [Term.derivBodyφ, eval, Sign.act] using hasDerivAt_rotMθθ_φ θ φ S
+  · simpa [Term.derivBodyφ, eval, Sign.act] using hasDerivAt_rotMθφ_φ θ φ S
+  · simpa [Term.derivBodyφ, eval, Sign.act] using hasDerivAt_rotMφφ_φ θ φ S
+  · simp [Term.derivBodyφ]
+  · simp [Term.derivBodyφ]
+
+end Body
+
+/-! ## Iterated symbolic differentiation -/
+
+/-- The base operator `rotR ∘L rotM`. -/
+def baseTerm : Term := ⟨.pos, .r, .m⟩
+
+/-- Apply the rightmost axis first, matching `nth_partial i (nth_partial j f)`. -/
+def derive : List Axis → Term → Option Term
+  | [], t => some t
+  | a :: as, t => (derive as t).bind (Term.deriv a)
+
+def derived (axes : List Axis) : Option Term := derive axes baseTerm
+
+/-- The generated second-partial table. -/
+def secondTerm (i j : Fin 3) : Term :=
+  (derived [axisOfFin i, axisOfFin j]).getD baseTerm
+
+/-- The generated third-partial table. -/
+def thirdTerm (i j k : Fin 3) : Term :=
+  (derived [axisOfFin i, axisOfFin j, axisOfFin k]).getD baseTerm
+
+/-- The fallback in `secondTerm` is unreachable. -/
+theorem second_defined (i j : Fin 3) :
+    (derived [axisOfFin i, axisOfFin j]).isSome := by
+  fin_cases i <;> fin_cases j <;> decide
+
+/-- The fallback in `thirdTerm` is unreachable. -/
+theorem third_defined (i j k : Fin 3) :
+    (derived [axisOfFin i, axisOfFin j, axisOfFin k]).isSome := by
+  fin_cases i <;> fin_cases j <;> fin_cases k <;> decide
+
+/-! ## Symbolic permutation symmetry -/
+
+theorem second_comm (i j : Fin 3) : secondTerm i j = secondTerm j i := by
+  fin_cases i <;> fin_cases j <;> decide
+
+theorem third_swap_first (i j k : Fin 3) : thirdTerm i j k = thirdTerm j i k := by
+  fin_cases i <;> fin_cases j <;> fin_cases k <;> decide
+
+theorem third_swap_last (i j k : Fin 3) : thirdTerm i j k = thirdTerm i k j := by
+  fin_cases i <;> fin_cases j <;> fin_cases k <;> decide
+
+end SymbolicRotation
+
+end GlobalTheorem


### PR DESCRIPTION
**Stacked on #65 — that PR must merge first.** This branch includes #65's three commits; only the top commit is new here. After #65 lands, this rebases to a single-commit PR.

## What

Through third order, every operator in the inner second- and third-partial tables is, up to sign, a composition `head ∘L body` with `head ∈ {rotR, rotR'}` and `body` one of eight `rotM` derivative families.

The new `Global/SymbolicRotationDerivs.lean` records this vocabulary as a small symbolic algebra:

- `Sign`, `Head`, `Body`, and `Term`, with `Term.eval` giving the corresponding continuous linear map;
- `Term.deriv`, which performs symbolic coordinate differentiation and returns `none` when a transition would leave the current vocabulary;
- `Head.deriv_correct`, `Body.derivθ_correct`, and `Body.derivφ_correct`, certifying **each supported primitive transition** against the existing `HasDerivAt` lemmas;
- `secondTerm` and `thirdTerm`, generating the second- and third-order symbolic tables;
- decidable proofs that all derivations through third order remain defined and that the generated tables satisfy the expected permutation symmetries.

In `SecondPartialHelpers.lean`, the hand-written `inner_second_partial_A` / `inner_third_partial_A` tables are shown to agree with the generated tables casewise by reflexivity (`fin_cases i <;> fin_cases j <;> rfl`, and similarly at third order). From those agreement lemmas:

- the 9-case and 27-case norm proofs reduce to rewriting by agreement and applying `Term.norm_le_one` — the uniform bound is proved once structurally from `‖head‖ = 1` and `‖body‖ ≤ 1`;
- new symmetry lemmas `inner_second_partial_A_symm`, `inner_third_partial_A_swap_first`, and `inner_third_partial_A_swap_last` follow from the corresponding symbolic equalities.

## Supporting moves

Both moves preserve existing statements and fully qualified names:

- `GlobalTheorem.HasDerivAt_rotR'` moves from `FDerivHelpers` to `RotationDerivs`, beside the related rotation-derivative results (avoids an import cycle and places the lemma with its natural dependencies; wrapped in `namespace GlobalTheorem` there so the name is unchanged).
- `comp_norm_le_one` and `neg_comp_norm_le_one` move from `SecondPartialHelpers` into the new file, staying in the `GlobalTheorem` namespace, so existing callers resolve unchanged.

## Why

The hand-written tables remain — they are useful, readable documentation. This PR moves their representation, norm-bound, and symmetry obligations into a common algebra; the existing analytic proofs connecting the tables to `nth_partial` are unchanged.

A future higher-order extension would add the required body states, their norm bounds, and their certified transitions; agreement with a readable hand-written table is then another finite reflexivity check, and permutation symmetries are finite decidable equalities. An inconsistent table entry causes the agreement proof to fail immediately.

## Validation

- Full `lake build` passes; `lake build constructValidTable benchRows` passes.
- Zero sorries.
- Existing lemma statements and fully qualified names are unchanged.
- New public API: the algebra under `GlobalTheorem.SymbolicRotation`, two agreement lemmas, and three table-symmetry lemmas.
