### PR TITLE
Golf: two proof simplifications in SecondPartialHelpers

### DIFF
--- a/Noperthedron/Global/SecondPartialHelpers.lean
+++ b/Noperthedron/Global/SecondPartialHelpers.lean
@@ -153,10 +153,7 @@ The result is: `fderiv (⟪f·, w⟫) y d = ⟪fderiv f y d, w⟫` when `w` is c
 lemma fderiv_inner_const {n : ℕ} (f : E n → ℝ²) (w : ℝ²) (y : E n) (d : E n)
     (hf : DifferentiableAt ℝ f y) :
     (fderiv ℝ (fun z => ⟪f z, w⟫) y) d = ⟪(fderiv ℝ f y) d, w⟫ := by
-  have hInner := fderiv_inner_apply ℝ hf (differentiableAt_const w) d
-  rw [(hasFDerivAt_const w y).fderiv] at hInner
-  simp only [zero_apply, inner_zero_right, zero_add] at hInner
-  exact hInner
+  simpa [(hasFDerivAt_const w y).fderiv] using fderiv_inner_apply ℝ hf (differentiableAt_const w) d
 
 /-- |⟪A S, w⟫ / ‖S‖| ≤ 1 when ‖A‖ ≤ 1 and ‖w‖ = 1 -/
 lemma inner_bound_helper (A : ℝ³ →L[ℝ] ℝ²) (S : ℝ³) (w : ℝ²)
@@ -237,10 +234,8 @@ These factor out the lineDeriv_eq_fderiv + HasLineDerivAt pattern.
 
 /-- Helper for deriv → fderiv composition pattern -/
 lemma hasDerivAt_comp_add (f : ℝ → ℝ²) (f' : ℝ²) (a : ℝ) (hf : HasDerivAt f f' a) :
-    HasDerivAt (fun t => f (a + t)) f' 0 := by
-  have hid : HasDerivAt (fun t : ℝ => a + t) 1 0 := by simpa using (hasDerivAt_id 0).const_add a
-  have hf' : HasDerivAt f f' (a + 0) := by simp only [add_zero]; exact hf
-  exact HasDerivAt.comp_const_add a 0 hf'
+    HasDerivAt (fun t => f (a + t)) f' 0 :=
+  HasDerivAt.comp_const_add a 0 (by simpa using hf)
 
 /-- For a differentiable function, the `fderiv` along a basis direction can be computed
 as the one-variable derivative along the line through that direction. -/


### PR DESCRIPTION
Extracted from #59 (its only content not superseded by #65/#66): direct proofs for `fderiv_inner_const` and `hasDerivAt_comp_add`. Statements unchanged; no conflicts with the open #65/#66/#68 stack, which rewrites different regions of this file.

Full `lake build` and `lake build constructValidTable benchRows` pass; no warnings.