### PR TITLE
Drop unnecessary nonzero hypotheses from rotation smoothness lemmas

### DIFF
--- a/Noperthedron/Global.lean
+++ b/Noperthedron/Global.lean
@@ -536,7 +536,7 @@ lemma global_theorem_inequality_ii {ι : Type} [Fintype ι] [Nonempty ι]
     · exact hθ₁
     · exact hφ₁
   have hz := bounded_partials_control_difference2
-    pc.fu (rotation_partials_exist S_norm_pos)
+    pc.fu rotation_partials_exist
     pbar.innerParams p.innerParams ![εα, εθ₁, εφ₁] hεv hdiffv
     (rotation_third_partials_bounded pc.S pc.w_unit)
   rw [show ∑ i, ![εα, εθ₁, εφ₁] i = εα + εθ₁ + εφ₁ by simp [Fin.sum_univ_three]] at hz
@@ -603,7 +603,7 @@ lemma global_theorem_inequality_iv {ι : Type} [Fintype ι] [Nonempty ι]
     · exact hθ₂
     · exact hφ₂
   have hz := bounded_partials_control_difference2
-    (pc.fu_outer P) (rotation_partials_exist_outer P_norm_pos)
+    (pc.fu_outer P) rotation_partials_exist_outer
     pbar.outerParams p.outerParams ![εθ₂, εφ₂] hεv hdiffv
     (rotation_third_partials_bounded_outer P pc.w_unit)
   rw [show ∑ i, ![εθ₂, εφ₂] i = εθ₂ + εφ₂ by simp [Fin.sum_univ_two]] at hz

--- a/Noperthedron/Global/Definitions.lean
+++ b/Noperthedron/Global/Definitions.lean
@@ -55,15 +55,15 @@ lemma rotproj_outer_eq (S : ℝ³) (w : ℝ²) (x : ℝ²) :
 lemma rotproj_outer_unit_eq (S : ℝ³) (w : ℝ²) (x : ℝ²) :
     rotproj_outer_unit S w x = rotproj_outer S w x / ‖S‖ := rfl
 
-lemma rotation_partials_exist {S : ℝ³} (S_nonzero : ‖S‖ > 0) {w : ℝ²} :
+lemma rotation_partials_exist {S : ℝ³} {w : ℝ²} :
     ContDiff ℝ 3 (rotproj_inner_unit S w) := by
-  refine ContDiff.div ?_ contDiff_const (fun x ↦ (ne_of_lt S_nonzero).symm)
+  refine ContDiff.div_const ?_ ‖S‖
   simp [inner, rotprojRM, rotR, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail]
   fun_prop
 
-lemma rotation_partials_exist_outer {S : ℝ³} (S_nonzero : ‖S‖ > 0) {w : ℝ²} :
+lemma rotation_partials_exist_outer {S : ℝ³} {w : ℝ²} :
     ContDiff ℝ 3 (rotproj_outer_unit S w) := by
-  refine ContDiff.div ?_ contDiff_const (fun x ↦ (ne_of_lt S_nonzero).symm)
+  refine ContDiff.div_const ?_ ‖S‖
   simp [inner, rotM, rotM_mat, Matrix.vecHead, Matrix.vecTail]
   fun_prop
 


### PR DESCRIPTION
## What

`rotation_partials_exist` and `rotation_partials_exist_outer` required a positive-norm hypothesis, but it is not needed for smoothness. Lean's division is totalized, and division by a real constant fixed with respect to the parameter is smooth even when that constant is zero; `ContDiff.div_const` captures exactly this.

This PR:

- removes the nonzero hypothesis from both declarations;
- replaces `ContDiff.div` plus a denominator-nonzero proof with `ContDiff.div_const`;
- updates the only two in-repository call sites.

This strengthens the propositions, although removing the explicit argument is a source-level signature change for downstream callers: any external use of `rotation_partials_exist h` becomes `rotation_partials_exist`.

The blueprint does not state a separate nonzero premise for these smoothness facts, so the formal declarations now match it more closely; no blueprint change is needed.

## Validation

- Full `lake build` passes; `lake build constructValidTable benchRows` passes.
- Zero actual sorrys; no new warnings in the touched files.
- `S_norm_pos` and `P_norm_pos` remain in `Global.lean`, where each is still used later in its proof.

This is independent of the #65/#66 chain and can merge in either order.
